### PR TITLE
fix: prettier and cspell ignore CHANGELOG

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -126,7 +126,8 @@
     "build",
     "gen",
     "proto",
-    "*.spec.ts"
+    "*.spec.ts",
+    "CHANGELOG.md"
   ],
   "patterns": [
     {

--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -2,3 +2,4 @@ build
 bundle
 dist
 node_modules
+CHANGELOG.md

--- a/packages/create/.prettierignore
+++ b/packages/create/.prettierignore
@@ -2,3 +2,4 @@ build
 bundle
 dist
 node_modules
+CHANGELOG.md

--- a/packages/dns-discovery/.prettierignore
+++ b/packages/dns-discovery/.prettierignore
@@ -2,3 +2,4 @@ build
 bundle
 dist
 node_modules
+CHANGELOG.md

--- a/packages/enr/.prettierignore
+++ b/packages/enr/.prettierignore
@@ -2,3 +2,4 @@ build
 bundle
 dist
 node_modules
+CHANGELOG.md

--- a/packages/interfaces/.prettierignore
+++ b/packages/interfaces/.prettierignore
@@ -2,3 +2,4 @@ build
 bundle
 dist
 node_modules
+CHANGELOG.md

--- a/packages/message-encryption/.prettierignore
+++ b/packages/message-encryption/.prettierignore
@@ -2,3 +2,4 @@ build
 bundle
 dist
 node_modules
+CHANGELOG.md

--- a/packages/peer-exchange/.prettierignore
+++ b/packages/peer-exchange/.prettierignore
@@ -2,3 +2,4 @@ build
 bundle
 dist
 node_modules
+CHANGELOG.md

--- a/packages/proto/.prettierignore
+++ b/packages/proto/.prettierignore
@@ -2,3 +2,4 @@ build
 bundle
 dist
 node_modules
+CHANGELOG.md

--- a/packages/utils/.prettierignore
+++ b/packages/utils/.prettierignore
@@ -2,3 +2,4 @@ build
 bundle
 dist
 node_modules
+CHANGELOG.md


### PR DESCRIPTION
## Problem

Because CHANGELOG is auto updated now it contradicts with prettier check.

## Solution

Ignore it's checking by prettier and cspell. 
