### PR TITLE
Add WebRTC Direct as default transport

### DIFF
--- a/examples/waku-node/index.mjs
+++ b/examples/waku-node/index.mjs
@@ -16,7 +16,7 @@ import WebRTCDirect from 'libp2p-webrtc-direct';
     libp2p: {
       peerId: hardcodedPeerId,
       addresses: {
-        listen: ['/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct']
+        listen: ['/ip4/0.0.0.0/tcp/9090/http/p2p-webrtc-direct']
       },
       modules: {
         transport: [WebRTCDirect]

--- a/examples/waku-node/index.mjs
+++ b/examples/waku-node/index.mjs
@@ -1,0 +1,35 @@
+import Bootstrap from 'libp2p-bootstrap';
+import PeerId from 'peer-id';
+import { Waku } from 'js-waku';
+import WebRTCDirect from 'libp2p-webrtc-direct';
+
+;
+(async () => {
+
+  const hardcodedPeerId = await PeerId.createFromJSON({
+    'id': '12D3KooWCuo3MdXfMgaqpLC5Houi1TRoFqgK9aoxok4NK5udMu8m',
+    'privKey': 'CAESQAG6Ld7ev6nnD0FKPs033/j0eQpjWilhxnzJ2CCTqT0+LfcWoI2Vr+zdc1vwk7XAVdyoCa2nwUR3RJebPWsF1/I=',
+    'pubKey': 'CAESIC33FqCNla/s3XNb8JO1wFXcqAmtp8FEd0SXmz1rBdfy'
+  });
+
+  const waku = await Waku.create({
+    libp2p: {
+      peerId: hardcodedPeerId,
+      addresses: {
+        listen: ['/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct']
+      },
+      modules: {
+        transport: [WebRTCDirect]
+      },
+    }
+  });
+
+  waku.libp2p.connectionManager.on('peer:connect', (connection) => {
+    console.info(`Connected to ${connection.remotePeer.toB58String()}!`);
+  });
+
+  console.log('Listening on:');
+  waku.libp2p.multiaddrs.forEach((ma) => console.log(`${ma.toString()}/p2p/${waku.libp2p.peerId.toB58String()}`));
+
+})();
+

--- a/examples/waku-node/package-lock.json
+++ b/examples/waku-node/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "@waku/node",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@waku/node",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "js-waku": "file:../../build/main"
+      }
+    },
+    "../../build/esm": {
+      "extraneous": true
+    },
+    "../../build/main": {},
+    "node_modules/js-waku": {
+      "resolved": "../../build/main",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "js-waku": {
+      "version": "file:../../build/main"
+    }
+  }
+}

--- a/examples/waku-node/package-lock.json
+++ b/examples/waku-node/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@waku/node",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "js-waku": "file:../../build/main"
       }

--- a/examples/waku-node/package.json
+++ b/examples/waku-node/package.json
@@ -3,9 +3,14 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "private": true,
   "scripts": {
+    "start": "node ./index.mjs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "MIT OR Apache-2.0",
+  "dependencies": {
+    "js-waku": "file:../../build/main"
+  }
 }

--- a/examples/waku-node/package.json
+++ b/examples/waku-node/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@waku/node",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/web-chat/src/App.tsx
+++ b/examples/web-chat/src/App.tsx
@@ -1,18 +1,13 @@
 import { useEffect, useReducer, useState } from "react";
 import "./App.css";
-import {
-  PageDirection,
-  getPredefinedBootstrapNodes,
-  Waku,
-  WakuMessage,
-} from "js-waku";
+import { PageDirection, Waku, WakuMessage } from "js-waku";
 import handleCommand from "./command";
 import Room from "./Room";
 import { WakuContext } from "./WakuContext";
 import { ThemeProvider } from "@livechat/ui-kit";
 import { generate } from "server-name-generator";
 import { Message } from "./Message";
