### PR TITLE
feat: add `@multiformats/multiaddr` as peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21913,6 +21913,14 @@
       },
       "engines": {
         "node": ">=16"
+      },
+      "peerDependencies": {
+        "@multiformats/multiaddr": "^11.0.6"
+      },
+      "peerDependenciesMeta": {
+        "@multiformats/multiaddr": {
+          "optional": true
+        }
       }
     },
     "packages/core/node_modules/uuid": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `@multiformats/multiaddr` as peer dependency.
+
 ## @waku/core [0.0.6](https://github.com/waku-org/js-waku/compare/@waku/core@0.0.5...@waku/core@0.0.6) (2022-11-18)
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -153,6 +153,14 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.6.3"
   },
+  "peerDependencies": {
+    "@multiformats/multiaddr": "^11.0.6"
+  },
+  "peerDependenciesMeta": {
+    "@multiformats/multiaddr": {
+      "optional": true
+    }
+  },
   "typedoc": {
     "entryPoint": "./src/index.ts"
   },


### PR DESCRIPTION
This dep often has breakings changes on type and is used by several APIs. Declaring as an optional peer dependency will hopefully help the user know what version to install.