### PR TITLE
feat!: add `meta` field on Waku Message and provide setter and validation interfaces

### DIFF
--- a/packages/core/src/lib/message/topic_only_message.ts
+++ b/packages/core/src/lib/message/topic_only_message.ts
@@ -12,6 +12,7 @@ export class TopicOnlyMessage implements IDecodedMessage {
   public payload: Uint8Array = new Uint8Array();
   public rateLimitProof: undefined;
   public timestamp: undefined;
+  public meta: undefined;
   public ephemeral: undefined;
 
   constructor(
@@ -35,6 +36,7 @@ export class TopicOnlyDecoder implements IDecoder<TopicOnlyMessage> {
       payload: new Uint8Array(),
       rateLimitProof: undefined,
       timestamp: undefined,
+      meta: undefined,
       version: undefined,
       ephemeral: undefined,
     });

--- a/packages/core/src/lib/message/topic_only_message.ts
+++ b/packages/core/src/lib/message/topic_only_message.ts
@@ -23,6 +23,10 @@ export class TopicOnlyMessage implements IDecodedMessage {
   get contentTopic(): string {
     return this.proto.contentTopic;
   }
+
+  isMetaValid(): boolean {
+    return true;
+  }
 }
 
 export class TopicOnlyDecoder implements IDecoder<TopicOnlyMessage> {

--- a/packages/core/src/lib/message/version_0.spec.ts
+++ b/packages/core/src/lib/message/version_0.spec.ts
@@ -105,4 +105,104 @@ describe("Waku Message version 0", function () {
       )
     );
   });
+
+  it("isMetaValid returns true when no validator specified", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        async (pubSubTopic, contentTopic, payload) => {
+          const encoder = createEncoder({
+            contentTopic,
+          });
+          const bytes = await encoder.toWire({ payload });
+          const decoder = createDecoder(contentTopic);
+          const protoResult = await decoder.fromWireToProtoObj(bytes);
+          const result = (await decoder.fromProtoObj(
+            pubSubTopic,
+            protoResult!
+          )) as DecodedMessage;
+
+          expect(result.isMetaValid()).to.be.true;
+        }
+      )
+    );
+  });
+
+  it("isMetaValid returns false when validator specified returns false", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        async (pubSubTopic, contentTopic, payload) => {
+          const encoder = createEncoder({
+            contentTopic,
+          });
+          const decoder = createDecoder(contentTopic, () => false);
+
+          const bytes = await encoder.toWire({ payload });
+          const protoResult = await decoder.fromWireToProtoObj(bytes);
+          const result = (await decoder.fromProtoObj(
+            pubSubTopic,
+            protoResult!
+          )) as DecodedMessage;
+
+          expect(result.isMetaValid()).to.be.false;
+        }
+      )
+    );
+  });
+
+  it("isMetaValid returns true when matching meta setter", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        async (pubSubTopic, contentTopic, payload) => {
+          const metaSetter = (
+            msg: IProtoMessage & { meta: undefined }
+          ): Uint8Array => {
+            const buffer = new ArrayBuffer(4);
+            const view = new DataView(buffer);
+            view.setUint32(0, msg.payload.length);
+            return new Uint8Array(buffer);
+          };
+
+          const encoder = createEncoder({
+            contentTopic,
+            metaSetter,
+          });
+
+          const metaValidator = (
+            _pubSubTopic: string,
+            message: IProtoMessage
+          ): boolean => {
+            if (!message.meta) return false;
+
+            const view = new DataView(
+              message.meta.buffer,
+              message.meta.byteOffset,
+              4
+            );
+            const metaInt = view.getUint32(0);
+
+            return metaInt === message.payload.length;
+          };
+          const decoder = createDecoder(contentTopic, metaValidator);
+
+          const bytes = await encoder.toWire({ payload });
+          const protoResult = await decoder.fromWireToProtoObj(bytes);
+          const result = (await decoder.fromProtoObj(
+            pubSubTopic,
+            protoResult!
+          )) as DecodedMessage;
+
+          expect(result.isMetaValid()).to.be.true;
+        }
+      )
+    );
+  });
 });

