### PR TITLE
chore: move codecs to @waku/interfaces as an enum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5342,9 +5342,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
-      "integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
+      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -22002,9 +22002,9 @@
       }
     },
     "engine.io": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
-      "integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
+      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.1",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,11 +17,7 @@ export * as waku_filter from "./lib/waku_filter/index.js";
 export { wakuFilter } from "./lib/waku_filter/index.js";
 
 export * as waku_light_push from "./lib/waku_light_push/index.js";
-export {
-  wakuLightPush,
-  LightPushCodec,
-  PushResponse,
-} from "./lib/waku_light_push/index.js";
+export { wakuLightPush, PushResponse } from "./lib/waku_light_push/index.js";
 
 export * as waku_relay from "./lib/waku_relay/index.js";
 export { wakuRelay } from "./lib/waku_relay/index.js";
@@ -30,7 +26,6 @@ export * as waku_store from "./lib/waku_store/index.js";
 export {
   PageDirection,
   wakuStore,
-  StoreCodec,
   createCursor,
 } from "./lib/waku_store/index.js";
 

--- a/packages/core/src/lib/wait_for_remote_peer.ts
+++ b/packages/core/src/lib/wait_for_remote_peer.ts
@@ -1,12 +1,8 @@
 import { PeerProtocolsChangeData } from "@libp2p/interface-peer-store";
-import type { PointToPointProtocol, Relay, Waku } from "@waku/interfaces";
+import { ECodecs, PointToPointProtocol, Relay, Waku } from "@waku/interfaces";
 import { Protocols } from "@waku/interfaces";
 import debug from "debug";
 import { pEvent } from "p-event";
-
-import { FilterCodec } from "./waku_filter/index.js";
-import { LightPushCodec } from "./waku_light_push/index.js";
-import { StoreCodec } from "./waku_store/index.js";
 
 const log = debug("waku:wait-for-remote-peer");
 
