### PR TITLE
Add `emitSelf` to `CreateOptions` interface

### DIFF
--- a/src/lib/create_waku.ts
+++ b/src/lib/create_waku.ts
@@ -31,6 +31,10 @@ export interface CreateOptions {
    */
   pubSubTopic?: string;
   /**
+   * Publish to self too, if subscribed.
+   */
+  emitSelf?: boolean;
+  /**
    * You can pass options to the `Libp2p` instance used by {@link index.waku.WakuNode} using the {@link CreateOptions.libp2p} property.
    * This property is the same type than the one passed to [`Libp2p.create`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#create)
    * apart that we made the `modules` property optional and partial,


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

Missing `emitSelf` option in `CreateOptions` interface

## Solution

<!-- describe the new behavior --> 

## Notes

<!-- Remove items that are not relevant -->

- Related to https://github.com/status-im/status-web/pull/307#discussion_r962932432