--- a/packages/core/src/lib/message/version_0.spec.ts
+++ b/packages/core/src/lib/message/version_0.spec.ts
@@ -3,51 +3,58 @@ import fc from "fast-check";
 
 import { createDecoder, createEncoder, DecodedMessage } from "./version_0.js";
 
-const TestContentTopic = "/test/1/waku-message/utf8";
-const TestPubSubTopic = "/test/pubsub/topic";
-
 describe("Waku Message version 0", function () {
   it("Round trip binary serialization", async function () {
     await fc.assert(
-      fc.asyncProperty(fc.uint8Array({ minLength: 1 }), async (payload) => {
-        const encoder = createEncoder({
-          contentTopic: TestContentTopic,
-        });
-        const bytes = await encoder.toWire({ payload });
-        const decoder = createDecoder(TestContentTopic);
-        const protoResult = await decoder.fromWireToProtoObj(bytes);
-        const result = (await decoder.fromProtoObj(
-          TestPubSubTopic,
-          protoResult!
-        )) as DecodedMessage;
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        async (contentTopic, pubSubTopic, payload) => {
+          const encoder = createEncoder({
+            contentTopic,
+          });
+          const bytes = await encoder.toWire({ payload });
+          const decoder = createDecoder(contentTopic);
+          const protoResult = await decoder.fromWireToProtoObj(bytes);
+          const result = (await decoder.fromProtoObj(
+            pubSubTopic,
+            protoResult!
+          )) as DecodedMessage;
 
-        expect(result.contentTopic).to.eq(TestContentTopic);
-        expect(result.pubSubTopic).to.eq(TestPubSubTopic);
-        expect(result.version).to.eq(0);
-        expect(result.ephemeral).to.be.false;
-        expect(result.payload).to.deep.eq(payload);
-        expect(result.timestamp).to.not.be.undefined;
-      })
+          expect(result.contentTopic).to.eq(contentTopic);
+          expect(result.pubSubTopic).to.eq(pubSubTopic);
+          expect(result.version).to.eq(0);
+          expect(result.ephemeral).to.be.false;
+          expect(result.payload).to.deep.eq(payload);
+          expect(result.timestamp).to.not.be.undefined;
+        }
+      )
     );
   });
 
   it("Ephemeral field set to true", async function () {
     await fc.assert(
-      fc.asyncProperty(fc.uint8Array({ minLength: 1 }), async (payload) => {
-        const encoder = createEncoder({
-          contentTopic: TestContentTopic,
-          ephemeral: true,
-        });
-        const bytes = await encoder.toWire({ payload });
-        const decoder = createDecoder(TestContentTopic);
-        const protoResult = await decoder.fromWireToProtoObj(bytes);
-        const result = (await decoder.fromProtoObj(
-          TestPubSubTopic,
-          protoResult!
-        )) as DecodedMessage;
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        async (contentTopic, pubSubTopic, payload) => {
+          const encoder = createEncoder({
+            contentTopic,
+            ephemeral: true,
+          });
+          const bytes = await encoder.toWire({ payload });
+          const decoder = createDecoder(contentTopic);
+          const protoResult = await decoder.fromWireToProtoObj(bytes);
+          const result = (await decoder.fromProtoObj(
+            pubSubTopic,
+            protoResult!
+          )) as DecodedMessage;
 
-        expect(result.ephemeral).to.be.true;
-      })
+          expect(result.ephemeral).to.be.true;
+        }
+      )
     );
   });
 });

--- a/packages/core/src/lib/message/version_0.spec.ts
+++ b/packages/core/src/lib/message/version_0.spec.ts
@@ -1,3 +1,4 @@
+import type { IProtoMessage } from "@waku/interfaces";
 import { expect } from "chai";
 import fc from "fast-check";
 
@@ -53,6 +54,53 @@ describe("Waku Message version 0", function () {
           )) as DecodedMessage;
 
           expect(result.ephemeral).to.be.true;
