### PR TITLE
peer-exchange: bind a response handler

### DIFF
--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -4,6 +4,7 @@ import type { ConnectionManager } from "@libp2p/interface-connection-manager";
 import type { PeerId } from "@libp2p/interface-peer-id";
 import type { Peer } from "@libp2p/interface-peer-store";
 import type { PeerStore } from "@libp2p/interface-peer-store";
+import type { Registrar } from "@libp2p/interface-registrar";
 import type { Multiaddr } from "@multiformats/multiaddr";
 import type { ENR } from "@waku/enr";
 import type { Libp2p } from "libp2p";
@@ -82,6 +83,7 @@ export interface TimeFilter {
 export interface PeerExchangeComponents {
   connectionManager: ConnectionManager;
   peerStore: PeerStore;
+  registrar: Registrar;
 }
 
 export type StoreQueryOptions = {

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -55,7 +55,7 @@ export interface LightPush extends PointToPointProtocol {
 }
 
 export interface PeerExchange extends PointToPointProtocol {
-  query(params: PeerExchangeQueryParams): Promise<PeerExchangeResponse>;
+  query(params: PeerExchangeQueryParams): Promise<void>;
 }
 
 export interface PeerExchangeQueryParams {

--- a/packages/peer-exchange/src/rpc.ts
+++ b/packages/peer-exchange/src/rpc.ts
@@ -22,6 +22,7 @@ export class PeerExchangeRPC {
    * @returns Uint8Array
    */
   encode(): Uint8Array {
+    console.log("encoding now", this.proto);
     return proto.PeerExchangeRPC.encode(this.proto);
   }
 
@@ -31,6 +32,7 @@ export class PeerExchangeRPC {
    */
   static decode(bytes: Uint8ArrayList): PeerExchangeRPC {
     const res = proto.PeerExchangeRPC.decode(bytes);
+    console.log("decoded-res", res);
     return new PeerExchangeRPC(res);
   }
 

--- a/packages/tests/tests/peer_exchange.node.spec.ts
+++ b/packages/tests/tests/peer_exchange.node.spec.ts
@@ -74,7 +74,7 @@ describe("Peer Exchange: Node", () => {
 
     try {
       const queryResponse = await waku.peerExchange.query({
-        numPeers: BigInt(1),
+        numPeers: 1n,
       });
       console.log({ queryResponse });
     } catch (error) {

--- a/packages/tests/tests/peer_exchange.node.spec.ts
+++ b/packages/tests/tests/peer_exchange.node.spec.ts
@@ -19,8 +19,8 @@ describe("Peer Exchange: Node", () => {
     !!waku && waku.stop().catch((e) => console.log("Waku failed to stop", e));
   });
 
-  it("Queries successfully", async function () {
-    this.timeout(15_000);
+  it.only("Queries successfully", async function () {
+    this.timeout(150_000);
 
     console.log("starting");
     nwaku1 = new Nwaku(makeLogFileName(this));

--- a/packages/tests/tests/peer_exchange.node.spec.ts
+++ b/packages/tests/tests/peer_exchange.node.spec.ts
@@ -1,21 +1,21 @@
 import { waitForRemotePeer } from "@waku/core/lib/wait_for_remote_peer";
-import { createLightNode } from "@waku/create";
-import type { WakuLight } from "@waku/interfaces";
+import { createFullNode } from "@waku/create";
+import type { WakuFull } from "@waku/interfaces";
 import { Protocols } from "@waku/interfaces";
 
-import { makeLogFileName, Nwaku } from "../src";
+import { NOISE_KEY_1, Nwaku } from "../src";
 import { delay } from "../src/delay";
 
 describe("Peer Exchange: Node", () => {
-  let waku: WakuLight;
+  let waku: WakuFull;
   let nwaku1: Nwaku;
   let nwaku2: Nwaku;
   let nwaku3: Nwaku;
-
   afterEach(async function () {
     !!nwaku1 && nwaku1.stop();
     !!nwaku2 && nwaku2.stop();
     !!nwaku3 && nwaku3.stop();
+
     !!waku && waku.stop().catch((e) => console.log("Waku failed to stop", e));
   });
 
@@ -23,41 +23,46 @@ describe("Peer Exchange: Node", () => {
     this.timeout(150_000);
 
     console.log("starting");
-    nwaku1 = new Nwaku(makeLogFileName(this));
-    nwaku2 = new Nwaku(makeLogFileName(this));
-    nwaku3 = new Nwaku(makeLogFileName(this));
-
-    await nwaku2.start({ discv5Discovery: true, peerExchange: true });
-    console.log("nwaku2 started");
-
-    const enr = (await nwaku2.info()).enrUri;
-    console.log({ enr });
+    nwaku1 = new Nwaku("node1");
+    nwaku2 = new Nwaku("node2");
+    nwaku3 = new Nwaku("node3");
 
     await nwaku1.start({
       discv5Discovery: true,
-      manualArgs: [
-        `--discv5-bootstrap-node:${(await nwaku2.info()).enrUri}`,
-        `--ports-shift=5`,
-      ],
+      peerExchange: true,
+      manualArgs: [`--discv5-udp-port:9007`],
     });
     console.log("nwaku1 started");
 
+    const enr = (await nwaku1.info()).enrUri;
+    console.log({ enr });
+
+    await nwaku2.start({
+      discv5Discovery: true,
+      manualArgs: [`--discv5-bootstrap-node:${enr}`, `--discv5-udp-port:9043`],
+    });
+    console.log("nwaku2 started");
+
     await nwaku3.start({
       discv5Discovery: true,
-      manualArgs: [
-        `--discv5-bootstrap-node:${(await nwaku2.info()).enrUri}`,
-        `--ports-shift=10`,
-      ],
+      manualArgs: [`--discv5-bootstrap-node:${enr}`, `--discv5-udp-port:9062`],
+    });
+    console.log("nwaku3 started");
+
+    await delay(40000);
+
+    waku = await createFullNode({
+      staticNoiseKey: NOISE_KEY_1,
+      libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } },
     });
 
-    waku = await createLightNode();
     console.log("created light node");
     await waku.start();
     console.log("started light node");
 
     await delay(1000);
 
-    const mulltiaddr = await nwaku2.getMultiaddrWithId();
+    const mulltiaddr = await nwaku1.getMultiaddrWithId();
 
     await waku.dial(mulltiaddr, [Protocols.PeerExchange]);
     console.log("dialed");


### PR DESCRIPTION
## Problem

Issue: https://github.com/waku-org/nwaku/issues/1408#issuecomment-1326708100

## Solution

As a follow-up to the above-mentioned issue, it was realized that the current nwaku peer-exchange implementation requires setting up a callback response handler which was implemented in the scope of this PR as a solution.

## Notes

- ~~Still blocked by the parent issue. Reference: https://github.com/waku-org/nwaku/issues/1408#issuecomment-1327325084~~

