### PR TITLE
Revert "fix: util polyfill not needed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API Docs moved to https://js.waku.org/
 - test: fix typing for nwaku JSON RPC responses.
 
-### Fixed
-
-- Specify that `util` polyfill is not needed so that bundlers can automatically discard it.
-
 ## [0.26.0] - 2022-09-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -83,8 +83,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "browser": {
-    "crypto": false,
-    "util": false
+    "crypto": false
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
This reverts commit cf6eafdff356e8339e8589fb2b3c01b5da241879.

The polyfill is actually needed because `util.inspect.custom` is called.