+        }
+      )
+    );
+  });
+
+  it("Meta field set when metaSetter is specified", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        async (contentTopic, pubSubTopic, payload) => {
+          // Encode the length of the payload
+          // Not a relevant real life example
+          const metaSetter = (
+            msg: IProtoMessage & { meta: undefined }
+          ): Uint8Array => {
+            const buffer = new ArrayBuffer(4);
+            const view = new DataView(buffer);
+            view.setUint32(0, msg.payload.length, false);
+            return new Uint8Array(buffer);
+          };
+
+          const encoder = createEncoder({
+            contentTopic,
+            ephemeral: true,
+            metaSetter,
+          });
+          const bytes = await encoder.toWire({ payload });
+          const decoder = createDecoder(contentTopic);
+          const protoResult = await decoder.fromWireToProtoObj(bytes);
+          const result = (await decoder.fromProtoObj(
+            pubSubTopic,
+            protoResult!
+          )) as DecodedMessage;
+
+          const expectedMeta = metaSetter({
+            payload,
+            timestamp: undefined,
+            contentTopic: "",
+            ephemeral: undefined,
+            meta: undefined,
+            rateLimitProof: undefined,
+            version: undefined,
+          });
+
+          expect(result.meta).to.deep.eq(expectedMeta);
         }
       )
     );

--- a/packages/core/src/lib/to_proto_message.ts
+++ b/packages/core/src/lib/to_proto_message.ts
@@ -6,6 +6,7 @@ const EmptyMessage: IProtoMessage = {
   contentTopic: "",
   version: undefined,
   timestamp: undefined,
+  meta: undefined,
   rateLimitProof: undefined,
   ephemeral: undefined,
 };

--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -58,6 +58,13 @@ export interface IEncoder {
   toProtoObj: (message: IMessage) => Promise<IProtoMessage | undefined>;
 }
 