@@ -49,19 +45,19 @@ export async function waitForRemotePeer(
   if (protocols.includes(Protocols.Store)) {
     if (!waku.store)
       throw new Error("Cannot wait for Store peer: protocol not mounted");
-    promises.push(waitForConnectedPeer(waku.store, [StoreCodec]));
+    promises.push(waitForConnectedPeer(waku.store, [ECodecs.Store]));
   }
 
   if (protocols.includes(Protocols.LightPush)) {
     if (!waku.lightPush)
       throw new Error("Cannot wait for LightPush peer: protocol not mounted");
-    promises.push(waitForConnectedPeer(waku.lightPush, [LightPushCodec]));
+    promises.push(waitForConnectedPeer(waku.lightPush, [ECodecs.LightPush]));
   }
 
   if (protocols.includes(Protocols.Filter)) {
     if (!waku.filter)
       throw new Error("Cannot wait for Filter peer: protocol not mounted");
-    promises.push(waitForConnectedPeer(waku.filter, [FilterCodec]));
+    promises.push(waitForConnectedPeer(waku.filter, [ECodecs.Filter]));
   }
 
   if (timeoutMs) {

--- a/packages/core/src/lib/waku.ts
+++ b/packages/core/src/lib/waku.ts
@@ -2,20 +2,24 @@ import type { Stream } from "@libp2p/interface-connection";
 import type { PeerId } from "@libp2p/interface-peer-id";
 import type { PubSub } from "@libp2p/interface-pubsub";
 import type { Multiaddr } from "@multiformats/multiaddr";
-import type { Filter, LightPush, Relay, Store, Waku } from "@waku/interfaces";
+import {
+  ECodecs,
+  Filter,
+  LightPush,
+  Relay,
+  Store,
+  Waku,
+} from "@waku/interfaces";
 import { Protocols } from "@waku/interfaces";
 import debug from "debug";
 import type { Libp2p } from "libp2p";
 
-import { FilterCodec, FilterComponents } from "./waku_filter/index.js";
-import {
-  LightPushCodec,
-  LightPushComponents,
-} from "./waku_light_push/index.js";
+import { FilterComponents } from "./waku_filter/index.js";
+import { LightPushComponents } from "./waku_light_push/index.js";
 import { createEncoder } from "./waku_message/version_0.js";
 import * as relayConstants from "./waku_relay/constants.js";
 import { RelayCodecs, RelayPingContentTopic } from "./waku_relay/constants.js";
-import { StoreCodec, StoreComponents } from "./waku_store/index.js";
+import { StoreComponents } from "./waku_store/index.js";
 
 export const DefaultPingKeepAliveValueSecs = 0;
 export const DefaultRelayKeepAliveValueSecs = 5 * 60;
@@ -154,13 +158,13 @@ export class WakuNode implements Waku {
       RelayCodecs.forEach((codec) => codecs.push(codec));
     }
     if (_protocols.includes(Protocols.Store)) {
-      codecs.push(StoreCodec);
+      codecs.push(ECodecs.Store);
     }
     if (_protocols.includes(Protocols.LightPush)) {
-      codecs.push(LightPushCodec);
+      codecs.push(ECodecs.LightPush);
     }
     if (_protocols.includes(Protocols.Filter)) {
-      codecs.push(FilterCodec);
+      codecs.push(ECodecs.Filter);
     }
 
     return this.libp2p.dialProtocol(peer, codecs);

--- a/packages/core/src/lib/waku_filter/index.ts
+++ b/packages/core/src/lib/waku_filter/index.ts
@@ -5,10 +5,11 @@ import type { PeerStore } from "@libp2p/interface-peer-store";
 import type { Peer } from "@libp2p/interface-peer-store";
 import type { IncomingStreamData } from "@libp2p/interface-registrar";
 import type { Registrar } from "@libp2p/interface-registrar";
-import type {
+import {
   Callback,
   DecodedMessage,
   Decoder,
+  ECodecs,
   Filter,
   Message,
   ProtocolOptions,
@@ -32,8 +33,6 @@ import { toProtoMessage } from "../to_proto_message.js";
 import { ContentFilter, FilterRPC } from "./filter_rpc.js";
 
 export { ContentFilter };
-
-export const FilterCodec = "/vac/waku/filter/2.0.0-beta1";
 
 const log = debug("waku:filter");
 
@@ -77,7 +76,7 @@ class WakuFilter implements Filter {
     this.decoders = new Map();
     this.pubSubTopic = options?.pubSubTopic ?? DefaultPubSubTopic;
     this.components.registrar
-      .handle(FilterCodec, this.onRequest.bind(this))
+      .handle(ECodecs.Filter, this.onRequest.bind(this))
       .catch((e) => log("Failed to register filter protocol", e));
   }
 
@@ -282,23 +281,23 @@ class WakuFilter implements Filter {
       throw new Error("Failed to get a connection to the peer");
     }
 
-    return connection.newStream(FilterCodec);
+    return connection.newStream(ECodecs.Filter);
   }
 
   private async getPeer(peerId?: PeerId): Promise<Peer> {
     const res = await selectPeerForProtocol(
       this.components.peerStore,
-      [FilterCodec],
+      [ECodecs.Filter],
       peerId
     );
     if (!res) {
-      throw new Error(`Failed to select peer for ${FilterCodec}`);
+      throw new Error(`Failed to select peer for ${ECodecs.Filter}`);
     }
     return res.peer;
   }
 
   async peers(): Promise<Peer[]> {
-    return getPeersForProtocol(this.components.peerStore, [FilterCodec]);
+    return getPeersForProtocol(this.components.peerStore, [ECodecs.Filter]);
   }
 
   async randomPeer(): Promise<Peer | undefined> {

--- a/packages/core/src/lib/waku_light_push/index.ts
+++ b/packages/core/src/lib/waku_light_push/index.ts
@@ -2,7 +2,8 @@ import { ConnectionManager } from "@libp2p/interface-connection-manager";
 import type { PeerId } from "@libp2p/interface-peer-id";
 import type { Peer } from "@libp2p/interface-peer-store";
 import type { PeerStore } from "@libp2p/interface-peer-store";
-import type {
+import {
+  ECodecs,
   Encoder,
   LightPush,
   Message,
@@ -28,7 +29,6 @@ import { PushRPC } from "./push_rpc.js";
 
 const log = debug("waku:light-push");
 
-export const LightPushCodec = "/vac/waku/lightpush/2.0.0-beta1";
 export { PushResponse };
 
 export interface LightPushComponents {
@@ -67,7 +67,7 @@ class WakuLightPush implements LightPush {
 
     const res = await selectPeerForProtocol(
       this.components.peerStore,
-      [LightPushCodec],
+      [ECodecs.LightPush],
       opts?.peerId
     );
 
@@ -83,7 +83,7 @@ class WakuLightPush implements LightPush {
 
     if (!connection) throw "Failed to get a connection to the peer";
 
-    const stream = await connection.newStream(LightPushCodec);
+    const stream = await connection.newStream(ECodecs.LightPush);
 
     const recipients: PeerId[] = [];
 
@@ -132,7 +132,7 @@ class WakuLightPush implements LightPush {
    * peers.
    */
   async peers(): Promise<Peer[]> {
-    return getPeersForProtocol(this.components.peerStore, [LightPushCodec]);
+    return getPeersForProtocol(this.components.peerStore, [ECodecs.LightPush]);
   }
 
   /**

--- a/packages/core/src/lib/waku_store/index.ts
+++ b/packages/core/src/lib/waku_store/index.ts
@@ -8,6 +8,7 @@ import {
   Cursor,
   DecodedMessage,
   Decoder,
+  ECodecs,
   Index,
   Store,
 } from "@waku/interfaces";
@@ -28,8 +29,6 @@ import { HistoryRPC, PageDirection, Params } from "./history_rpc.js";
 import HistoryError = proto.HistoryResponse.HistoryError;
 
 const log = debug("waku:store");
-
-export const StoreCodec = "/vac/waku/store/2.0.0-beta4";
 
 export const DefaultPageSize = 10;
 
@@ -252,7 +251,7 @@ class WakuStore implements Store {
 
     const res = await selectPeerForProtocol(
       this.components.peerStore,
-      [StoreCodec],
+      [ECodecs.Store],
       options?.peerId
     );
 
@@ -284,7 +283,7 @@ class WakuStore implements Store {
    * store protocol. Waku may or  may not be currently connected to these peers.
    */
   async peers(): Promise<Peer[]> {
-    return getPeersForProtocol(this.components.peerStore, [StoreCodec]);
+    return getPeersForProtocol(this.components.peerStore, [ECodecs.Store]);
   }
 
   get peerStore(): PeerStore {

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -13,6 +13,14 @@ export enum Protocols {
   Filter = "filter",
 }
 
+export enum ECodecs {
+  PeerExchange = "/vac/waku/peer-exchange/2.0.0-alpha1",
+  Relay = "/vac/waku/relay/2.0.0",
+  Store = "/vac/waku/store/2.0.0-beta4",
+  LightPush = "/vac/waku/lightpush/2.0.0-beta1",
+  Filter = "/vac/waku/filter/2.0.0-beta1",
+}
+
 export interface PointToPointProtocol {
   peerStore: PeerStore;
   peers: () => Promise<Peer[]>;


### PR DESCRIPTION
## Problem

As we are moving `PeerExchange` into a separate package, importing from and to PeerExchange (specifically for the codec) is creating a circular dependency.

## Solution

This change moves all the codecs into interfaces, within an enum

## Notes

- Related to/unblocks https://github.com/waku-org/js-waku/pull/1027
- Currently does not move the Relay codecs
   - There are currently two codecs defined -- unsure why.
   - Can we deprecate the one with `beta` and use the one from the RFC (stable?)
