### PR TITLE
test: use `createLightNode` instead of a full node

### DIFF
--- a/packages/tests/tests/ephemeral.node.spec.ts
+++ b/packages/tests/tests/ephemeral.node.spec.ts
@@ -1,7 +1,7 @@
 import { bytesToUtf8, utf8ToBytes } from "@waku/byte-utils";
 import { waitForRemotePeer } from "@waku/core/lib/wait_for_remote_peer";
 import { DecoderV0, EncoderV0 } from "@waku/core/lib/waku_message/version_0";
-import { createFullNode, createLightNode } from "@waku/create";
+import { createLightNode } from "@waku/create";
 import { DecodedMessage, Protocols, WakuLight } from "@waku/interfaces";
 import {
   AsymDecoder,
@@ -83,10 +83,10 @@ describe("Waku Message Ephemeral field", () => {
     const symDecoder = new SymDecoder(SymContentTopic, symKey);
 
     const [waku1, waku2, nimWakuMultiaddr] = await Promise.all([
-      createFullNode({
+      createLightNode({
         staticNoiseKey: NOISE_KEY_1,
       }).then((waku) => waku.start().then(() => waku)),
-      createFullNode({
+      createLightNode({
         staticNoiseKey: NOISE_KEY_2,
       }).then((waku) => waku.start().then(() => waku)),
       nwaku.getMultiaddrWithId(),

--- a/packages/tests/tests/filter.node.spec.ts
+++ b/packages/tests/tests/filter.node.spec.ts
@@ -1,8 +1,8 @@
 import { bytesToUtf8, utf8ToBytes } from "@waku/byte-utils";
 import { waitForRemotePeer } from "@waku/core/lib/wait_for_remote_peer";
 import { DecoderV0, EncoderV0 } from "@waku/core/lib/waku_message/version_0";
-import { createFullNode } from "@waku/create";
-import type { DecodedMessage, WakuFull } from "@waku/interfaces";
+import { createLightNode } from "@waku/create";
+import type { DecodedMessage, WakuLight } from "@waku/interfaces";
 import { Protocols } from "@waku/interfaces";
 import { expect } from "chai";
 import debug from "debug";
@@ -17,7 +17,7 @@ const TestEncoder = new EncoderV0(TestContentTopic);
 const TestDecoder = new DecoderV0(TestContentTopic);
 
 describe("Waku Filter", () => {
-  let waku: WakuFull;
+  let waku: WakuLight;
   let nwaku: Nwaku;
 
   afterEach(async function () {
@@ -29,7 +29,7 @@ describe("Waku Filter", () => {
     this.timeout(15000);
     nwaku = new Nwaku(makeLogFileName(this));
     await nwaku.start({ filter: true, lightpush: true });
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
       libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } },
     });

--- a/packages/tests/tests/light_push.node.spec.ts
+++ b/packages/tests/tests/light_push.node.spec.ts
@@ -1,8 +1,8 @@
 import { bytesToUtf8, utf8ToBytes } from "@waku/byte-utils";
 import { waitForRemotePeer } from "@waku/core/lib/wait_for_remote_peer";
 import { EncoderV0 } from "@waku/core/lib/waku_message/version_0";
-import { createFullNode } from "@waku/create";
-import type { WakuFull } from "@waku/interfaces";
+import { createLightNode } from "@waku/create";
+import type { WakuLight } from "@waku/interfaces";
 import { Protocols } from "@waku/interfaces";
 import { expect } from "chai";
 import debug from "debug";
@@ -21,7 +21,7 @@ const TestContentTopic = "/test/1/waku-light-push/utf8";
 const TestEncoder = new EncoderV0(TestContentTopic);
 
 describe("Waku Light Push [node only]", () => {
-  let waku: WakuFull;
+  let waku: WakuLight;
   let nwaku: Nwaku;
 
   afterEach(async function () {
@@ -35,7 +35,7 @@ describe("Waku Light Push [node only]", () => {
     nwaku = new Nwaku(makeLogFileName(this));
     await nwaku.start({ lightpush: true });
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -68,7 +68,7 @@ describe("Waku Light Push [node only]", () => {
     nwaku = new Nwaku(makeLogFileName(this));
     await nwaku.start({ lightpush: true, topics: customPubSubTopic });
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       pubSubTopic: customPubSubTopic,
       staticNoiseKey: NOISE_KEY_1,
     });

--- a/packages/tests/tests/store.node.spec.ts
+++ b/packages/tests/tests/store.node.spec.ts
@@ -2,8 +2,8 @@ import { bytesToUtf8, utf8ToBytes } from "@waku/byte-utils";
 import { createCursor, PageDirection } from "@waku/core";
 import { waitForRemotePeer } from "@waku/core/lib/wait_for_remote_peer";
 import { DecoderV0, EncoderV0 } from "@waku/core/lib/waku_message/version_0";
-import { createFullNode } from "@waku/create";
-import { DecodedMessage, Message, WakuFull } from "@waku/interfaces";
+import { createLightNode } from "@waku/create";
+import { DecodedMessage, Message, WakuLight } from "@waku/interfaces";
 import { Protocols } from "@waku/interfaces";
 import {
   AsymDecoder,
@@ -27,7 +27,7 @@ const TestEncoder = new EncoderV0(TestContentTopic);
 const TestDecoder = new DecoderV0(TestContentTopic);
 
 describe("Waku Store", () => {
-  let waku: WakuFull;
+  let waku: WakuLight;
   let nwaku: Nwaku;
 
   beforeEach(async function () {
@@ -56,7 +56,7 @@ describe("Waku Store", () => {
       ).to.be.true;
     }
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -87,7 +87,7 @@ describe("Waku Store", () => {
   it("Generator, no message returned", async function () {
     this.timeout(15_000);
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -126,7 +126,7 @@ describe("Waku Store", () => {
       ).to.be.true;
     }
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -183,7 +183,7 @@ describe("Waku Store", () => {
       ).to.be.true;
     }
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -224,7 +224,7 @@ describe("Waku Store", () => {
       ).to.be.true;
     }
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -264,7 +264,7 @@ describe("Waku Store", () => {
       await delay(1); // to ensure each timestamp is unique.
     }
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -303,7 +303,7 @@ describe("Waku Store", () => {
       await delay(1); // to ensure each timestamp is unique.
     }
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -372,10 +372,10 @@ describe("Waku Store", () => {
     const symDecoder = new SymDecoder(symTopic, symKey);
 
     const [waku1, waku2, nimWakuMultiaddr] = await Promise.all([
-      createFullNode({
+      createLightNode({
         staticNoiseKey: NOISE_KEY_1,
       }).then((waku) => waku.start().then(() => waku)),
-      createFullNode({
+      createLightNode({
         staticNoiseKey: NOISE_KEY_2,
       }).then((waku) => waku.start().then(() => waku)),
       nwaku.getMultiaddrWithId(),
@@ -462,7 +462,7 @@ describe("Waku Store", () => {
       ).to.be.true;
     }
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -524,7 +524,7 @@ describe("Waku Store", () => {
       await delay(1); // to ensure each timestamp is unique.
     }
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
@@ -548,7 +548,7 @@ describe("Waku Store", () => {
 
 describe("Waku Store, custom pubsub topic", () => {
   const customPubSubTopic = "/waku/2/custom-dapp/proto";
-  let waku: WakuFull;
+  let waku: WakuLight;
   let nwaku: Nwaku;
 
   beforeEach(async function () {
@@ -581,7 +581,7 @@ describe("Waku Store, custom pubsub topic", () => {
       ).to.be.true;
     }
 
-    waku = await createFullNode({
+    waku = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
       pubSubTopic: customPubSubTopic,
     });


### PR DESCRIPTION
As full node was only necessary due to an issue nwaku v0.11.

Ref: https://github.com/status-im/nwaku/pull/1090