### PR TITLE
package.json: set type to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@waku/root",
   "private": true,
+  "type": "module",
   "workspaces": [
     "packages/byte-utils",
     "packages/interfaces",


### PR DESCRIPTION
Fixes errors like:
```
SyntaxError: Cannot use import statement outside a module
```
https://ci.infra.status.im/job/website/job/js.waku.org/4/