### PR TITLE
fix: export `Encoder` and `Decoder` types

### DIFF
--- a/packages/message-encryption/CHANGELOG.md
+++ b/packages/message-encryption/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Export `Encoder` and `Decoder` types.
+
 ## [0.0.7] - 2022-12-19
 
 ### Fixed

--- a/packages/message-encryption/src/ecies.ts
+++ b/packages/message-encryption/src/ecies.ts
@@ -27,7 +27,7 @@ export { DecodedMessage, generatePrivateKey, getPublicKey };
 
 const log = debug("waku:message-encryption:ecies");
 
-class Encoder implements IEncoder {
+export class Encoder implements IEncoder {
   constructor(
     public contentTopic: string,
     private publicKey: Uint8Array,
@@ -90,7 +90,7 @@ export function createEncoder(
   return new Encoder(contentTopic, publicKey, sigPrivKey, ephemeral);
 }
 
-class Decoder extends DecoderV0 implements IDecoder<DecodedMessage> {
+export class Decoder extends DecoderV0 implements IDecoder<DecodedMessage> {
   constructor(contentTopic: string, private privateKey: Uint8Array) {
     super(contentTopic);
   }

--- a/packages/message-encryption/src/symmetric.ts
+++ b/packages/message-encryption/src/symmetric.ts
@@ -26,7 +26,7 @@ export { DecodedMessage, generateSymmetricKey };
 
 const log = debug("waku:message-encryption:symmetric");
 
-class Encoder implements IEncoder {
+export class Encoder implements IEncoder {
   constructor(
     public contentTopic: string,
     private symKey: Uint8Array,
@@ -88,7 +88,7 @@ export function createEncoder(
   return new Encoder(contentTopic, symKey, sigPrivKey, ephemeral);
 }
 
-class Decoder extends DecoderV0 implements IDecoder<DecodedMessage> {
+export class Decoder extends DecoderV0 implements IDecoder<DecodedMessage> {
   constructor(contentTopic: string, private symKey: Uint8Array) {
     super(contentTopic);
   }


### PR DESCRIPTION
Enables API consumer to use the types.

Ref https://github.com/waku-org/js-waku-examples/pull/168#discussion_r1052761319