### PR TITLE
fix: `queryOrderedCallback` not stopping when callback returns true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Incorrect cursor encoding in Store queries.
+- `WakuStore.queryOrderedCallback` not stopping when callback returns true.
 
 ### Removed
 

--- a/src/lib/waku_store/index.ts
+++ b/src/lib/waku_store/index.ts
@@ -112,7 +112,7 @@ export class WakuStore {
     callback: (message: T) => Promise<void | boolean> | boolean | void,
     options?: QueryOptions
   ): Promise<void> {
-    const abort = false;
+    let abort = false;
     for await (const promises of this.queryGenerator(decoders, options)) {
       if (abort) break;
       const messagesOrUndef: Array<T | undefined> = await Promise.all(promises);
@@ -129,9 +129,9 @@ export class WakuStore {
       }
 
       await Promise.all(
-        messages.map((msg) => {
-          if (!abort) {
-            if (msg) return callback(msg);
+        messages.map(async (msg) => {
+          if (msg && !abort) {
+            abort = Boolean(await callback(msg));
           }
         })
       );


### PR DESCRIPTION
Fixes #978.