### PR TITLE
refactor: use the ENR type for PeerExchangeResponse

### DIFF
--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -4,6 +4,7 @@ import type { PeerId } from "@libp2p/interface-peer-id";
 import type { Peer } from "@libp2p/interface-peer-store";
 import type { PeerStore } from "@libp2p/interface-peer-store";
 import type { Multiaddr } from "@multiformats/multiaddr";
+import type { ENR } from "@waku/enr";
 import type { Libp2p } from "libp2p";
 
 export enum Protocols {
@@ -64,7 +65,7 @@ export interface PeerExchangeResponse {
 }
 
 export interface PeerInfo {
-  ENR?: Uint8Array;
+  ENR?: ENR;
 }
 
 export enum PageDirection {


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->
The `PeerExchangeRPC` query returns us a List<ENR> which is of type List<`Uint8Array`> which should be converted to the interface implemented `ENR` for consistency

## Solution

Using the already implemented `ENR` class to convert the `Uint8Array` to `ENR`

## Notes

<!-- Remove items that are not relevant -->

- ~~Blocked by the parent PR: https://github.com/waku-org/js-waku/pull/1027~~