### PR TITLE
fix: make IProtoMessage and IDecodedMessage props optional

### DIFF
--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -13,12 +13,12 @@ export interface IRateLimitProof {
  * Field types matches the protobuf type over the wire
  */
 export interface IProtoMessage {
-  payload: Uint8Array | undefined;
-  contentTopic: string | undefined;
-  version: number | undefined;
-  timestamp: bigint | undefined;
-  rateLimitProof: IRateLimitProof | undefined;
-  ephemeral: boolean | undefined;
+  payload?: Uint8Array;
+  contentTopic?: string;
+  version?: number;
+  timestamp?: bigint;
+  rateLimitProof?: IRateLimitProof;
+  ephemeral?: boolean;
 }
 
 /**

--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -38,11 +38,11 @@ export interface IEncoder {
 }
 
 export interface IDecodedMessage {
-  payload: Uint8Array | undefined;
-  contentTopic: string | undefined;
-  timestamp: Date | undefined;
-  rateLimitProof: IRateLimitProof | undefined;
-  ephemeral: boolean | undefined;
+  payload?: Uint8Array;
+  contentTopic?: string;
+  timestamp?: Date;
+  rateLimitProof?: IRateLimitProof;
+  ephemeral?: boolean;
 }
 
 export interface IDecoder<T extends IDecodedMessage> {


### PR DESCRIPTION
## Problem
Because properties on these interfaces are defined with `| undefined` to make them optional as a consequence it forces consumer to explicitly set those properties to `undefined` instead of just ignoring them.

## Solution
Use `?:` type definition token. 


- Related to https://github.com/waku-org/js-noise/issues/19
