### PR TITLE
feat: improve the cursor API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           node-version: ${{ env.NODE_JS }}
       - uses: bahmutov/npm-install@v1
       - run: npm run build
-      - run: npm run test:node > debug.log
+      - run: npm run test:node
         env:
           DEBUG: "waku:nwaku*,waku:test*"
 
@@ -131,7 +131,7 @@ jobs:
 
       - uses: bahmutov/npm-install@v1
       - run: npm run build
-      - run: npm run test:node > debug.log
+      - run: npm run test:node
         env:
           DEBUG: "waku:nwaku*,waku:test*"
 
@@ -185,7 +185,7 @@ jobs:
           ./build/wakunode2 --help
 
       - run: npm run build
-      - run: npm run test:node > debug.log
+      - run: npm run test:node
         env:
           DEBUG: "waku:nwaku*,waku:test*"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - run: npm run build
       - run: npm run test:node
         env:
-          DEBUG: "waku:nwaku*,waku:test*"
+          DEBUG: ""
 
       - name: Upload debug logs on failure
         uses: actions/upload-artifact@v3

--- a/packages/core/src/lib/waku_store/index.ts
+++ b/packages/core/src/lib/waku_store/index.ts
@@ -309,9 +309,8 @@ async function* paginate<T extends DecodedMessage>(
   }
 
   let currentCursor = cursor;
-
   while (true) {
-    queryOpts = Object.assign(queryOpts, { currentCursor });
+    queryOpts.cursor = currentCursor;
 
     const stream = await connection.newStream(protocol);
     const historyRpcQuery = HistoryRPC.createQuery(queryOpts);

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -60,6 +60,12 @@ export interface TimeFilter {
   endTime: Date;
 }
 
+export type Cursor = {
+  digest?: Uint8Array;
+  senderTime?: bigint;
+  pubsubTopic?: string;
+};
+
 export type StoreQueryOptions = {
   /**
    * The direction in which pages are retrieved:
@@ -83,7 +89,7 @@ export type StoreQueryOptions = {
   /**
    * Cursor as an index to start a query from.
    */
-  cursor?: Index;
+  cursor?: Cursor;
 } & ProtocolOptions;
 
 export interface Store extends PointToPointProtocol {


### PR DESCRIPTION
## Problem

Addresses a few (non-blocking/breaking) comments/changes requested on the initial PR introducing cursor support for the store protocol.

## Solution

- improves doc for the cursor usage
- increases code readability for the usage of `cursor` in `paginate()`
- better/remove redundant usage of types

## Notes

- A followup to https://github.com/waku-org/js-waku/pull/1024