### PR TITLE
chore: deprecate `Cursor` as a separate interface and use `Index`

### DIFF
--- a/packages/core/src/lib/waku_store/index.ts
+++ b/packages/core/src/lib/waku_store/index.ts
@@ -4,13 +4,7 @@ import type { PeerId } from "@libp2p/interface-peer-id";
 import type { Peer, PeerStore } from "@libp2p/interface-peer-store";
 import { sha256 } from "@noble/hashes/sha256";
 import { concat, utf8ToBytes } from "@waku/byte-utils";
-import {
-  Cursor,
-  DecodedMessage,
-  Decoder,
-  Index,
-  Store,
-} from "@waku/interfaces";
+import { DecodedMessage, Decoder, Index, Store } from "@waku/interfaces";
 import {
   getPeersForProtocol,
   selectConnection,
@@ -96,7 +90,7 @@ export interface QueryOptions {
    * The cursor index will be exclusive (i.e. the message at the cursor index will not be included in the result).
    * If undefined, the query will start from the beginning or end of the history, depending on the page direction.
    */
-  cursor?: Cursor;
+  cursor?: Index;
 }
 
 /**
@@ -300,7 +294,7 @@ async function* paginate<T extends DecodedMessage>(
   protocol: string,
   queryOpts: Params,
   decoders: Map<string, Decoder<T>>,
-  cursor?: Cursor
+  cursor?: Index
 ): AsyncGenerator<Promise<T | undefined>[]> {
   if (
     queryOpts.contentTopics.toString() !==

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -88,11 +88,6 @@ export interface PeerExchangeComponents {
   peerStore: PeerStore;
   registrar: Registrar;
 }
-export type Cursor = {
-  digest?: Uint8Array;
-  senderTime?: bigint;
-  pubsubTopic?: string;
-};
 
 export type StoreQueryOptions = {
   /**
@@ -117,7 +112,7 @@ export type StoreQueryOptions = {
   /**
    * Cursor as an index to start a query from.
    */
-  cursor?: Cursor;
+  cursor?: Index;
 } & ProtocolOptions;
 
 export interface Store extends PointToPointProtocol {


### PR DESCRIPTION
`proto.Index`

## Problem

The interface `Cursor` was introduced as the need for `senderTime` was not required from the `cursor` properties. But, since there is a majority overlap between the types for both, and `senderTime` is an optional param, it can be deprecated.

## Solution

Remove `Cursor` as an interface, and use `Index`

## Notes