### PR TITLE
chore: add manual trigger for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - "staging"
       - "trying"
   pull_request:
+  workflow_dispatch:
 
 env:
   NWAKU_VERSION: "v0.15.0"


### PR DESCRIPTION
## Problem

js-waku CI provides valuable integration test results for `nwaku` and as such helps the nwaku team get feedback on any regressions or inadvertent breaking changes. From `nwaku`'s side we're proposing that js-waku CI passing against nwaku release candidates should be a requirement before a nwaku release can be finalised.

## Solution

This PR proposes adding a manual trigger for js-waku CI. This will allow `nwaku` contributors to verify ad-hoc js-waku CI against any nwaku release candidate.

## Notes

If this is unacceptable to the js-waku team, workarounds could be to
- trigger CI by opening a draft PR, which gets closed without merging
- simply verify from past CI runs that the latest merged PR in js-waku had a successful CI run (although there may be a slight mismatch here in terms of nwaku master and js-waku master. 