-import { Fleet } from "js-waku/lib/discovery/predefined";
+import { Protocols } from "js-waku/lib/waku";
 
 const themes = {
   AuthorName: {
@@ -130,8 +125,7 @@ export default function App() {
     if (historicalMessagesRetrieved) return;
 
     const retrieveMessages = async () => {
-      await waku.waitForRemotePeer();
-      console.log(`Retrieving archived messages`);
+      await waku.waitForRemotePeer([Protocols.Relay]);
 
       try {
         retrieveStoreMessages(waku, dispatchMessages).then((length) => {
@@ -185,22 +179,15 @@ async function initWaku(setter: (waku: Waku) => void) {
         },
       },
       bootstrap: {
-        peers: getPredefinedBootstrapNodes(selectFleetEnv()),
+        peers: [
+          `/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct/p2p/12D3KooWCuo3MdXfMgaqpLC5Houi1TRoFqgK9aoxok4NK5udMu8m`,
+        ],
       },
     });
 
     setter(waku);
   } catch (e) {
     console.log("Issue starting waku ", e);
-  }
-}
-
-function selectFleetEnv() {
-  // Works with react-scripts
-  if (process?.env?.NODE_ENV === "development") {
-    return Fleet.Test;
-  } else {
-    return Fleet.Prod;
   }
 }
 

--- a/examples/web-chat/src/App.tsx
+++ b/examples/web-chat/src/App.tsx
@@ -180,7 +180,7 @@ async function initWaku(setter: (waku: Waku) => void) {
       },
       bootstrap: {
         peers: [
-          `/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct/p2p/12D3KooWCuo3MdXfMgaqpLC5Houi1TRoFqgK9aoxok4NK5udMu8m`,
+          `/dns4/waku.fryorcraken.xyz/tcp/9090/http/p2p-webrtc-direct/p2p/12D3KooWCuo3MdXfMgaqpLC5Houi1TRoFqgK9aoxok4NK5udMu8m`,
         ],
       },
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "libp2p-bootstrap": "^0.14.0",
         "libp2p-gossipsub": "^0.13.0",
         "libp2p-mplex": "^0.10.4",
+        "libp2p-webrtc-direct": "^0.7.1",
         "libp2p-websockets": "^0.16.1",
         "multiaddr": "^10.0.1",
         "multihashes": "^4.0.3",
@@ -3005,8 +3006,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -3420,6 +3420,20 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/configstore": {
       "version": "5.0.1",
@@ -4148,6 +4162,11 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
     "node_modules/devtools-protocol": {
       "version": "0.0.960912",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.960912.tgz",
@@ -4261,6 +4280,11 @@
         "extend": "^3.0.0",
         "void-elements": "^2.0.0"
       }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/domain-browser": {
       "version": "4.19.0",
@@ -5661,6 +5685,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-browser-rtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ=="
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -5888,6 +5917,15 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
     },
     "node_modules/global-dirs": {
       "version": "0.1.1",
@@ -6573,6 +6611,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "node_modules/is-generator-function": {
       "version": "1.0.9",
@@ -7786,6 +7829,64 @@
         "private-ip": "^2.1.1"
       }
     },
+    "node_modules/libp2p-webrtc-direct": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-direct/-/libp2p-webrtc-direct-0.7.1.tgz",
+      "integrity": "sha512-BTOaEFb9cT+5Arej2W+OdBFALOx+65IGKEa7isx/jKQLXzj76qiZqj88FvXxmLa3rl5UATsiB99sdzD19+IrDA==",
+      "dependencies": {
+        "abortable-iterator": "^3.0.0",
+        "class-is": "^1.1.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.3.1",
+        "detect-node": "^2.0.4",
+        "err-code": "^3.0.0",
+        "libp2p-utils": "^0.4.1",
+        "libp2p-webrtc-peer": "^10.0.1",
+        "mafmt": "^10.0.0",
+        "multiformats": "^9.4.5",
+        "once": "^1.4.0",
+        "request": "^2.88.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^3.0.0",
+        "wrtc": "~0.4.6",
+        "xhr": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/libp2p-webrtc-peer": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-peer/-/libp2p-webrtc-peer-10.0.1.tgz",
+      "integrity": "sha512-Qi/YVrSI5sjU+iBvr1iAjGrakIEvzCS8S76v4q43jjlDb6Wj+S4OnFLH/uRlt7eLXcx4vlaI6huMzYrUAoopMg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.0.1",
+        "err-code": "^2.0.3",
+        "get-browser-rtc": "^1.0.0",
+        "queue-microtask": "^1.1.0",
+        "randombytes": "^2.0.3",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/libp2p-webrtc-peer/node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+    },
     "node_modules/libp2p-websockets": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.16.1.tgz",
@@ -8389,6 +8490,14 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -9332,7 +9441,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -9645,6 +9753,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -9979,7 +10092,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -10217,7 +10329,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10237,7 +10348,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -11878,6 +11988,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -12551,8 +12666,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -12565,6 +12679,39 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "node_modules/wrtc": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/wrtc/-/wrtc-0.4.7.tgz",
+      "integrity": "sha512-P6Hn7VT4lfSH49HxLHcHhDq+aFf/jd9dPY7lDHeFhZ22N3858EKuwm2jmnlPzpsRGEPaoF6XwkcxY5SYnt4f/g==",
+      "bundleDependencies": [
+        "node-pre-gyp"
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-pre-gyp": "^0.13.0"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10.0.0"
+      },
+      "optionalDependencies": {
+        "domexception": "^1.0.1"
+      }
+    },
+    "node_modules/wrtc/node_modules/domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "optional": true,
+      "dependencies": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/wrtc/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "optional": true
     },
     "node_modules/ws": {
       "version": "7.5.0",
@@ -12593,6 +12740,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+      "dependencies": {
+        "global": "~4.4.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "node_modules/xml-name-validator": {
@@ -12630,7 +12788,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -15117,8 +15274,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -15445,6 +15601,17 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "configstore": {
       "version": "5.0.1",
@@ -16025,6 +16192,11 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
     "devtools-protocol": {
       "version": "0.0.960912",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.960912.tgz",
@@ -16120,6 +16292,11 @@
         "extend": "^3.0.0",
         "void-elements": "^2.0.0"
       }
+    },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "domain-browser": {
       "version": "4.19.0",
@@ -17179,6 +17356,11 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
+    "get-browser-rtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -17347,6 +17529,15 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
+    },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
     },
     "global-dirs": {
       "version": "0.1.1",
@@ -17841,6 +18032,11 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
       "dev": true
+    },
+    "is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "is-generator-function": {
       "version": "1.0.9",
@@ -18837,6 +19033,49 @@
         "private-ip": "^2.1.1"
       }
     },
