### PR TITLE
fix(dns-discovery/peer-exchange): check if peer is already tagged

### DIFF
--- a/packages/dns-discovery/src/index.ts
+++ b/packages/dns-discovery/src/index.ts
@@ -96,6 +96,13 @@ export class PeerDiscoveryDns
       if (!this._started) return;
       const peerInfos = multiaddrsToPeerInfo(peer.getFullMultiaddrs());
       peerInfos.forEach(async (peerInfo) => {
+        if (
+          (await this._components.peerStore.getTags(peerInfo.id)).find(
+            ({ name }) => name === DEFAULT_BOOTSTRAP_TAG_NAME
+          )
+        )
+          return;
+
         await this._components.peerStore.tagPeer(
           peerInfo.id,
           DEFAULT_BOOTSTRAP_TAG_NAME,

--- a/packages/peer-exchange/src/waku_peer_exchange_discovery.ts
+++ b/packages/peer-exchange/src/waku_peer_exchange_discovery.ts
@@ -170,8 +170,6 @@ export class PeerExchangeDiscovery
 
           if (!peerId || !multiaddrs || multiaddrs.length === 0) continue;
 
-          if (await this.components.peerStore.has(peerId)) continue;
-
           if (
             (await this.components.peerStore.getTags(peerId)).find(
               ({ name }) => name === DEFAULT_PEER_EXCHANGE_TAG_NAME


### PR DESCRIPTION
If we `continue` when the peer is already known by the `peerStore` then the next step of checking the tags is useless (no tags if peer is not known).

There are two ways around it:
1. either do nothing if peer is already in peer store
2. OR, do nothing if peer is in peer store and is already tagged

I opted for the second approach to ensure all peers are tagged properly.