### PR TITLE
fix: add payload to relay ping messages to avoid poor relay peer scoring

### DIFF
--- a/packages/core/src/lib/keep_alive_manager.ts
+++ b/packages/core/src/lib/keep_alive_manager.ts
@@ -54,7 +54,7 @@ export class KeepAliveManager {
       const interval = setInterval(() => {
         log("Sending Waku Relay ping message");
         relay
-          .send(encoder, { payload: new Uint8Array() })
+          .send(encoder, { payload: new Uint8Array([1]) })
           .catch((e) => log("Failed to send relay ping", e));
       }, relayPeriodSecs * 1000);
       this.relayKeepAliveTimers.set(peerId, interval);


### PR DESCRIPTION
Note that this keep alive mechanism should probably be removed.