+export interface IMetaValidator {
+  /**
+   * Used to validate the `meta` field of a message.
+   */
+  (pubSubTopic: string, message: IProtoMessage): boolean;
+}
+
 export interface IDecodedMessage {
   payload: Uint8Array;
   contentTopic: string;
@@ -65,6 +72,11 @@ export interface IDecodedMessage {
   timestamp: Date | undefined;
   rateLimitProof: IRateLimitProof | undefined;
   ephemeral: boolean | undefined;
+  /**
+   * Calls the { @link @waku/interface.message.IMetaValidator } passed on the
+   * decoder. Returns true if no meta validator is passed.
+   */
+  isMetaValid: () => boolean;
 }
 
 export interface IDecoder<T extends IDecodedMessage> {

--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -17,6 +17,7 @@ export interface IProtoMessage {
   contentTopic: string;
   version: number | undefined;
   timestamp: bigint | undefined;
+  meta: Uint8Array | undefined;
   rateLimitProof: IRateLimitProof | undefined;
   ephemeral: boolean | undefined;
 }
@@ -30,6 +31,10 @@ export interface IMessage {
   rateLimitProof?: IRateLimitProof;
 }
 
+export interface IMetaSetter {
+  (message: IProtoMessage & { meta: undefined }): Uint8Array;
+}
+
 export interface EncoderOptions {
   /** The content topic to set on outgoing messages. */
   contentTopic: string;
@@ -38,6 +43,12 @@ export interface EncoderOptions {
    * @defaultValue `false`
    */
   ephemeral?: boolean;
+  /**
+   * A function called when encoding messages to set the meta field.
+   * @param IProtoMessage The message encoded for wire, without the meta field.
+   * If encryption is used, `metaSetter` only accesses _encrypted_ payload.
+   */
+  metaSetter?: IMetaSetter;
 }
 
 export interface IEncoder {

--- a/packages/message-encryption/src/decoded_message.ts
+++ b/packages/message-encryption/src/decoded_message.ts
@@ -2,7 +2,7 @@ import {
   DecodedMessage as DecodedMessageV0,
   proto,
 } from "@waku/core/lib/message/version_0";
-import type { IDecodedMessage } from "@waku/interfaces";
+import type { IDecodedMessage, IMetaValidator } from "@waku/interfaces";
 
 export class DecodedMessage
   extends DecodedMessageV0
@@ -14,10 +14,11 @@ export class DecodedMessage
     pubSubTopic: string,
     proto: proto.WakuMessage,
     decodedPayload: Uint8Array,
+    metaValidator: IMetaValidator,
     public signature?: Uint8Array,
     public signaturePublicKey?: Uint8Array
   ) {
-    super(pubSubTopic, proto);
+    super(pubSubTopic, proto, metaValidator);
     this._decodedPayload = decodedPayload;
   }
 

--- a/packages/message-encryption/src/ecies.spec.ts
+++ b/packages/message-encryption/src/ecies.spec.ts
@@ -4,35 +4,31 @@ import fc from "fast-check";
 import { getPublicKey } from "./crypto/index.js";
 import { createDecoder, createEncoder } from "./ecies.js";
 
-const TestContentTopic = "/test/1/waku-message/utf8";
-const TestPubSubTopic = "/test/pubsub/topic";
-
 describe("Ecies Encryption", function () {
   it("Round trip binary encryption [ecies, no signature]", async function () {
     await fc.assert(
       fc.asyncProperty(
+        fc.string(),
+        fc.string(),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
-        async (payload, privateKey) => {
+        async (pubSubTopic, contentTopic, payload, privateKey) => {
           const publicKey = getPublicKey(privateKey);
 
           const encoder = createEncoder({
-            contentTopic: TestContentTopic,
+            contentTopic,
             publicKey,
           });
           const bytes = await encoder.toWire({ payload });
 
-          const decoder = createDecoder(TestContentTopic, privateKey);
+          const decoder = createDecoder(contentTopic, privateKey);
           const protoResult = await decoder.fromWireToProtoObj(bytes!);
           if (!protoResult) throw "Failed to proto decode";
-          const result = await decoder.fromProtoObj(
-            TestPubSubTopic,
-            protoResult
-          );
+          const result = await decoder.fromProtoObj(pubSubTopic, protoResult);
           if (!result) throw "Failed to decode";
 
-          expect(result.contentTopic).to.equal(TestContentTopic);
-          expect(result.pubSubTopic).to.equal(TestPubSubTopic);
+          expect(result.contentTopic).to.equal(contentTopic);
+          expect(result.pubSubTopic).to.equal(pubSubTopic);
           expect(result.version).to.equal(1);
           expect(result?.payload).to.deep.equal(payload);
           expect(result.signature).to.be.undefined;
@@ -47,31 +43,36 @@ describe("Ecies Encryption", function () {
 
     await fc.assert(
       fc.asyncProperty(
+        fc.string(),
+        fc.string(),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
-        async (payload, alicePrivateKey, bobPrivateKey) => {
+        async (
+          pubSubTopic,
+          contentTopic,
+          payload,
+          alicePrivateKey,
+          bobPrivateKey
+        ) => {
           const alicePublicKey = getPublicKey(alicePrivateKey);
           const bobPublicKey = getPublicKey(bobPrivateKey);
 
           const encoder = createEncoder({
-            contentTopic: TestContentTopic,
+            contentTopic,
             publicKey: bobPublicKey,
             sigPrivKey: alicePrivateKey,
           });
           const bytes = await encoder.toWire({ payload });
 
-          const decoder = createDecoder(TestContentTopic, bobPrivateKey);
+          const decoder = createDecoder(contentTopic, bobPrivateKey);
           const protoResult = await decoder.fromWireToProtoObj(bytes!);
           if (!protoResult) throw "Failed to proto decode";
-          const result = await decoder.fromProtoObj(
-            TestPubSubTopic,
-            protoResult
-          );
+          const result = await decoder.fromProtoObj(pubSubTopic, protoResult);
           if (!result) throw "Failed to decode";
 
-          expect(result.contentTopic).to.equal(TestContentTopic);
-          expect(result.pubSubTopic).to.equal(TestPubSubTopic);
+          expect(result.contentTopic).to.equal(contentTopic);
+          expect(result.pubSubTopic).to.equal(pubSubTopic);
           expect(result.version).to.equal(1);
           expect(result?.payload).to.deep.equal(payload);
           expect(result.signature).to.not.be.undefined;

--- a/packages/message-encryption/src/ecies.spec.ts
+++ b/packages/message-encryption/src/ecies.spec.ts
@@ -1,3 +1,4 @@
+import { IProtoMessage } from "@waku/interfaces";
 import { expect } from "chai";
 import fc from "fast-check";
 
@@ -77,6 +78,53 @@ describe("Ecies Encryption", function () {
           expect(result?.payload).to.deep.equal(payload);
           expect(result.signature).to.not.be.undefined;
           expect(result.signaturePublicKey).to.deep.eq(alicePublicKey);
+        }
+      )
+    );
+  });
+
+  it("Check meta is set [ecies]", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
+        async (pubSubTopic, contentTopic, payload, privateKey) => {
+          const publicKey = getPublicKey(privateKey);
+          const metaSetter = (
+            msg: IProtoMessage & { meta: undefined }
+          ): Uint8Array => {
+            const buffer = new ArrayBuffer(4);
+            const view = new DataView(buffer);
+            view.setUint32(0, msg.payload.length, false);
+            return new Uint8Array(buffer);
+          };
+
+          const encoder = createEncoder({
+            contentTopic,
+            publicKey,
+            metaSetter,
+          });
+          const bytes = await encoder.toWire({ payload });
+
+          const decoder = createDecoder(contentTopic, privateKey);
+          const protoResult = await decoder.fromWireToProtoObj(bytes!);
+          if (!protoResult) throw "Failed to proto decode";
+          const result = await decoder.fromProtoObj(pubSubTopic, protoResult);
+          if (!result) throw "Failed to decode";
+
+          const expectedMeta = metaSetter({
+            payload: protoResult.payload,
+            timestamp: undefined,
+            contentTopic: "",
+            ephemeral: undefined,
+            meta: undefined,
+            rateLimitProof: undefined,
+            version: undefined,
+          });
+
+          expect(result.meta).to.deep.equal(expectedMeta);
         }
       )
     );

--- a/packages/message-encryption/src/ecies.spec.ts
+++ b/packages/message-encryption/src/ecies.spec.ts
@@ -1,3 +1,4 @@
+import { DecodedMessage } from "@waku/core";
 import { IProtoMessage } from "@waku/interfaces";
 import { expect } from "chai";
 import fc from "fast-check";
@@ -125,6 +126,118 @@ describe("Ecies Encryption", function () {
           });
 
           expect(result.meta).to.deep.equal(expectedMeta);
+        }
+      )
+    );
+  });
+
+  it("isMetaValid returns true when no meta validator is specified [ecies]", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
+        async (pubSubTopic, contentTopic, payload, privateKey) => {
+          const publicKey = getPublicKey(privateKey);
+          const encoder = createEncoder({
+            contentTopic,
+            publicKey,
+          });
+          const bytes = await encoder.toWire({ payload });
+
+          const decoder = createDecoder(contentTopic, privateKey);
+          const protoResult = await decoder.fromWireToProtoObj(bytes!);
+          if (!protoResult) throw "Failed to proto decode";
+          const result = await decoder.fromProtoObj(pubSubTopic, protoResult);
+          if (!result) throw "Failed to decode";
+
+          expect(result.isMetaValid()).to.be.true;
+        }
+      )
+    );
+  });
+
+  it("isMetaValid returns false when validator specified returns false [ecies]", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
+        async (pubSubTopic, contentTopic, payload, privateKey) => {
+          const publicKey = getPublicKey(privateKey);
+          const encoder = createEncoder({
+            contentTopic,
+            publicKey,
+          });
+          const bytes = await encoder.toWire({ payload });
+
+          const decoder = createDecoder(contentTopic, privateKey, () => false);
+          const protoResult = await decoder.fromWireToProtoObj(bytes!);
+          if (!protoResult) throw "Failed to proto decode";
+          const result = await decoder.fromProtoObj(pubSubTopic, protoResult);
+          if (!result) throw "Failed to decode";
+
+          expect(result.isMetaValid()).to.be.false;
+        }
+      )
+    );
+  });
+
+  it("isMetaValid returns true when matching meta setter [ecies]", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
+        async (pubSubTopic, contentTopic, payload, privateKey) => {
+          const publicKey = getPublicKey(privateKey);
+          const metaSetter = (
+            msg: IProtoMessage & { meta: undefined }
+          ): Uint8Array => {
+            const buffer = new ArrayBuffer(4);
+            const view = new DataView(buffer);
+            view.setUint32(0, msg.payload.length);
+            return new Uint8Array(buffer);
+          };
+
+          const encoder = createEncoder({
+            contentTopic,
+            publicKey,
+            metaSetter,
+          });
+
+          const metaValidator = (
+            _pubSubTopic: string,
+            message: IProtoMessage
+          ): boolean => {
+            if (!message.meta) return false;
+
+            const view = new DataView(
+              message.meta.buffer,
+              message.meta.byteOffset,
+              4
+            );
+            const metaInt = view.getUint32(0);
+
+            return metaInt === message.payload.length;
+          };
+          const decoder = createDecoder(
+            contentTopic,
+            privateKey,
+            metaValidator
+          );
+
+          const bytes = await encoder.toWire({ payload });
+          const protoResult = await decoder.fromWireToProtoObj(bytes!);
+          const result = (await decoder.fromProtoObj(
+            pubSubTopic,
+            protoResult!
+          )) as DecodedMessage;
+
+          expect(result.isMetaValid()).to.be.true;
         }
       )
     );

--- a/packages/message-encryption/src/symmetric.spec.ts
+++ b/packages/message-encryption/src/symmetric.spec.ts
@@ -4,33 +4,29 @@ import fc from "fast-check";
 import { getPublicKey } from "./crypto/index.js";
 import { createDecoder, createEncoder } from "./symmetric.js";
 
-const TestContentTopic = "/test/1/waku-message/utf8";
-const TestPubSubTopic = "/test/pubsub/topic";
-
 describe("Symmetric Encryption", function () {
   it("Round trip binary encryption [symmetric, no signature]", async function () {
     await fc.assert(
       fc.asyncProperty(
+        fc.string(),
+        fc.string(),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
-        async (payload, symKey) => {
+        async (pubSubTopic, contentTopic, payload, symKey) => {
           const encoder = createEncoder({
-            contentTopic: TestContentTopic,
+            contentTopic,
             symKey,
           });
           const bytes = await encoder.toWire({ payload });
 
-          const decoder = createDecoder(TestContentTopic, symKey);
+          const decoder = createDecoder(contentTopic, symKey);
           const protoResult = await decoder.fromWireToProtoObj(bytes!);
           if (!protoResult) throw "Failed to proto decode";
-          const result = await decoder.fromProtoObj(
-            TestPubSubTopic,
-            protoResult
-          );
+          const result = await decoder.fromProtoObj(pubSubTopic, protoResult);
           if (!result) throw "Failed to decode";
 
-          expect(result.contentTopic).to.equal(TestContentTopic);
-          expect(result.pubSubTopic).to.equal(TestPubSubTopic);
+          expect(result.contentTopic).to.equal(contentTopic);
+          expect(result.pubSubTopic).to.equal(pubSubTopic);
           expect(result.version).to.equal(1);
           expect(result?.payload).to.deep.equal(payload);
           expect(result.signature).to.be.undefined;
@@ -43,30 +39,29 @@ describe("Symmetric Encryption", function () {
   it("Round trip binary encryption [symmetric, signature]", async function () {
     await fc.assert(
       fc.asyncProperty(
+        fc.string(),
+        fc.string(),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
-        async (payload, sigPrivKey, symKey) => {
+        async (pubSubTopic, contentTopic, payload, sigPrivKey, symKey) => {
           const sigPubKey = getPublicKey(sigPrivKey);
 
           const encoder = createEncoder({
-            contentTopic: TestContentTopic,
+            contentTopic,
             symKey,
             sigPrivKey,
           });
           const bytes = await encoder.toWire({ payload });
 
-          const decoder = createDecoder(TestContentTopic, symKey);
+          const decoder = createDecoder(contentTopic, symKey);
           const protoResult = await decoder.fromWireToProtoObj(bytes!);
           if (!protoResult) throw "Failed to proto decode";
-          const result = await decoder.fromProtoObj(
-            TestPubSubTopic,
-            protoResult
-          );
+          const result = await decoder.fromProtoObj(pubSubTopic, protoResult);
           if (!result) throw "Failed to decode";
 
-          expect(result.contentTopic).to.equal(TestContentTopic);
-          expect(result.pubSubTopic).to.equal(TestPubSubTopic);
+          expect(result.contentTopic).to.equal(contentTopic);
+          expect(result.pubSubTopic).to.equal(pubSubTopic);
           expect(result.version).to.equal(1);
           expect(result?.payload).to.deep.equal(payload);
           expect(result.signature).to.not.be.undefined;

--- a/packages/message-encryption/src/symmetric.spec.ts
+++ b/packages/message-encryption/src/symmetric.spec.ts
@@ -1,3 +1,4 @@
+import { DecodedMessage } from "@waku/core";
 import { IProtoMessage } from "@waku/interfaces";
 import { expect } from "chai";
 import fc from "fast-check";
@@ -113,6 +114,111 @@ describe("Symmetric Encryption", function () {
           });
 
           expect(result.meta).to.deep.equal(expectedMeta);
+        }
+      )
+    );
+  });
+
+  it("isMetaValid returns true when no meta validator is specified [symmetric]", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
+        async (pubSubTopic, contentTopic, payload, symKey) => {
+          const encoder = createEncoder({
+            contentTopic,
+            symKey,
+          });
+          const bytes = await encoder.toWire({ payload });
+
+          const decoder = createDecoder(contentTopic, symKey);
+          const protoResult = await decoder.fromWireToProtoObj(bytes!);
+          if (!protoResult) throw "Failed to proto decode";
+          const result = await decoder.fromProtoObj(pubSubTopic, protoResult);
+          if (!result) throw "Failed to decode";
+
+          expect(result.isMetaValid()).to.be.true;
+        }
+      )
+    );
+  });
+
+  it("isMetaValid returns false when validator specified returns false [symmetric]", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
+        async (pubSubTopic, contentTopic, payload, symKey) => {
+          const encoder = createEncoder({
+            contentTopic,
+            symKey,
+          });
+          const bytes = await encoder.toWire({ payload });
+
+          const decoder = createDecoder(contentTopic, symKey, () => false);
+          const protoResult = await decoder.fromWireToProtoObj(bytes!);
+          if (!protoResult) throw "Failed to proto decode";
+          const result = await decoder.fromProtoObj(pubSubTopic, protoResult);
+          if (!result) throw "Failed to decode";
+
+          expect(result.isMetaValid()).to.be.false;
+        }
+      )
+    );
+  });
+
+  it("isMetaValid returns true when matching meta setter [symmetric]", async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.string(),
+        fc.uint8Array({ minLength: 1 }),
+        fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
+        async (pubSubTopic, contentTopic, payload, symKey) => {
+          const metaSetter = (
+            msg: IProtoMessage & { meta: undefined }
+          ): Uint8Array => {
+            const buffer = new ArrayBuffer(4);
+            const view = new DataView(buffer);
+            view.setUint32(0, msg.payload.length);
+            return new Uint8Array(buffer);
+          };
+
+          const encoder = createEncoder({
+            contentTopic,
+            symKey,
+            metaSetter,
+          });
+
+          const metaValidator = (
+            _pubSubTopic: string,
+            message: IProtoMessage
+          ): boolean => {
+            if (!message.meta) return false;
+
+            const view = new DataView(
+              message.meta.buffer,
+              message.meta.byteOffset,
+              4
+            );
+            const metaInt = view.getUint32(0);
+
+            return metaInt === message.payload.length;
+          };
+          const decoder = createDecoder(contentTopic, symKey, metaValidator);
+
+          const bytes = await encoder.toWire({ payload });
+          const protoResult = await decoder.fromWireToProtoObj(bytes!);
+          const result = (await decoder.fromProtoObj(
+            pubSubTopic,
+            protoResult!
+          )) as DecodedMessage;
+
+          expect(result.isMetaValid()).to.be.true;
         }
       )
     );

--- a/packages/proto/src/lib/filter.ts
+++ b/packages/proto/src/lib/filter.ts
@@ -430,6 +430,7 @@ export interface WakuMessage {
   contentTopic: string;
   version?: number;
   timestamp?: bigint;
+  meta?: Uint8Array;
   rateLimitProof?: RateLimitProof;
   ephemeral?: boolean;
 }
@@ -463,6 +464,11 @@ export namespace WakuMessage {
           if (obj.timestamp != null) {
             w.uint32(80);
             w.sint64(obj.timestamp);
+          }
+
+          if (obj.meta != null) {
+            w.uint32(90);
+            w.bytes(obj.meta);
           }
 
           if (obj.rateLimitProof != null) {
@@ -502,6 +508,9 @@ export namespace WakuMessage {
                 break;
               case 10:
                 obj.timestamp = reader.sint64();
+                break;
+              case 11:
+                obj.meta = reader.bytes();
                 break;
               case 21:
                 obj.rateLimitProof = RateLimitProof.codec().decode(

--- a/packages/proto/src/lib/light_push.ts
+++ b/packages/proto/src/lib/light_push.ts
@@ -362,6 +362,7 @@ export interface WakuMessage {
   contentTopic: string;
   version?: number;
   timestamp?: bigint;
+  meta?: Uint8Array;
   rateLimitProof?: RateLimitProof;
   ephemeral?: boolean;
 }
@@ -395,6 +396,11 @@ export namespace WakuMessage {
           if (obj.timestamp != null) {
             w.uint32(80);
             w.sint64(obj.timestamp);
+          }
+
+          if (obj.meta != null) {
+            w.uint32(90);
+            w.bytes(obj.meta);
           }
 
           if (obj.rateLimitProof != null) {
@@ -434,6 +440,9 @@ export namespace WakuMessage {
                 break;
               case 10:
                 obj.timestamp = reader.sint64();
+                break;
+              case 11:
+                obj.meta = reader.bytes();
                 break;
               case 21:
                 obj.rateLimitProof = RateLimitProof.codec().decode(

--- a/packages/proto/src/lib/message.proto
+++ b/packages/proto/src/lib/message.proto
@@ -17,6 +17,7 @@ message WakuMessage {
   string content_topic = 2;
   optional uint32 version = 3;
   optional sint64 timestamp = 10;
+  optional bytes meta = 11;
   optional RateLimitProof rate_limit_proof = 21;
   optional bool ephemeral = 31;
 }

--- a/packages/proto/src/lib/message.ts
+++ b/packages/proto/src/lib/message.ts
@@ -134,6 +134,7 @@ export interface WakuMessage {
   contentTopic: string;
   version?: number;
   timestamp?: bigint;
+  meta?: Uint8Array;
   rateLimitProof?: RateLimitProof;
   ephemeral?: boolean;
 }
@@ -167,6 +168,11 @@ export namespace WakuMessage {
           if (obj.timestamp != null) {
             w.uint32(80);
             w.sint64(obj.timestamp);
+          }
+
+          if (obj.meta != null) {
+            w.uint32(90);
+            w.bytes(obj.meta);
           }
 
           if (obj.rateLimitProof != null) {
@@ -206,6 +212,9 @@ export namespace WakuMessage {
                 break;
               case 10:
                 obj.timestamp = reader.sint64();
+                break;
+              case 11:
+                obj.meta = reader.bytes();
                 break;
               case 21:
                 obj.rateLimitProof = RateLimitProof.codec().decode(

--- a/packages/proto/src/lib/store.ts
+++ b/packages/proto/src/lib/store.ts
@@ -676,6 +676,7 @@ export interface WakuMessage {
   contentTopic: string;
   version?: number;
   timestamp?: bigint;
+  meta?: Uint8Array;
   rateLimitProof?: RateLimitProof;
   ephemeral?: boolean;
 }
@@ -709,6 +710,11 @@ export namespace WakuMessage {
           if (obj.timestamp != null) {
             w.uint32(80);
             w.sint64(obj.timestamp);
+          }
+
+          if (obj.meta != null) {
+            w.uint32(90);
+            w.bytes(obj.meta);
           }
 
           if (obj.rateLimitProof != null) {
@@ -748,6 +754,9 @@ export namespace WakuMessage {
                 break;
               case 10:
                 obj.timestamp = reader.sint64();
+                break;
+              case 11:
+                obj.meta = reader.bytes();
                 break;
               case 21:
                 obj.rateLimitProof = RateLimitProof.codec().decode(


### PR DESCRIPTION
Ref: #1208 