### PR TITLE
fix: add `ephemeral: true` to relay pings

### DIFF
--- a/packages/core/src/lib/waku.ts
+++ b/packages/core/src/lib/waku.ts
@@ -234,7 +234,7 @@ export class WakuNode implements Waku {
 
     const relay = this.relay;
     if (relay && relayPeriodSecs !== 0) {
-      const encoder = createEncoder(RelayPingContentTopic);
+      const encoder = createEncoder(RelayPingContentTopic, true);
       this.relayKeepAliveTimers[peerIdStr] = setInterval(() => {
         log("Sending Waku Relay ping message");
         relay


### PR DESCRIPTION
## Problem

ref: https://github.com/waku-org/js-waku/issues/949

## Solution

sets `ephemeral: true` for relay ping messages


