### PR TITLE
feat!: remove peer exchange from protocols to wait on by default

### DIFF
--- a/packages/core/src/lib/wait_for_remote_peer.ts
+++ b/packages/core/src/lib/wait_for_remote_peer.ts
@@ -155,9 +155,6 @@ function getEnabledProtocols(waku: Waku): Protocols[] {
   if (waku.lightPush) {
     protocols.push(Protocols.LightPush);
   }
-  if (waku.peerExchange) {
-    protocols.push(Protocols.PeerExchange);
-  }
 
   return protocols;
 }


### PR DESCRIPTION
This is because peer exchange is still experimental and not enabled on all prod fleets.

The issue is that we could be connected to a remote peer with relay/ filter/lightpush yet never resolve because peer exchange is missing.

This also shows the limit of this function logic which should be addressed as we dive deeper in peer management.