### PR TITLE
Release 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2022-10-28
+
 ### Added
 
 - `RateLimitProof` field in Waku Message protobuf for RLN.
@@ -533,7 +535,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://js-waku.wakuconnect.dev/).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.30.0...HEAD
+[0.30.0]: https://github.com/status-im/js-waku/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/status-im/js-waku/compare/v0.28.0...v0.29.0
 [0.28.1]: https://github.com/status-im/js-waku/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/status-im/js-waku/compare/v0.27.0...v0.28.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",


### PR DESCRIPTION
### Added

- `RateLimitProof` field in Waku Message protobuf for RLN.

### Changed

- `Message` interface changed to ensure implementations do not omit fields.
- `Decoder` and `Encoder` interfaces change to better express what the function members do.

### Fixed

- Incorrect cursor encoding in Store queries.
- `WakuStore.queryOrderedCallback` not stopping when callback returns true.

### Removed

- Support for Waku Store 2.0.0-beta3.