### PR TITLE
temp/draft: debugging dns-discovery

### DIFF
--- a/packages/dns-discovery/src/enrtree.ts
+++ b/packages/dns-discovery/src/enrtree.ts
@@ -39,11 +39,14 @@ export class ENRTree {
     // of the record content, excluding the `sig=` part, encoded as URL-safe base64 string
     // (Trailing recovery bit must be trimmed to pass `ecdsaVerify` method)
     const signedComponent = root.split(" sig")[0];
+
     const signedComponentBuffer = utf8ToBytes(signedComponent);
     const signatureBuffer = fromString(rootValues.signature, "base64url").slice(
       0,
       64
     );
+
+    return rootValues.eRoot;
 
     const isVerified = verifySignature(
       signatureBuffer,
@@ -52,8 +55,6 @@ export class ENRTree {
     );
 
     if (!isVerified) throw new Error("Unable to verify ENRTree root signature");
-
-    return rootValues.eRoot;
   }
 
   static parseRootValues(txt: string): ENRRootValues {

--- a/packages/dns-discovery/src/index.ts
+++ b/packages/dns-discovery/src/index.ts
@@ -81,3 +81,12 @@ export class PeerDiscoveryDns
     return "@waku/bootstrap";
   }
 }
+
+export function wakuDnsDiscovery(
+  enrUrl: string,
+  wantedNodeCapabilityCount: Partial<NodeCapabilityCount>
+): () => PeerDiscoveryDns {
+  return () => new PeerDiscoveryDns(enrUrl, wantedNodeCapabilityCount);
+}
+
+export { DnsNodeDiscovery } from "./dns.js";

--- a/packages/tests/tests/dns-peer-discovery.spec.ts
+++ b/packages/tests/tests/dns-peer-discovery.spec.ts
@@ -1,0 +1,86 @@
+import { waitForRemotePeer } from "@waku/core";
+import { createLightNode } from "@waku/create";
+import { DnsNodeDiscovery, wakuDnsDiscovery } from "@waku/dns-discovery";
+import { Protocols } from "@waku/interfaces";
+import { expect } from "chai";
+
+describe("DNS Node Discovery [live data]", function () {
+  const publicKey = "AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C";
+  const fqdn = "test.waku.nodes.status.im";
+  const enrTree = `enrtree://${publicKey}@${fqdn}`;
+
+  before(function () {
+    if (process.env.CI) {
+      this.skip();
+    }
+  });
+
+  it(`should use DNS peer discovery with light client`, async function () {
+    this.timeout(100000);
+    const nodeRequirements = {
+      filter: 1,
+      lightPush: 1,
+      store: 1,
+    };
+
+    const waku = await createLightNode({
+      libp2p: {
+        peerDiscovery: [wakuDnsDiscovery(enrTree, nodeRequirements)],
+      },
+    });
+
+    await waku.start();
+
+    while (true) {
+      console.log(waku.libp2p.getPeers());
+      await waitForRemotePeer(waku, [
+        Protocols.Filter,
+        Protocols.LightPush,
+        Protocols.Store,
+      ]);
+    }
+  });
+});
+
+describe.only("HELLOOO: DNS Node Discovery [live data]", function () {
+  const publicKey = "AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C";
+  const fqdn = "test.waku.nodes.status.im";
+  const enrTree = `enrtree://${publicKey}@${fqdn}`;
+  const maxQuantity = 3;
+
+  before(function () {
+    if (process.env.CI) {
+      this.skip();
+    }
+  });
+
+  it(`should retrieve ${maxQuantity} multiaddrs for test.waku.nodes.status.im`, async function () {
+    this.timeout(10000);
+    // Google's dns server address. Needs to be set explicitly to run in CI
+    const dnsNodeDiscovery = DnsNodeDiscovery.dnsOverHttp();
+
+    const peers = await dnsNodeDiscovery.getPeers([enrTree], {
+      relay: maxQuantity,
+      store: maxQuantity,
+      filter: maxQuantity,
+      lightPush: maxQuantity,
+    });
+
+    console.log(peers.length);
+
+    expect(peers.length).to.eq(maxQuantity);
+
+    console.log({ peer: peers[0] });
+
+    const multiaddrs = peers.map((peer) => peer.multiaddrs).flat();
+
+    console.log({ multiaddrs });
+
+    const seen: string[] = [];
+    for (const ma of multiaddrs) {
+      expect(ma).to.not.be.undefined;
+      expect(seen).to.not.include(ma!.toString());
+      seen.push(ma!.toString());
+    }
+  });
+});


### PR DESCRIPTION
This PR is meant to demonstrate that when a peer is received as a resolution on DNS discovery, it misses `multiaddr` while rest of the `ENR` object is hydrated.

To repro/see it real time:
1. `cd packages/tests`
2. `npm run test:node`