### PR TITLE
Release 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2022-09-13
+
+### Added
+
+- `createLightNode` to create a Waku node for resource restricted environment with Light Push, Filter and Relay.
+- `createPrivacyNode` to create a Waku node for privacy preserving usage with Relay only.
+- `createFullNode` to create a Waku node for with all protocols, for **testing purposes only**.
+
 ### Changed
 
+- `Waku` is now defined as an interface with `WakuNode` an implementation of it.
+- `createWaku` is deprecated in favour of `createLightNode` and `createPrivacyNode`.
+- `waitForRemotePeer` can throw, default behaviour has changed.
 - `addPeerToAddressBook` is now async.
 - API Docs moved to https://js.waku.org/
 - test: fix typing for nwaku JSON RPC responses.
@@ -18,17 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Simple connection management that selects the most recent connection for store, light push and filter requests.
-- `createLightNode` to create a Waku node for resource restricted environment with Light Push, Filter and Relay.
-- `createPrivacyNode` to create a Waku node for privacy preserving usage with Relay only.
-- `createFullNode` to create a Waku node for with all protocols, for **testing purposes only**.
 
 ### Changed
 
 - **breaking**: `DecryptionParams` may be passed when using `queryHistory` instead of just keys.
 - Examples have been moved to https://github.com/waku-org/js-waku-examples.
-- `Waku` is now defined as an interface with `WakuNode` an implementation of it.
-- `createWaku` is deprecated in favour of `createLightNode` and `createPrivacyNode`.
-- `waitForRemotePeer` can throw, default behaviour has changed.
 
 ### Fixed
 
@@ -478,7 +483,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://js-waku.wakuconnect.dev/).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/status-im/js-waku/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/status-im/js-waku/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/status-im/js-waku/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/status-im/js-waku/compare/v0.23.0...v0.24.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -76,6 +76,13 @@ export class WakuNode implements Waku {
       this.relay = libp2p.pubsub;
     }
 
+    log(
+      "Waku node created",
+      this.libp2p.peerId.toString(),
+      `relay: ${!!this.relay}, store: ${!!this.store}, light push: ${!!this
+        .lightPush}, filter: ${!!this.filter}`
+    );
+
     this.pingKeepAliveTimers = {};
     this.relayKeepAliveTimers = {};
 


### PR DESCRIPTION
### Added

- `createLightNode` to create a Waku node for resource restricted environment with Light Push, Filter and Relay.
- `createPrivacyNode` to create a Waku node for privacy preserving usage with Relay only.
- `createFullNode` to create a Waku node for with all protocols, for **testing purposes only**.

### Changed

- `Waku` is now defined as an interface with `WakuNode` an implementation of it.
- `createWaku` is deprecated in favour of `createLightNode` and `createPrivacyNode`.
- `waitForRemotePeer` can throw, default behaviour has changed.
- `addPeerToAddressBook` is now async.
- API Docs moved to https://js.waku.org/
- test: fix typing for nwaku JSON RPC responses.