### PR TITLE
feat: store callback takes promises 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Correct options type for `createFullNode` & `createPrivacy` to enable passing gossipsub options.
+- `WakuStore` now provides several APIs: `queryGenerator`, `queryCallbackOnPromise`, `queryOrderedCallback`;
+  each provides different guarantees and performance.
 
 ## [0.27.0] - 2022-09-13
 

--- a/src/lib/select_peer.ts
+++ b/src/lib/select_peer.ts
@@ -4,9 +4,7 @@ import type { Peer, PeerStore } from "@libp2p/interface-peer-store";
  * Returns a pseudo-random peer that supports the given protocol.
  * Useful for protocols such as store and light push
  */
-export async function selectRandomPeer(
-  peers: Peer[]
-): Promise<Peer | undefined> {
+export function selectRandomPeer(peers: Peer[]): Peer | undefined {
   if (peers.length === 0) return;
 
   const index = Math.round(Math.random() * (peers.length - 1));

--- a/src/lib/select_peer.ts
+++ b/src/lib/select_peer.ts
@@ -1,5 +1,4 @@
-import { Peer } from "@libp2p/interface-peer-store";
-import { Libp2p } from "libp2p";
+import type { Peer, PeerStore } from "@libp2p/interface-peer-store";
 
 /**
  * Returns a pseudo-random peer that supports the given protocol.
@@ -18,11 +17,11 @@ export async function selectRandomPeer(
  * Returns the list of peers that supports the given protocol.
  */
 export async function getPeersForProtocol(
-  libp2p: Libp2p,
+  peerStore: PeerStore,
   protocols: string[]
 ): Promise<Peer[]> {
   const peers: Peer[] = [];
-  await libp2p.peerStore.forEach((peer) => {
+  await peerStore.forEach((peer) => {
     for (let i = 0; i < protocols.length; i++) {
       if (peer.protocols.includes(protocols[i])) {
         peers.push(peer);

--- a/src/lib/select_peer.ts
+++ b/src/lib/select_peer.ts
@@ -1,4 +1,8 @@
+import type { PeerId } from "@libp2p/interface-peer-id";
 import type { Peer, PeerStore } from "@libp2p/interface-peer-store";
+import debug from "debug";
+
+const log = debug("waku:select-peer");
 
 /**
  * Returns a pseudo-random peer that supports the given protocol.
@@ -28,4 +32,46 @@ export async function getPeersForProtocol(
     }
   });
   return peers;
+}
+
+export async function selectPeerForProtocol(
+  peerStore: PeerStore,
+  protocols: string[],
+  peerId?: PeerId
+): Promise<{ peer: Peer; protocol: string } | undefined> {
+  let peer;
+  if (peerId) {
+    peer = await peerStore.get(peerId);
+    if (!peer) {
+      log(
+        `Failed to retrieve connection details for provided peer in peer store: ${peerId.toString()}`
+      );
+      return;
+    }
+  } else {
+    const peers = await getPeersForProtocol(peerStore, protocols);
+    peer = selectRandomPeer(peers);
+    if (!peer) {
+      log("Failed to find known peer that registers protocols", protocols);
+      return;
+    }
+  }
+
+  let protocol;
+  for (const codec of protocols) {
+    if (peer.protocols.includes(codec)) {
+      protocol = codec;
+      // Do not break as we want to keep the last value
+    }
+  }
+  log(`Using codec ${protocol}`);
+  if (!protocol) {
+    log(
+      `Peer does not register required protocols: ${peer.id.toString()}`,
+      protocols
+    );
+    return;
+  }
+
+  return { peer, protocol };
 }

--- a/src/lib/waku_filter/index.ts
+++ b/src/lib/waku_filter/index.ts
@@ -272,7 +272,7 @@ export class WakuFilter {
   }
 
   async peers(): Promise<Peer[]> {
-    return getPeersForProtocol(this.libp2p, [FilterCodec]);
+    return getPeersForProtocol(this.libp2p.peerStore, [FilterCodec]);
   }
 
   async randomPeer(): Promise<Peer | undefined> {

--- a/src/lib/waku_filter/index.ts
+++ b/src/lib/waku_filter/index.ts
@@ -11,7 +11,11 @@ import type { Libp2p } from "libp2p";
 import { WakuMessage as WakuMessageProto } from "../../proto/message";
 import { DefaultPubSubTopic } from "../constants";
 import { selectConnection } from "../select_connection";
-import { getPeersForProtocol, selectRandomPeer } from "../select_peer";
+import {
+  getPeersForProtocol,
+  selectPeerForProtocol,
+  selectRandomPeer,
+} from "../select_peer";
 import { hexToBytes } from "../utils";
 import { DecryptionMethod, WakuMessage } from "../waku_message";
 
@@ -228,23 +232,15 @@ export class WakuFilter {
   }
 
   private async getPeer(peerId?: PeerId): Promise<Peer> {
-    let peer;
-    if (peerId) {
-      peer = await this.libp2p.peerStore.get(peerId);
-      if (!peer) {
-        throw new Error(
-          `Failed to retrieve connection details for provided peer in peer store: ${peerId.toString()}`
-        );
-      }
-    } else {
-      peer = await this.randomPeer();
-      if (!peer) {
-        throw new Error(
-          "Failed to find known peer that registers waku filter protocol"
-        );
-      }
+    const res = await selectPeerForProtocol(
+      this.libp2p.peerStore,
+      [FilterCodec],
+      peerId
+    );
+    if (!res) {
+      throw new Error(`Failed to select peer for ${FilterCodec}`);
     }
-    return peer;
+    return res.peer;
   }
 
   /**

--- a/src/lib/waku_light_push/index.ts
+++ b/src/lib/waku_light_push/index.ts
@@ -109,7 +109,7 @@ export class WakuLightPush {
    * peers.
    */
   async peers(): Promise<Peer[]> {
-    return getPeersForProtocol(this.libp2p, [LightPushCodec]);
+    return getPeersForProtocol(this.libp2p.peerStore, [LightPushCodec]);
   }
 
   /**

--- a/src/lib/waku_store/index.node.spec.ts
+++ b/src/lib/waku_store/index.node.spec.ts
@@ -25,70 +25,23 @@ const log = debug("waku:test:store");
 
 const TestContentTopic = "/test/1/waku-store/utf8";
 
-const isWakuMessageDefined = (
-  msg: WakuMessage | undefined
-): msg is WakuMessage => {
-  return !!msg;
-};
-
 describe("Waku Store", () => {
   let waku: WakuFull;
   let nwaku: Nwaku;
+
+  beforeEach(async function () {
+    this.timeout(15_000);
+    nwaku = new Nwaku(makeLogFileName(this));
+    await nwaku.start({ persistMessages: true, store: true, lightpush: true });
+  });
 
   afterEach(async function () {
     !!nwaku && nwaku.stop();
     !!waku && waku.stop().catch((e) => console.log("Waku failed to stop", e));
   });
 
-  it("Retrieves history", async function () {
+  it("Generator", async function () {
     this.timeout(15_000);
-
-    nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, store: true });
-
-    for (let i = 0; i < 2; i++) {
-      expect(
-        await nwaku.sendMessage(
-          Nwaku.toMessageRpcQuery({
-            payload: utf8ToBytes(`Message ${i}`),
-            contentTopic: TestContentTopic,
-          })
-        )
-      ).to.be.true;
-    }
-
-    waku = await createFullNode({
-      staticNoiseKey: NOISE_KEY_1,
-    });
-    await waku.start();
-    await waku.dial(await nwaku.getMultiaddrWithId());
-    await waitForRemotePeer(waku, [Protocols.Store]);
-
-    const messages: WakuMessage[] = [];
-    await waku.store.queryHistory([], async (msgPromises) => {
-      await Promise.all(
-        msgPromises.map(async (promise) => {
-          const msg = await promise;
-          if (msg) {
-            messages.push(msg);
-          }
-        })
-      );
-    });
-
-    expect(messages?.length).eq(2);
-    const result = messages?.findIndex((msg) => {
-      return msg.payloadAsUtf8 === "Message 0";
-    });
-    expect(result).to.not.eq(-1);
-  });
-
-  it("Retrieves history using callback", async function () {
-    this.timeout(15_000);
-
-    nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, store: true });
-
     const totalMsgs = 20;
 
     for (let i = 0; i < totalMsgs; i++) {
@@ -110,15 +63,82 @@ describe("Waku Store", () => {
     await waitForRemotePeer(waku, [Protocols.Store]);
 
     const messages: WakuMessage[] = [];
-    await waku.store.queryHistory([], async (msgPromises) => {
-      await Promise.all(
-        msgPromises.map(async (promise) => {
-          const msg = await promise;
-          if (msg) {
-            messages.push(msg);
-          }
-        })
-      );
+    let promises: Promise<void>[] = [];
+    for await (const msgPromises of waku.store.queryGenerator([])) {
+      const _promises = msgPromises.map(async (promise) => {
+        const msg = await promise;
+        if (msg) {
+          messages.push(msg);
+        }
+      });
+
+      promises = promises.concat(_promises);
+    }
+    await Promise.all(promises);
+
+    expect(messages?.length).eq(totalMsgs);
+    const result = messages?.findIndex((msg) => {
+      return msg.payloadAsUtf8 === "Message 0";
+    });
+    expect(result).to.not.eq(-1);
+  });
+
+  it("Generator, no message returned", async function () {
+    this.timeout(15_000);
+
+    waku = await createFullNode({
+      staticNoiseKey: NOISE_KEY_1,
+    });
+    await waku.start();
+    await waku.dial(await nwaku.getMultiaddrWithId());
+    await waitForRemotePeer(waku, [Protocols.Store]);
+
+    const messages: WakuMessage[] = [];
+    let promises: Promise<void>[] = [];
+    for await (const msgPromises of waku.store.queryGenerator([])) {
+      const _promises = msgPromises.map(async (promise) => {
+        const msg = await promise;
+        if (msg) {
+          messages.push(msg);
+        }
+      });
+
+      promises = promises.concat(_promises);
+    }
+    await Promise.all(promises);
+
+    expect(messages?.length).eq(0);
+  });
+
+  it("Callback on promise", async function () {
+    this.timeout(15_000);
+
+    const totalMsgs = 15;
+
+    for (let i = 0; i < totalMsgs; i++) {
+      expect(
+        await nwaku.sendMessage(
+          Nwaku.toMessageRpcQuery({
+            payload: utf8ToBytes(`Message ${i}`),
+            contentTopic: TestContentTopic,
+          })
+        )
+      ).to.be.true;
+    }
+
+    waku = await createFullNode({
+      staticNoiseKey: NOISE_KEY_1,
+    });
+    await waku.start();
+    await waku.dial(await nwaku.getMultiaddrWithId());
+    await waitForRemotePeer(waku, [Protocols.Store]);
+
+    const messages: WakuMessage[] = [];
+    await waku.store.queryCallbackOnPromise([], async (msgPromise) => {
+      const msg = await msgPromise;
+      if (msg) {
+        messages.push(msg);
+      }
     });
 
     expect(messages?.length).eq(totalMsgs);
@@ -128,15 +148,12 @@ describe("Waku Store", () => {
     expect(result).to.not.eq(-1);
   });
 
-  it("Retrieval aborts when callback returns true", async function () {
+  it("Callback on promise, aborts when callback returns true", async function () {
     this.timeout(15_000);
 
-    nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, store: true });
+    const totalMsgs = 20;
 
-    const availMsgs = 20;
-
-    for (let i = 0; i < availMsgs; i++) {
+    for (let i = 0; i < totalMsgs; i++) {
       expect(
         await nwaku.sendMessage(
           Nwaku.toMessageRpcQuery({
@@ -154,15 +171,15 @@ describe("Waku Store", () => {
     await waku.dial(await nwaku.getMultiaddrWithId());
     await waitForRemotePeer(waku, [Protocols.Store]);
 
-    let messages: WakuMessage[] = [];
     const desiredMsgs = 14;
-
-    await waku.store.queryHistory(
+    const messages: WakuMessage[] = [];
+    await waku.store.queryCallbackOnPromise(
       [],
-      async (msgPromises) => {
-        const msgsOrUndefined = await Promise.all(msgPromises);
-        const msgs = msgsOrUndefined.filter(isWakuMessageDefined);
-        messages = messages.concat(msgs);
+      async (msgPromise) => {
+        const msg = await msgPromise;
+        if (msg) {
+          messages.push(msg);
+        }
         return messages.length >= desiredMsgs;
       },
       { pageSize: 7 }
@@ -171,13 +188,11 @@ describe("Waku Store", () => {
     expect(messages?.length).eq(desiredMsgs);
   });
 
-  it("Retrieves all historical elements in chronological order through paging", async function () {
+  it("Ordered Callback - Forward", async function () {
     this.timeout(15_000);
 
-    nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, store: true });
-
-    for (let i = 0; i < 15; i++) {
+    const totalMsgs = 18;
+    for (let i = 0; i < totalMsgs; i++) {
       expect(
         await nwaku.sendMessage(
           Nwaku.toMessageRpcQuery({
@@ -195,24 +210,19 @@ describe("Waku Store", () => {
     await waku.dial(await nwaku.getMultiaddrWithId());
     await waitForRemotePeer(waku, [Protocols.Store]);
 
-    let messages: WakuMessage[] = [];
-    await waku.store.queryHistory(
+    const messages: WakuMessage[] = [];
+    await waku.store.queryOrderedCallback(
       [],
-      async (msgPromises) => {
-        const msgsOrUndefined = await Promise.all(msgPromises);
-        const msgs = msgsOrUndefined.filter(isWakuMessageDefined);
-        // Note: messages within a page are ordered from oldest to most recent
-        // so the `concat` can only preserve order when `PageDirection`
-        // is forward
-        messages = messages.concat(msgs);
+      async (msg) => {
+        messages.push(msg);
       },
       {
         pageDirection: PageDirection.FORWARD,
       }
     );
 
-    expect(messages?.length).eq(15);
-    for (let index = 0; index < 2; index++) {
+    expect(messages?.length).eq(totalMsgs);
+    for (let index = 0; index < totalMsgs; index++) {
       expect(
         messages?.findIndex((msg) => {
           return msg.payloadAsUtf8 === `Message ${index}`;
@@ -221,175 +231,53 @@ describe("Waku Store", () => {
     }
   });
 
-  it("Retrieves history using custom pubsub topic", async function () {
+  it("Ordered Callback - Backward", async function () {
     this.timeout(15_000);
 
-    const customPubSubTopic = "/waku/2/custom-dapp/proto";
-    nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({
-      persistMessages: true,
-      store: true,
-      topics: customPubSubTopic,
-    });
-
-    for (let i = 0; i < 2; i++) {
+    const totalMsgs = 18;
+    for (let i = 0; i < totalMsgs; i++) {
       expect(
         await nwaku.sendMessage(
           Nwaku.toMessageRpcQuery({
             payload: utf8ToBytes(`Message ${i}`),
             contentTopic: TestContentTopic,
-          }),
-          customPubSubTopic
+          })
         )
       ).to.be.true;
     }
 
     waku = await createFullNode({
-      pubSubTopic: customPubSubTopic,
       staticNoiseKey: NOISE_KEY_1,
     });
     await waku.start();
     await waku.dial(await nwaku.getMultiaddrWithId());
     await waitForRemotePeer(waku, [Protocols.Store]);
 
-    const nimPeerId = await nwaku.getPeerId();
-
-    const messages: WakuMessage[] = [];
-    await waku.store.queryHistory(
-      [],
-      async (msgPromises) => {
-        await Promise.all(
-          msgPromises.map(async (promise) => {
-            const msg = await promise;
-            if (msg) {
-              messages.push(msg);
-            }
-          })
-        );
-      },
-      {
-        peerId: nimPeerId,
-      }
-    );
-
-    expect(messages?.length).eq(2);
-    const result = messages?.findIndex((msg) => {
-      return msg.payloadAsUtf8 === "Message 0";
-    });
-    expect(result).to.not.eq(-1);
-  });
-
-  it("Retrieves history with asymmetric & symmetric encrypted messages", async function () {
-    this.timeout(15_000);
-
-    nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, store: true, lightpush: true });
-
-    const encryptedAsymmetricMessageText = "asymmetric encryption";
-    const encryptedSymmetricMessageText = "symmetric encryption";
-    const clearMessageText =
-      "This is a clear text message for everyone to read";
-    const otherEncMessageText =
-      "This message is not for and I must not be able to read it";
-
-    const privateKey = generatePrivateKey();
-    const symKey = generateSymmetricKey();
-    const publicKey = getPublicKey(privateKey);
-
-    const timestamp = new Date();
-    const [
-      encryptedAsymmetricMessage,
-      encryptedSymmetricMessage,
-      clearMessage,
-      otherEncMessage,
-    ] = await Promise.all([
-      WakuMessage.fromUtf8String(
-        encryptedAsymmetricMessageText,
-        TestContentTopic,
-        {
-          encPublicKey: publicKey,
-          timestamp,
-        }
-      ),
-      WakuMessage.fromUtf8String(
-        encryptedSymmetricMessageText,
-        TestContentTopic,
-        {
-          symKey: symKey,
-          timestamp: new Date(timestamp.valueOf() + 1),
-        }
-      ),
-      WakuMessage.fromUtf8String(clearMessageText, TestContentTopic, {
-        timestamp: new Date(timestamp.valueOf() + 2),
-      }),
-      WakuMessage.fromUtf8String(otherEncMessageText, TestContentTopic, {
-        encPublicKey: getPublicKey(generatePrivateKey()),
-        timestamp: new Date(timestamp.valueOf() + 3),
-      }),
-    ]);
-
-    log("Messages have been encrypted");
-    const [waku1, waku2, nimWakuMultiaddr] = await Promise.all([
-      createFullNode({
-        staticNoiseKey: NOISE_KEY_1,
-      }).then((waku) => waku.start().then(() => waku)),
-      createFullNode({
-        staticNoiseKey: NOISE_KEY_2,
-      }).then((waku) => waku.start().then(() => waku)),
-      nwaku.getMultiaddrWithId(),
-    ]);
-
-    log("Waku nodes created");
-
-    await Promise.all([
-      waku1.dial(nimWakuMultiaddr),
-      waku2.dial(nimWakuMultiaddr),
-    ]);
-
-    log("Waku nodes connected to nwaku");
-
-    await waitForRemotePeer(waku1, [Protocols.LightPush]);
-
-    log("Sending messages using light push");
-    await Promise.all([
-      waku1.lightPush.push(encryptedAsymmetricMessage),
-      waku1.lightPush.push(encryptedSymmetricMessage),
-      waku1.lightPush.push(otherEncMessage),
-      waku1.lightPush.push(clearMessage),
-    ]);
-
-    await waitForRemotePeer(waku2, [Protocols.Store]);
-
-    waku2.store.addDecryptionKey(symKey);
-
-    log("Retrieve messages from store");
     let messages: WakuMessage[] = [];
-    await waku2.store.queryHistory(
+    await waku.store.queryOrderedCallback(
       [],
-      async (msgPromises) => {
-        const msgsOrUndefined = await Promise.all(msgPromises);
-        const msgs = msgsOrUndefined.filter(isWakuMessageDefined);
-        messages = messages.concat(msgs);
+      async (msg) => {
+        messages.push(msg);
       },
       {
-        decryptionParams: [{ key: privateKey }],
+        pageDirection: PageDirection.BACKWARD,
       }
     );
 
-    // Messages are ordered from oldest to latest within a page (1 page query)
-    expect(messages[0]?.payloadAsUtf8).to.eq(encryptedAsymmetricMessageText);
-    expect(messages[1]?.payloadAsUtf8).to.eq(encryptedSymmetricMessageText);
-    expect(messages[2]?.payloadAsUtf8).to.eq(clearMessageText);
+    messages = messages.reverse();
 
-    !!waku1 && waku1.stop().catch((e) => console.log("Waku failed to stop", e));
-    !!waku2 && waku2.stop().catch((e) => console.log("Waku failed to stop", e));
+    expect(messages?.length).eq(totalMsgs);
+    for (let index = 0; index < totalMsgs; index++) {
+      expect(
+        messages?.findIndex((msg) => {
+          return msg.payloadAsUtf8 === `Message ${index}`;
+        })
+      ).to.eq(index);
+    }
   });
 
-  it("Retrieves history with asymmetric & symmetric encrypted messages on different content topics", async function () {
+  it("Generator, with asymmetric & symmetric encrypted messages", async function () {
     this.timeout(15_000);
-
-    nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, store: true, lightpush: true });
 
     const encryptedAsymmetricMessageText =
       "This message is encrypted for me using asymmetric";
@@ -482,19 +370,19 @@ describe("Waku Store", () => {
       method: DecryptionMethod.Symmetric,
     });
 
-    let messages: WakuMessage[] = [];
+    const messages: WakuMessage[] = [];
     log("Retrieve messages from store");
-    await waku2.store.queryHistory(
-      [],
-      async (msgPromises) => {
-        const msgsOrUndefined = await Promise.all(msgPromises);
-        const msgs = msgsOrUndefined.filter(isWakuMessageDefined);
-        messages = messages.concat(msgs);
-      },
-      {
-        decryptionParams: [{ key: privateKey }],
+
+    for await (const msgPromises of waku2.store.queryGenerator([], {
+      decryptionParams: [{ key: privateKey }],
+    })) {
+      for (const promise of msgPromises) {
+        const msg = await promise;
+        if (msg) {
+          messages.push(msg);
+        }
       }
-    );
+    }
 
     expect(messages?.length).eq(3);
     if (!messages) throw "Length was tested";
@@ -503,15 +391,24 @@ describe("Waku Store", () => {
     expect(messages[1].payloadAsUtf8).to.eq(encryptedSymmetricMessageText);
     expect(messages[2].payloadAsUtf8).to.eq(clearMessageText);
 
+    for (const text of [
+      encryptedAsymmetricMessageText,
+      encryptedSymmetricMessageText,
+      clearMessageText,
+    ]) {
+      expect(
+        messages?.findIndex((msg) => {
+          return msg.payloadAsUtf8 === text;
+        })
+      ).to.not.eq(-1);
+    }
+
     !!waku1 && waku1.stop().catch((e) => console.log("Waku failed to stop", e));
     !!waku2 && waku2.stop().catch((e) => console.log("Waku failed to stop", e));
   });
 
-  it("Retrieves history using start and end time", async function () {
-    this.timeout(15_000);
-
-    nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, store: true });
+  it("Ordered callback, using start and end time", async function () {
+    this.timeout(20000);
 
     const now = new Date();
 
@@ -554,17 +451,12 @@ describe("Waku Store", () => {
     const nwakuPeerId = await nwaku.getPeerId();
 
     const firstMessages: WakuMessage[] = [];
-    await waku.store.queryHistory(
+    await waku.store.queryOrderedCallback(
       [],
-      async (msgPromises) => {
-        await Promise.all(
-          msgPromises.map(async (promise) => {
-            const msg = await promise;
-            if (msg) {
-              firstMessages.push(msg);
-            }
-          })
-        );
+      (msg) => {
+        if (msg) {
+          firstMessages.push(msg);
+        }
       },
       {
         peerId: nwakuPeerId,
@@ -573,17 +465,10 @@ describe("Waku Store", () => {
     );
 
     const bothMessages: WakuMessage[] = [];
-    await waku.store.queryHistory(
+    await waku.store.queryOrderedCallback(
       [],
-      async (msgPromises) => {
-        await Promise.all(
-          msgPromises.map(async (promise) => {
-            const msg = await promise;
-            if (msg) {
-              bothMessages.push(msg);
-            }
-          })
-        );
+      async (msg) => {
+        bothMessages.push(msg);
       },
       {
         peerId: nwakuPeerId,
@@ -599,5 +484,71 @@ describe("Waku Store", () => {
     expect(firstMessages[0]?.payloadAsUtf8).eq("Message 0");
 
     expect(bothMessages?.length).eq(2);
+  });
+});
+
+describe("Waku Store, custom pubsub topic", () => {
+  const customPubSubTopic = "/waku/2/custom-dapp/proto";
+  let waku: WakuFull;
+  let nwaku: Nwaku;
+
+  beforeEach(async function () {
+    this.timeout(15_000);
+    nwaku = new Nwaku(makeLogFileName(this));
+    await nwaku.start({
+      persistMessages: true,
+      store: true,
+      topics: customPubSubTopic,
+    });
+  });
+
+  afterEach(async function () {
+    !!nwaku && nwaku.stop();
+    !!waku && waku.stop().catch((e) => console.log("Waku failed to stop", e));
+  });
+
+  it("Generator, custom pubsub topic", async function () {
+    this.timeout(15_000);
+
+    const totalMsgs = 20;
+    for (let i = 0; i < totalMsgs; i++) {
+      expect(
+        await nwaku.sendMessage(
+          Nwaku.toMessageRpcQuery({
+            payload: utf8ToBytes(`Message ${i}`),
+            contentTopic: TestContentTopic,
+          }),
+          customPubSubTopic
+        )
+      ).to.be.true;
+    }
+
+    waku = await createFullNode({
+      staticNoiseKey: NOISE_KEY_1,
+      pubSubTopic: customPubSubTopic,
+    });
+    await waku.start();
+    await waku.dial(await nwaku.getMultiaddrWithId());
+    await waitForRemotePeer(waku, [Protocols.Store]);
+
+    const messages: WakuMessage[] = [];
+    let promises: Promise<void>[] = [];
+    for await (const msgPromises of waku.store.queryGenerator([])) {
+      const _promises = msgPromises.map(async (promise) => {
+        const msg = await promise;
+        if (msg) {
+          messages.push(msg);
+        }
+      });
+
+      promises = promises.concat(_promises);
+    }
+    await Promise.all(promises);
+
+    expect(messages?.length).eq(totalMsgs);
+    const result = messages?.findIndex((msg) => {
+      return msg.payloadAsUtf8 === "Message 0";
+    });
+    expect(result).to.not.eq(-1);
   });
 });

--- a/src/lib/waku_store/index.ts
+++ b/src/lib/waku_store/index.ts
@@ -312,7 +312,7 @@ export class WakuStore {
       codecs.push(codec);
     }
 
-    return getPeersForProtocol(this.libp2p, codecs);
+    return getPeersForProtocol(this.libp2p.peerStore, codecs);
   }
 
   /**

--- a/src/lib/waku_store/index.ts
+++ b/src/lib/waku_store/index.ts
@@ -21,7 +21,7 @@ import {
 
 import { HistoryRPC, PageDirection } from "./history_rpc";
 
-import Error = HistoryResponse.HistoryError;
+import HistoryError = HistoryResponse.HistoryError;
 
 const log = debug("waku:store");
 
@@ -225,7 +225,10 @@ export class WakuStore {
 
       const response = reply.response as protoV2Beta4.HistoryResponse;
 
-      if (response.error && response.error !== Error.ERROR_NONE_UNSPECIFIED) {
+      if (
+        response.error &&
+        response.error !== HistoryError.ERROR_NONE_UNSPECIFIED
+      ) {
         throw "History response contains an Error: " + response.error;
       }
 


### PR DESCRIPTION
This enables the consumer to decide between:

1. Waiting for all promises, less efficient but maintain order;
2. Process promises as they resolve, faster to get messages through but
disrupt message order.

Helps with #937
Resolves #750