### PR TITLE
chore: re-enable nwaku master CIs jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,6 @@ jobs:
           path: packages/tests/log/
 
   node_with_nwaku_master:
-    if: false # Can be removed when nwaku in regular CI is bumped to v0.15.0
     runs-on: ubuntu-latest
     env:
       DEBUG: "waku*"


### PR DESCRIPTION
All issues have been resolved on nwaku master.
Note that 0.14.0 contains regressions and hence cannot be used for CI run.