### PR TITLE
fix(core,create): dependencies mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22500,7 +22500,6 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^4.1.1",
-        "@chainsafe/libp2p-noise": "^8.0.1",
         "@libp2p/interface-connection": "3.0.1",
         "@libp2p/interface-peer-discovery": "^1.0.0",
         "@libp2p/interface-peer-id": "^1.0.2",
@@ -22508,9 +22507,7 @@
         "@libp2p/interface-peer-store": "^1.0.0",
         "@libp2p/interface-pubsub": "^2.0.1",
         "@libp2p/interfaces": "^3.0.2",
-        "@libp2p/mplex": "^5.1.1",
         "@libp2p/peer-id": "^1.1.10",
-        "@libp2p/websockets": "^3.0.3",
         "@multiformats/multiaddr": "^11.0.6",
         "@waku/byte-utils": "*",
         "@waku/interfaces": "*",
@@ -22618,6 +22615,10 @@
       "version": "0.0.2",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
+        "@chainsafe/libp2p-noise": "^8.0.1",
+        "@libp2p/interface-peer-discovery": "^1.0.0",
+        "@libp2p/mplex": "^5.1.1",
+        "@libp2p/websockets": "^3.0.3",
         "@waku/core": "*",
         "@waku/interfaces": "*"
       },
@@ -27338,7 +27339,6 @@
       "version": "file:packages/core",
       "requires": {
         "@chainsafe/libp2p-gossipsub": "^4.1.1",
-        "@chainsafe/libp2p-noise": "^8.0.1",
         "@libp2p/interface-connection": "3.0.1",
         "@libp2p/interface-peer-discovery": "^1.0.0",
         "@libp2p/interface-peer-id": "^1.0.2",
@@ -27346,9 +27346,7 @@
         "@libp2p/interface-peer-store": "^1.0.0",
         "@libp2p/interface-pubsub": "^2.0.1",
         "@libp2p/interfaces": "^3.0.2",
-        "@libp2p/mplex": "^5.1.1",
         "@libp2p/peer-id": "^1.1.10",
-        "@libp2p/websockets": "^3.0.3",
         "@multiformats/multiaddr": "^11.0.6",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-json": "^4.1.0",
@@ -27439,6 +27437,10 @@
     "@waku/create": {
       "version": "file:packages/create",
       "requires": {
+        "@chainsafe/libp2p-noise": "^8.0.1",
+        "@libp2p/interface-peer-discovery": "^1.0.0",
+        "@libp2p/mplex": "^5.1.1",
+        "@libp2p/websockets": "^3.0.3",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,6 @@
   "dependencies": {
     "@waku/byte-utils": "*",
     "@chainsafe/libp2p-gossipsub": "^4.1.1",
-    "@chainsafe/libp2p-noise": "^8.0.1",
     "@libp2p/interface-connection": "3.0.1",
     "@libp2p/interface-peer-discovery": "^1.0.0",
     "@libp2p/interface-peer-id": "^1.0.2",
@@ -96,9 +95,7 @@
     "@libp2p/interface-peer-store": "^1.0.0",
     "@libp2p/interface-pubsub": "^2.0.1",
     "@libp2p/interfaces": "^3.0.2",
-    "@libp2p/mplex": "^5.1.1",
     "@libp2p/peer-id": "^1.1.10",
-    "@libp2p/websockets": "^3.0.3",
     "@multiformats/multiaddr": "^11.0.6",
     "@waku/interfaces": "*",
     "debug": "^4.3.4",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -51,7 +51,11 @@
   },
   "dependencies": {
     "@waku/core": "*",
-    "@waku/interfaces": "*"
+    "@waku/interfaces": "*",
+    "@chainsafe/libp2p-noise": "^8.0.1",
+    "@libp2p/interface-peer-discovery": "^1.0.0",
+    "@libp2p/mplex": "^5.1.1",
+    "@libp2p/websockets": "^3.0.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",


### PR DESCRIPTION
Some `create` dependencies were still in the `core` package.json file.