### PR TITLE
chore: release bump patch only 

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,7 @@
   "plugins": ["node-workspace", "sentence-case"],
   "release-type": "node",
   "separate-pull-requests": false,
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "versioning": "always-bump-patch",
   "group-pull-request-title-pattern": "chore: release ${branch}",
   "packages": {
     "packages/utils": {},

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "plugins": ["node-workspace", "sentence-case"],
   "release-type": "node",
   "separate-pull-requests": false,
+  "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "group-pull-request-title-pattern": "chore: release ${branch}",
   "packages": {


### PR DESCRIPTION
Follow up to `release-please` config to bump only `patch`.

Solution is to use valid property which is not well documented - https://github.com/googleapis/release-please/commit/8a7bfc165755cec97cc9a3baa39ccd21e719644c#diff-545bcd69c10300cbce0642d6970d8ccbff666d1e2b70b048084d4c6ec8b1e3d7

Example of release PR: https://github.com/waku-org/js-waku/pull/1175
Previous PR to https://github.com/waku-org/js-waku/pull/1155
