### PR TITLE
Release 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2022-09-16
+
 ### Changed
 
 - Correct options type for `createFullNode` & `createPrivacy` to enable passing gossipsub options.
@@ -489,7 +491,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://js-waku.wakuconnect.dev/).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/status-im/js-waku/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/status-im/js-waku/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/status-im/js-waku/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/status-im/js-waku/compare/v0.24.0...v0.25.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",


### PR DESCRIPTION
### Changed

- Correct options type for `createFullNode` & `createPrivacy` to enable passing gossipsub options.
- `WakuStore` now provides several APIs: `queryGenerator`, `queryCallbackOnPromise`, `queryOrderedCallback`;
  each provides different guarantees and performance.