### PR TITLE
chore: update note in CHANGELOG and add missing

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/dns-discovery/CHANGELOG.md
+++ b/packages/dns-discovery/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/dns-discovery/CHANGELOG.md
+++ b/packages/dns-discovery/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/enr/CHANGELOG.md
+++ b/packages/enr/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/enr/CHANGELOG.md
+++ b/packages/enr/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/message-encryption/CHANGELOG.md
+++ b/packages/message-encryption/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/message-encryption/CHANGELOG.md
+++ b/packages/message-encryption/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/packages/peer-exchange/CHANGELOG.md
+++ b/packages/peer-exchange/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this project will be documented in this file.
 
-The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/peer-exchange/CHANGELOG.md
+++ b/packages/peer-exchange/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/proto/CHANGELOG.md
+++ b/packages/proto/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this project will be documented in this file.
 
-The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/proto/CHANGELOG.md
+++ b/packages/proto/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All notable changes to this project will be documented in this file.
 
-The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventionalcommits](https://www.conventionalcommits.org) specification,
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
## What was done
Add missing CHANGELOG.md in some packages:
- peer-exchange
- proto
- utils

And update note in the existing CHANGELOG.md 

- Related to https://github.com/waku-org/js-waku/pull/1176
