### PR TITLE
chore: make latest default tag for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
       - run: npm run build
         if: ${{ steps.release.outputs.releases_created }}
 
-      - run: npm publish --workspaces --next --access public
+      - run: npm publish --workspaces --tag latest --access public
         if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Makes `latest` default tag for publishing of `js-waku` packages.