### PR TITLE
chore: upgrade to node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   NWAKU_VERSION: "v0.13.0"
-  NODE_JS: "16"
+  NODE_JS: "18"
 
 jobs:
   check:

--- a/packages/tests/src/nwaku.ts
+++ b/packages/tests/src/nwaku.ts
@@ -395,7 +395,7 @@ export class Nwaku {
   }
 
   get rpcUrl(): string {
-    return `http://localhost:${this.rpcPort}/`;
+    return `http://127.0.0.1:${this.rpcPort}/`;
   }
 
   private async rpcCall<T>(


### PR DESCRIPTION
## Problem

Node recently moved its LTS to 18, from 16 and we should run our CI on 18 as well.

## Solution

Part of change was using `127.0.0.1` instead of `localhost` while making the request:
There is a change in how Node does DNS resolution in Node 18 vs 16 -- `localhost` resolves to `::1`, which is the equivalent of `127.0.0.1` but in IPv6 instead of IPv4. The server however is only listening on IPv4.

Reference:
https://github.com/nodejs/node/issues/40702#issuecomment-958143154

## Notes

<!-- Remove items that are not relevant -->

- Resolves https://github.com/waku-org/js-waku/issues/1023