+    "libp2p-webrtc-direct": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-direct/-/libp2p-webrtc-direct-0.7.1.tgz",
+      "integrity": "sha512-BTOaEFb9cT+5Arej2W+OdBFALOx+65IGKEa7isx/jKQLXzj76qiZqj88FvXxmLa3rl5UATsiB99sdzD19+IrDA==",
+      "requires": {
+        "abortable-iterator": "^3.0.0",
+        "class-is": "^1.1.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.3.1",
+        "detect-node": "^2.0.4",
+        "err-code": "^3.0.0",
+        "libp2p-utils": "^0.4.1",
+        "libp2p-webrtc-peer": "^10.0.1",
+        "mafmt": "^10.0.0",
+        "multiformats": "^9.4.5",
+        "once": "^1.4.0",
+        "request": "^2.88.0",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^3.0.0",
+        "wrtc": "~0.4.6",
+        "xhr": "^2.5.0"
+      }
+    },
+    "libp2p-webrtc-peer": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-peer/-/libp2p-webrtc-peer-10.0.1.tgz",
+      "integrity": "sha512-Qi/YVrSI5sjU+iBvr1iAjGrakIEvzCS8S76v4q43jjlDb6Wj+S4OnFLH/uRlt7eLXcx4vlaI6huMzYrUAoopMg==",
+      "requires": {
+        "debug": "^4.0.1",
+        "err-code": "^2.0.3",
+        "get-browser-rtc": "^1.0.0",
+        "queue-microtask": "^1.1.0",
+        "randombytes": "^2.0.3",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "err-code": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+        }
+      }
+    },
     "libp2p-websockets": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.16.1.tgz",
@@ -19286,6 +19525,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -20022,7 +20269,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -20251,6 +20497,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
     },
     "parse-json": {
       "version": "5.2.0",
@@ -20501,8 +20752,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-on-spawn": {
       "version": "1.0.0",
@@ -20674,14 +20924,12 @@
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -21942,6 +22190,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -22453,8 +22706,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -22468,6 +22720,32 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "wrtc": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/wrtc/-/wrtc-0.4.7.tgz",
+      "integrity": "sha512-P6Hn7VT4lfSH49HxLHcHhDq+aFf/jd9dPY7lDHeFhZ22N3858EKuwm2jmnlPzpsRGEPaoF6XwkcxY5SYnt4f/g==",
+      "requires": {
+        "domexception": "^1.0.1",
+        "node-pre-gyp": "^0.13.0"
+      },
+      "dependencies": {
+        "domexception": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+          "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+          "optional": true,
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "optional": true
+        }
+      }
+    },
     "ws": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
@@ -22479,6 +22757,17 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
+    },
+    "xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+      "requires": {
+        "global": "~4.4.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
     },
     "xml-name-validator": {
       "version": "4.0.0",
@@ -22508,8 +22797,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "libp2p-bootstrap": "^0.14.0",
     "libp2p-gossipsub": "^0.13.0",
     "libp2p-mplex": "^0.10.4",
+    "libp2p-webrtc-direct": "^0.7.1",
     "libp2p-websockets": "^0.16.1",
     "multiaddr": "^10.0.1",
     "multihashes": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "exports": "./",
   "repository": "https://github.com/status-im/js-waku",
   "license": "MIT OR Apache-2.0",
+  "exports": "./",
   "keywords": [
     "waku",
     "decentralised",

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -8,6 +8,9 @@ import { MuxedStream } from "libp2p-interfaces/dist/src/stream-muxer/types";
 import Mplex from "libp2p-mplex";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: No types available
+import WebRTCDirect from "libp2p-webrtc-direct";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: No types available
 import Websockets from "libp2p-websockets";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: No types available
@@ -175,7 +178,7 @@ export class Waku {
     // Default transport for libp2p is Websockets
     libp2pOpts.modules = Object.assign(
       {
-        transport: [Websockets],
+        transport: [Websockets, WebRTCDirect],
       },
       options?.libp2p?.modules
     );


### PR DESCRIPTION
Pending support in nim-waku

Related to #20

To try out:

```
git checkout webrtc-direct
npm i
npm run build
cd examples/web-chat
npm i
npm run start
```

Use Chrome (Known issue in Firefox: https://github.com/libp2p/js-libp2p/issues/1167)