### PR TITLE
chore: update dependabot reviewers and number of max PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,10 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 2
     schedule:
       interval: "daily"
-    reviewers: ["fryorcraken"]
+    reviewers: ["fryorcraken","danisharora099","weboko"]
     versioning-strategy: increase
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
Dependabot is working well now that config was fixed for monorepo so we can increase the number of ongoing PRs for deps.