### PR TITLE
chore: make no-console an error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
       "error",
       { "ignoreDeclarationSort": true, "ignoreCase": true }
     ],
-    "no-console": "warn"
+    "no-console": "error"
   },
   "overrides": [
     {


### PR DESCRIPTION
We use `debug` across the codebase, this ensures no `console.log` slips in by mistake.