### PR TITLE
chore: bump core version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,7 +4,7 @@
   "packages/interfaces": "0.0.10",
   "packages/enr": "0.0.9",
   "packages/peer-exchange": "0.0.7",
-  "packages/core": "0.0.15",
+  "packages/core": "0.0.14",
   "packages/dns-discovery": "0.0.9",
   "packages/message-encryption": "0.0.12",
   "packages/create": "0.0.10"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,7 +4,7 @@
   "packages/interfaces": "0.0.10",
   "packages/enr": "0.0.9",
   "packages/peer-exchange": "0.0.7",
-  "packages/core": "0.0.14",
+  "packages/core": "0.0.15",
   "packages/dns-discovery": "0.0.9",
   "packages/message-encryption": "0.0.12",
   "packages/create": "0.0.10"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,7 +4,7 @@
   "packages/interfaces": "0.0.10",
   "packages/enr": "0.0.9",
   "packages/peer-exchange": "0.0.7",
-  "packages/core": "0.0.13",
+  "packages/core": "0.0.14",
   "packages/dns-discovery": "0.0.9",
   "packages/message-encryption": "0.0.12",
   "packages/create": "0.0.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29694,7 +29694,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@libp2p/peer-id": "^2.0.2",
-        "@waku/core": "*",
+        "@waku/core": "0.0.15",
         "@waku/enr": "*",
         "@waku/interfaces": "*",
         "@waku/utils": "*",
@@ -29734,6 +29734,34 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "packages/tests/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+      "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "packages/tests/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/utils": {
@@ -34751,7 +34779,7 @@
         "@types/tail": "^2.2.1",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
         "@typescript-eslint/parser": "^5.51.0",
-        "@waku/core": "*",
+        "@waku/core": "0.0.15",
         "@waku/create": "*",
         "@waku/dns-discovery": "*",
         "@waku/enr": "*",
@@ -34776,6 +34804,27 @@
         "prettier": "^2.8.4",
         "tail": "^2.2.6",
         "typescript": "^4.9.5"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+          "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "@chainsafe/netmask": "^2.0.0",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "uuid": {
+          "version": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
       }
     },
     "@waku/utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28973,7 +28973,7 @@
     },
     "packages/core": {
       "name": "@waku/core",
-      "version": "0.0.15",
+      "version": "0.0.14",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^6.1.0",
@@ -29078,7 +29078,7 @@
         "@chainsafe/libp2p-noise": "^11.0.0",
         "@libp2p/mplex": "^7.1.1",
         "@libp2p/websockets": "^5.0.3",
-        "@waku/core": "0.0.13",
+        "@waku/core": "0.0.14",
         "@waku/dns-discovery": "0.0.9",
         "libp2p": "^0.42.2"
       },
@@ -29170,37 +29170,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "packages/create/node_modules/@waku/core": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
-      "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
-      "dependencies": {
-        "@chainsafe/libp2p-gossipsub": "^6.1.0",
-        "@noble/hashes": "^1.3.0",
-        "@waku/interfaces": "0.0.10",
-        "@waku/proto": "0.0.4",
-        "@waku/utils": "0.0.3",
-        "debug": "^4.3.4",
-        "it-all": "^2.0.0",
-        "it-length-prefixed": "^8.0.4",
-        "it-pipe": "^2.0.5",
-        "p-event": "^5.0.1",
-        "uint8arraylist": "^2.4.3",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@multiformats/multiaddr": "^12.0.0",
-        "libp2p": "^0.42.2"
-      },
-      "peerDependenciesMeta": {
-        "@multiformats/multiaddr": {
-          "optional": true
-        }
       }
     },
     "packages/create/node_modules/uuid": {
@@ -29401,7 +29370,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@noble/secp256k1": "^1.7.1",
-        "@waku/core": "0.0.13",
+        "@waku/core": "0.0.14",
         "@waku/interfaces": "0.0.10",
         "@waku/proto": "0.0.4",
         "@waku/utils": "0.0.3",
@@ -29469,37 +29438,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "packages/message-encryption/node_modules/@waku/core": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
-      "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
-      "dependencies": {
-        "@chainsafe/libp2p-gossipsub": "^6.1.0",
-        "@noble/hashes": "^1.3.0",
-        "@waku/interfaces": "0.0.10",
-        "@waku/proto": "0.0.4",
-        "@waku/utils": "0.0.3",
-        "debug": "^4.3.4",
-        "it-all": "^2.0.0",
-        "it-length-prefixed": "^8.0.4",
-        "it-pipe": "^2.0.5",
-        "p-event": "^5.0.1",
-        "uint8arraylist": "^2.4.3",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@multiformats/multiaddr": "^12.0.0",
-        "libp2p": "^0.42.2"
-      },
-      "peerDependenciesMeta": {
-        "@multiformats/multiaddr": {
-          "optional": true
-        }
-      }
-    },
     "packages/message-encryption/node_modules/uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -29515,7 +29453,7 @@
       "dependencies": {
         "@libp2p/interface-peer-discovery": "^1.0.5",
         "@libp2p/interfaces": "^3.3.1",
-        "@waku/core": "0.0.13",
+        "@waku/core": "0.0.14",
         "@waku/enr": "0.0.9",
         "@waku/proto": "0.0.4",
         "@waku/utils": "0.0.3",
@@ -29574,37 +29512,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "packages/peer-exchange/node_modules/@waku/core": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
-      "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
-      "dependencies": {
-        "@chainsafe/libp2p-gossipsub": "^6.1.0",
-        "@noble/hashes": "^1.3.0",
-        "@waku/interfaces": "0.0.10",
-        "@waku/proto": "0.0.4",
-        "@waku/utils": "0.0.3",
-        "debug": "^4.3.4",
-        "it-all": "^2.0.0",
-        "it-length-prefixed": "^8.0.4",
-        "it-pipe": "^2.0.5",
-        "p-event": "^5.0.1",
-        "uint8arraylist": "^2.4.3",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@multiformats/multiaddr": "^12.0.0",
-        "libp2p": "^0.42.2"
-      },
-      "peerDependenciesMeta": {
-        "@multiformats/multiaddr": {
-          "optional": true
-        }
       }
     },
     "packages/peer-exchange/node_modules/uuid": {
@@ -29694,7 +29601,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@libp2p/peer-id": "^2.0.2",
-        "@waku/core": "0.0.15",
+        "@waku/core": "0.0.14",
         "@waku/enr": "*",
         "@waku/interfaces": "*",
         "@waku/utils": "*",
@@ -29734,34 +29641,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "packages/tests/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
-      "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "@chainsafe/netmask": "^2.0.0",
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "packages/tests/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "packages/utils": {
@@ -34299,7 +34178,7 @@
         "@typescript-eslint/eslint-plugin": "^5.57.0",
         "@typescript-eslint/parser": "^5.51.0",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.13",
+        "@waku/core": "0.0.14",
         "@waku/dns-discovery": "0.0.9",
         "@waku/interfaces": "0.0.10",
         "cspell": "^6.31.1",
@@ -34340,8 +34219,7 @@
           }
         },
         "@multiformats/multiaddr": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+          "version": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
           "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
           "optional": true,
           "peer": true,
@@ -34355,28 +34233,8 @@
             "varint": "^6.0.0"
           }
         },
-        "@waku/core": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
-          "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
-          "requires": {
-            "@chainsafe/libp2p-gossipsub": "^6.1.0",
-            "@noble/hashes": "^1.3.0",
-            "@waku/interfaces": "0.0.10",
-            "@waku/proto": "0.0.4",
-            "@waku/utils": "0.0.3",
-            "debug": "^4.3.4",
-            "it-all": "^2.0.0",
-            "it-length-prefixed": "^8.0.4",
-            "it-pipe": "^2.0.5",
-            "p-event": "^5.0.1",
-            "uint8arraylist": "^2.4.3",
-            "uuid": "^9.0.0"
-          }
-        },
         "uuid": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "version": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
           "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
@@ -34558,7 +34416,7 @@
         "@typescript-eslint/eslint-plugin": "^5.57.0",
         "@typescript-eslint/parser": "^5.51.0",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.13",
+        "@waku/core": "0.0.14",
         "@waku/interfaces": "0.0.10",
         "@waku/proto": "0.0.4",
         "@waku/utils": "0.0.3",
@@ -34588,8 +34446,7 @@
       },
       "dependencies": {
         "@multiformats/multiaddr": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+          "version": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
           "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
           "optional": true,
           "peer": true,
@@ -34603,28 +34460,8 @@
             "varint": "^6.0.0"
           }
         },
-        "@waku/core": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
-          "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
-          "requires": {
-            "@chainsafe/libp2p-gossipsub": "^6.1.0",
-            "@noble/hashes": "^1.3.0",
-            "@waku/interfaces": "0.0.10",
-            "@waku/proto": "0.0.4",
-            "@waku/utils": "0.0.3",
-            "debug": "^4.3.4",
-            "it-all": "^2.0.0",
-            "it-length-prefixed": "^8.0.4",
-            "it-pipe": "^2.0.5",
-            "p-event": "^5.0.1",
-            "uint8arraylist": "^2.4.3",
-            "uuid": "^9.0.0"
-          }
-        },
         "uuid": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "version": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
           "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
@@ -34645,7 +34482,7 @@
         "@typescript-eslint/eslint-plugin": "^5.57.0",
         "@typescript-eslint/parser": "^5.51.0",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.13",
+        "@waku/core": "0.0.14",
         "@waku/enr": "0.0.9",
         "@waku/interfaces": "0.0.10",
         "@waku/proto": "0.0.4",
@@ -34671,8 +34508,7 @@
       },
       "dependencies": {
         "@multiformats/multiaddr": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+          "version": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
           "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
           "optional": true,
           "peer": true,
@@ -34686,28 +34522,8 @@
             "varint": "^6.0.0"
           }
         },
-        "@waku/core": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
-          "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
-          "requires": {
-            "@chainsafe/libp2p-gossipsub": "^6.1.0",
-            "@noble/hashes": "^1.3.0",
-            "@waku/interfaces": "0.0.10",
-            "@waku/proto": "0.0.4",
-            "@waku/utils": "0.0.3",
-            "debug": "^4.3.4",
-            "it-all": "^2.0.0",
-            "it-length-prefixed": "^8.0.4",
-            "it-pipe": "^2.0.5",
-            "p-event": "^5.0.1",
-            "uint8arraylist": "^2.4.3",
-            "uuid": "^9.0.0"
-          }
-        },
         "uuid": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "version": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
           "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
@@ -34779,7 +34595,7 @@
         "@types/tail": "^2.2.1",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
         "@typescript-eslint/parser": "^5.51.0",
-        "@waku/core": "0.0.15",
+        "@waku/core": "0.0.14",
         "@waku/create": "*",
         "@waku/dns-discovery": "*",
         "@waku/enr": "*",
@@ -34804,27 +34620,6 @@
         "prettier": "^2.8.4",
         "tail": "^2.2.6",
         "typescript": "^4.9.5"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
-          "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@chainsafe/is-ip": "^2.0.1",
-            "@chainsafe/netmask": "^2.0.0",
-            "dns-over-http-resolver": "^2.1.0",
-            "err-code": "^3.0.1",
-            "multiformats": "^11.0.0",
-            "uint8arrays": "^4.0.2",
-            "varint": "^6.0.0"
-          }
-        },
-        "uuid": {
-          "version": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
-        }
       }
     },
     "@waku/utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28973,7 +28973,7 @@
     },
     "packages/core": {
       "name": "@waku/core",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^6.1.0",
@@ -29150,6 +29150,65 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "packages/create/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+      "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "packages/create/node_modules/@waku/core": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
+      "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
+      "dependencies": {
+        "@chainsafe/libp2p-gossipsub": "^6.1.0",
+        "@noble/hashes": "^1.3.0",
+        "@waku/interfaces": "0.0.10",
+        "@waku/proto": "0.0.4",
+        "@waku/utils": "0.0.3",
+        "debug": "^4.3.4",
+        "it-all": "^2.0.0",
+        "it-length-prefixed": "^8.0.4",
+        "it-pipe": "^2.0.5",
+        "p-event": "^5.0.1",
+        "uint8arraylist": "^2.4.3",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@multiformats/multiaddr": "^12.0.0",
+        "libp2p": "^0.42.2"
+      },
+      "peerDependenciesMeta": {
+        "@multiformats/multiaddr": {
+          "optional": true
+        }
+      }
+    },
+    "packages/create/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/dns-discovery": {
@@ -29390,6 +29449,65 @@
         "node": ">=16"
       }
     },
+    "packages/message-encryption/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+      "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "packages/message-encryption/node_modules/@waku/core": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
+      "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
+      "dependencies": {
+        "@chainsafe/libp2p-gossipsub": "^6.1.0",
+        "@noble/hashes": "^1.3.0",
+        "@waku/interfaces": "0.0.10",
+        "@waku/proto": "0.0.4",
+        "@waku/utils": "0.0.3",
+        "debug": "^4.3.4",
+        "it-all": "^2.0.0",
+        "it-length-prefixed": "^8.0.4",
+        "it-pipe": "^2.0.5",
+        "p-event": "^5.0.1",
+        "uint8arraylist": "^2.4.3",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@multiformats/multiaddr": "^12.0.0",
+        "libp2p": "^0.42.2"
+      },
+      "peerDependenciesMeta": {
+        "@multiformats/multiaddr": {
+          "optional": true
+        }
+      }
+    },
+    "packages/message-encryption/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "packages/peer-exchange": {
       "name": "@waku/peer-exchange",
       "version": "0.0.7",
@@ -29436,6 +29554,65 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "packages/peer-exchange/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+      "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "packages/peer-exchange/node_modules/@waku/core": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
+      "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
+      "dependencies": {
+        "@chainsafe/libp2p-gossipsub": "^6.1.0",
+        "@noble/hashes": "^1.3.0",
+        "@waku/interfaces": "0.0.10",
+        "@waku/proto": "0.0.4",
+        "@waku/utils": "0.0.3",
+        "debug": "^4.3.4",
+        "it-all": "^2.0.0",
+        "it-length-prefixed": "^8.0.4",
+        "it-pipe": "^2.0.5",
+        "p-event": "^5.0.1",
+        "uint8arraylist": "^2.4.3",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@multiformats/multiaddr": "^12.0.0",
+        "libp2p": "^0.42.2"
+      },
+      "peerDependenciesMeta": {
+        "@multiformats/multiaddr": {
+          "optional": true
+        }
+      }
+    },
+    "packages/peer-exchange/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/proto": {
@@ -34133,6 +34310,46 @@
             "@libp2p/interfaces": "^3.0.0",
             "multiformats": "^11.0.0"
           }
+        },
+        "@multiformats/multiaddr": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+          "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "@chainsafe/netmask": "^2.0.0",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "@waku/core": {
+          "version": "0.0.13",
+          "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
+          "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
+          "requires": {
+            "@chainsafe/libp2p-gossipsub": "^6.1.0",
+            "@noble/hashes": "^1.3.0",
+            "@waku/interfaces": "0.0.10",
+            "@waku/proto": "0.0.4",
+            "@waku/utils": "0.0.3",
+            "debug": "^4.3.4",
+            "it-all": "^2.0.0",
+            "it-length-prefixed": "^8.0.4",
+            "it-pipe": "^2.0.5",
+            "p-event": "^5.0.1",
+            "uint8arraylist": "^2.4.3",
+            "uuid": "^9.0.0"
+          }
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
     },
@@ -34340,6 +34557,48 @@
         "rollup": "^3.15.0",
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.5"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+          "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "@chainsafe/netmask": "^2.0.0",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "@waku/core": {
+          "version": "0.0.13",
+          "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
+          "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
+          "requires": {
+            "@chainsafe/libp2p-gossipsub": "^6.1.0",
+            "@noble/hashes": "^1.3.0",
+            "@waku/interfaces": "0.0.10",
+            "@waku/proto": "0.0.4",
+            "@waku/utils": "0.0.3",
+            "debug": "^4.3.4",
+            "it-all": "^2.0.0",
+            "it-length-prefixed": "^8.0.4",
+            "it-pipe": "^2.0.5",
+            "p-event": "^5.0.1",
+            "uint8arraylist": "^2.4.3",
+            "uuid": "^9.0.0"
+          }
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
       }
     },
     "@waku/peer-exchange": {
@@ -34381,6 +34640,48 @@
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.5",
         "uint8arraylist": "^2.4.3"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
+          "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "@chainsafe/netmask": "^2.0.0",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "@waku/core": {
+          "version": "0.0.13",
+          "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.13.tgz",
+          "integrity": "sha512-MyPdQm8/M7sFPO+YeMg4z1ymodnl9Tou21WfFRlj/7s6u/2sGrbi+Su7qxy4UCd17tNOODvpOyw+8H3KkLnlMw==",
+          "requires": {
+            "@chainsafe/libp2p-gossipsub": "^6.1.0",
+            "@noble/hashes": "^1.3.0",
+            "@waku/interfaces": "0.0.10",
+            "@waku/proto": "0.0.4",
+            "@waku/utils": "0.0.3",
+            "debug": "^4.3.4",
+            "it-all": "^2.0.0",
+            "it-length-prefixed": "^8.0.4",
+            "it-pipe": "^2.0.5",
+            "p-event": "^5.0.1",
+            "uint8arraylist": "^2.4.3",
+            "uuid": "^9.0.0"
+          }
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
       }
     },
     "@waku/proto": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28973,7 +28973,7 @@
     },
     "packages/core": {
       "name": "@waku/core",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^6.1.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -13,80 +13,87 @@ Was published by mistake and does not contain valid code.
 
 ### Bug Fixes
 
-- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
+* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
+
 
 ### Dependencies
 
-- The following workspace dependencies were updated
-  - dependencies
-    - @waku/interfaces bumped from 0.0.9 to 0.0.10
-    - @waku/proto bumped from 0.0.3 to 0.0.4
-    - @waku/utils bumped from 0.0.2 to 0.0.3
+* The following workspace dependencies were updated
+  * dependencies
+    * @waku/interfaces bumped from 0.0.9 to 0.0.10
+    * @waku/proto bumped from 0.0.3 to 0.0.4
+    * @waku/utils bumped from 0.0.2 to 0.0.3
 
 ## [0.0.12](https://github.com/waku-org/js-waku/compare/core-v0.0.11...core-v0.0.12) (2023-03-23)
 
+
 ### ⚠ BREAKING CHANGES
 
-- use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
+* use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
 
 ### Features
 
-- Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
-- Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
+* Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
+* Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
+
 
 ### Dependencies
 
-- The following workspace dependencies were updated
-  - dependencies
-    - @waku/interfaces bumped from 0.0.8 to 0.0.9
+* The following workspace dependencies were updated
+  * dependencies
+    * @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.11](https://github.com/waku-org/js-waku/compare/core-v0.0.10...core-v0.0.11) (2023-03-16)
 
+
 ### ⚠ BREAKING CHANGES
 
-- add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
-- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-- enable encoding of `meta` field
-- expose pubsub topic in `IDecodedMessage`
-- update store.proto
-- update message.proto: payload and content topic are always defined
-- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
-- bump typescript
-- bump all prod dependencies
-- bump libp2p dependencies
+* add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
+* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+* enable encoding of `meta` field
+* expose pubsub topic in `IDecodedMessage`
+* update store.proto
+* update message.proto: payload and content topic are always defined
+* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
+* bump typescript
+* bump all prod dependencies
+* bump libp2p dependencies
 
 ### Features
 
-- Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
-- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
-- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-- Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
-- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-- **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
+* Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
+* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
+* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+* Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
+* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
+* **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
+
 
 ### Bug Fixes
 
-- Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
-- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
+* Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
+* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
+
 
 ### Miscellaneous Chores
 
-- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
+* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
+
 
 ### Dependencies
 
-- The following workspace dependencies were updated
-  - dependencies
-    - @waku/interfaces bumped from \* to 0.0.8
-    - @waku/proto bumped from \* to 0.0.3
-    - @waku/utils bumped from \* to 0.0.2
+* The following workspace dependencies were updated
+  * dependencies
+    * @waku/interfaces bumped from * to 0.0.8
+    * @waku/proto bumped from * to 0.0.3
+    * @waku/utils bumped from * to 0.0.2
 
 ## [Unreleased]
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,93 +7,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.14](https://www.npmjs.com/package/@waku/core/v/0.0.14) (2023-03-29)
 
-Wrong publish.
+Was published by mistake and does not contain valid code.
 
 ## [0.0.13](https://github.com/waku-org/js-waku/compare/core-v0.0.12...core-v0.0.13) (2023-03-24)
 
 ### Bug Fixes
 
-* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
-
+- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
-    * @waku/proto bumped from 0.0.3 to 0.0.4
-    * @waku/utils bumped from 0.0.2 to 0.0.3
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
+    - @waku/proto bumped from 0.0.3 to 0.0.4
+    - @waku/utils bumped from 0.0.2 to 0.0.3
 
 ## [0.0.12](https://github.com/waku-org/js-waku/compare/core-v0.0.11...core-v0.0.12) (2023-03-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
+- use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
 
 ### Features
 
-* Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
-* Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
-
+- Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
+- Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.11](https://github.com/waku-org/js-waku/compare/core-v0.0.10...core-v0.0.11) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
-* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-* enable encoding of `meta` field
-* expose pubsub topic in `IDecodedMessage`
-* update store.proto
-* update message.proto: payload and content topic are always defined
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
-* bump typescript
-* bump all prod dependencies
-* bump libp2p dependencies
+- add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
+- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+- enable encoding of `meta` field
+- expose pubsub topic in `IDecodedMessage`
+- update store.proto
+- update message.proto: payload and content topic are always defined
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
+- bump typescript
+- bump all prod dependencies
+- bump libp2p dependencies
 
 ### Features
 
-* Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
-* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
-* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-* Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
-* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-* **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
-
+- Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
+- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
+- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+- Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
+- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
+- **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
 
 ### Bug Fixes
 
-* Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
-
+- Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
 
 ### Miscellaneous Chores
 
-* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
-
+- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from * to 0.0.8
-    * @waku/proto bumped from * to 0.0.3
-    * @waku/utils bumped from * to 0.0.2
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from \* to 0.0.8
+    - @waku/proto bumped from \* to 0.0.3
+    - @waku/utils bumped from \* to 0.0.2
 
 ## [Unreleased]
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -17,80 +17,87 @@ Was published by mistake and does not contain valid code.
 
 ### Bug Fixes
 
-- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
+* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
+
 
 ### Dependencies
 
-- The following workspace dependencies were updated
-  - dependencies
-    - @waku/interfaces bumped from 0.0.9 to 0.0.10
-    - @waku/proto bumped from 0.0.3 to 0.0.4
-    - @waku/utils bumped from 0.0.2 to 0.0.3
+* The following workspace dependencies were updated
+  * dependencies
+    * @waku/interfaces bumped from 0.0.9 to 0.0.10
+    * @waku/proto bumped from 0.0.3 to 0.0.4
+    * @waku/utils bumped from 0.0.2 to 0.0.3
 
 ## [0.0.12](https://github.com/waku-org/js-waku/compare/core-v0.0.11...core-v0.0.12) (2023-03-23)
 
+
 ### ⚠ BREAKING CHANGES
 
-- use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
+* use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
 
 ### Features
 
-- Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
-- Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
+* Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
+* Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
+
 
 ### Dependencies
 
-- The following workspace dependencies were updated
-  - dependencies
-    - @waku/interfaces bumped from 0.0.8 to 0.0.9
+* The following workspace dependencies were updated
+  * dependencies
+    * @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.11](https://github.com/waku-org/js-waku/compare/core-v0.0.10...core-v0.0.11) (2023-03-16)
 
+
 ### ⚠ BREAKING CHANGES
 
-- add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
-- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-- enable encoding of `meta` field
-- expose pubsub topic in `IDecodedMessage`
-- update store.proto
-- update message.proto: payload and content topic are always defined
-- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
-- bump typescript
-- bump all prod dependencies
-- bump libp2p dependencies
+* add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
+* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+* enable encoding of `meta` field
+* expose pubsub topic in `IDecodedMessage`
+* update store.proto
+* update message.proto: payload and content topic are always defined
+* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
+* bump typescript
+* bump all prod dependencies
+* bump libp2p dependencies
 
 ### Features
 
-- Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
-- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
-- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-- Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
-- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-- **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
+* Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
+* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
+* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+* Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
+* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
+* **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
+
 
 ### Bug Fixes
 
-- Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
-- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
+* Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
+* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
+
 
 ### Miscellaneous Chores
 
-- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
+* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
+
 
 ### Dependencies
 
-- The following workspace dependencies were updated
-  - dependencies
-    - @waku/interfaces bumped from \* to 0.0.8
-    - @waku/proto bumped from \* to 0.0.3
-    - @waku/utils bumped from \* to 0.0.2
+* The following workspace dependencies were updated
+  * dependencies
+    * @waku/interfaces bumped from * to 0.0.8
+    * @waku/proto bumped from * to 0.0.3
+    * @waku/utils bumped from * to 0.0.2
 
 ## [Unreleased]
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,92 +5,88 @@ All notable changes to this project will be documented in this file.
 The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.13](https://github.com/waku-org/js-waku/compare/core-v0.0.12...core-v0.0.13) (2023-03-24)
+## [0.0.14](https://www.npmjs.com/package/@waku/core/v/0.0.14) (2023-03-29)
 
+Wrong publish.
+
+## [0.0.13](https://github.com/waku-org/js-waku/compare/core-v0.0.12...core-v0.0.13) (2023-03-24)
 
 ### Bug Fixes
 
-* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
-
+- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
-    * @waku/proto bumped from 0.0.3 to 0.0.4
-    * @waku/utils bumped from 0.0.2 to 0.0.3
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
+    - @waku/proto bumped from 0.0.3 to 0.0.4
+    - @waku/utils bumped from 0.0.2 to 0.0.3
 
 ## [0.0.12](https://github.com/waku-org/js-waku/compare/core-v0.0.11...core-v0.0.12) (2023-03-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
+- use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
 
 ### Features
 
-* Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
-* Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
-
+- Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
+- Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.11](https://github.com/waku-org/js-waku/compare/core-v0.0.10...core-v0.0.11) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
-* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-* enable encoding of `meta` field
-* expose pubsub topic in `IDecodedMessage`
-* update store.proto
-* update message.proto: payload and content topic are always defined
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
-* bump typescript
-* bump all prod dependencies
-* bump libp2p dependencies
+- add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
+- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+- enable encoding of `meta` field
+- expose pubsub topic in `IDecodedMessage`
+- update store.proto
+- update message.proto: payload and content topic are always defined
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
+- bump typescript
+- bump all prod dependencies
+- bump libp2p dependencies
 
 ### Features
 
-* Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
-* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
-* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-* Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
-* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-* **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
-
+- Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
+- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
+- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+- Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
+- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
+- **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
 
 ### Bug Fixes
 
-* Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
-
+- Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
 
 ### Miscellaneous Chores
 
-* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
-
+- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from * to 0.0.8
-    * @waku/proto bumped from * to 0.0.3
-    * @waku/utils bumped from * to 0.0.2
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from \* to 0.0.8
+    - @waku/proto bumped from \* to 0.0.3
+    - @waku/utils bumped from \* to 0.0.2
 
 ## [Unreleased]
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -13,80 +13,87 @@ Wrong publish.
 
 ### Bug Fixes
 
-- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
+* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
+
 
 ### Dependencies
 
-- The following workspace dependencies were updated
-  - dependencies
-    - @waku/interfaces bumped from 0.0.9 to 0.0.10
-    - @waku/proto bumped from 0.0.3 to 0.0.4
-    - @waku/utils bumped from 0.0.2 to 0.0.3
+* The following workspace dependencies were updated
+  * dependencies
+    * @waku/interfaces bumped from 0.0.9 to 0.0.10
+    * @waku/proto bumped from 0.0.3 to 0.0.4
+    * @waku/utils bumped from 0.0.2 to 0.0.3
 
 ## [0.0.12](https://github.com/waku-org/js-waku/compare/core-v0.0.11...core-v0.0.12) (2023-03-23)
 
+
 ### ⚠ BREAKING CHANGES
 
-- use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
+* use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
 
 ### Features
 
-- Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
-- Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
+* Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
+* Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
+
 
 ### Dependencies
 
-- The following workspace dependencies were updated
-  - dependencies
-    - @waku/interfaces bumped from 0.0.8 to 0.0.9
+* The following workspace dependencies were updated
+  * dependencies
+    * @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.11](https://github.com/waku-org/js-waku/compare/core-v0.0.10...core-v0.0.11) (2023-03-16)
 
+
 ### ⚠ BREAKING CHANGES
 
-- add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
-- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-- enable encoding of `meta` field
-- expose pubsub topic in `IDecodedMessage`
-- update store.proto
-- update message.proto: payload and content topic are always defined
-- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
-- bump typescript
-- bump all prod dependencies
-- bump libp2p dependencies
+* add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
+* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+* enable encoding of `meta` field
+* expose pubsub topic in `IDecodedMessage`
+* update store.proto
+* update message.proto: payload and content topic are always defined
+* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
+* bump typescript
+* bump all prod dependencies
+* bump libp2p dependencies
 
 ### Features
 
-- Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
-- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
-- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-- Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
-- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-- **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
+* Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
+* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
+* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+* Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
+* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
+* **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
+
 
 ### Bug Fixes
 
-- Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
-- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
+* Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
+* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
+
 
 ### Miscellaneous Chores
 
-- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
+* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
+
 
 ### Dependencies
 
-- The following workspace dependencies were updated
-  - dependencies
-    - @waku/interfaces bumped from \* to 0.0.8
-    - @waku/proto bumped from \* to 0.0.3
-    - @waku/utils bumped from \* to 0.0.2
+* The following workspace dependencies were updated
+  * dependencies
+    * @waku/interfaces bumped from * to 0.0.8
+    * @waku/proto bumped from * to 0.0.3
+    * @waku/utils bumped from * to 0.0.2
 
 ## [Unreleased]
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,10 +5,6 @@ All notable changes to this project will be documented in this file.
 The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.15](https://www.npmjs.com/package/@waku/core/v/0.0.15) (2023-03-31)
-
-Published to replicate 0.0.13 to have correct latest version.
-
 ## [0.0.14](https://www.npmjs.com/package/@waku/core/v/0.0.14) (2023-03-29)
 
 Was published by mistake and does not contain valid code.
@@ -17,87 +13,80 @@ Was published by mistake and does not contain valid code.
 
 ### Bug Fixes
 
-* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
-
+- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
-    * @waku/proto bumped from 0.0.3 to 0.0.4
-    * @waku/utils bumped from 0.0.2 to 0.0.3
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
+    - @waku/proto bumped from 0.0.3 to 0.0.4
+    - @waku/utils bumped from 0.0.2 to 0.0.3
 
 ## [0.0.12](https://github.com/waku-org/js-waku/compare/core-v0.0.11...core-v0.0.12) (2023-03-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
+- use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
 
 ### Features
 
-* Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
-* Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
-
+- Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
+- Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.11](https://github.com/waku-org/js-waku/compare/core-v0.0.10...core-v0.0.11) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
-* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-* enable encoding of `meta` field
-* expose pubsub topic in `IDecodedMessage`
-* update store.proto
-* update message.proto: payload and content topic are always defined
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
-* bump typescript
-* bump all prod dependencies
-* bump libp2p dependencies
+- add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
+- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+- enable encoding of `meta` field
+- expose pubsub topic in `IDecodedMessage`
+- update store.proto
+- update message.proto: payload and content topic are always defined
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
+- bump typescript
+- bump all prod dependencies
+- bump libp2p dependencies
 
 ### Features
 
-* Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
-* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
-* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-* Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
-* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-* **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
-
+- Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
+- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
+- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+- Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
+- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
+- **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
 
 ### Bug Fixes
 
-* Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
-
+- Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
 
 ### Miscellaneous Chores
 
-* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
-
+- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from * to 0.0.8
-    * @waku/proto bumped from * to 0.0.3
-    * @waku/utils bumped from * to 0.0.2
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from \* to 0.0.8
+    - @waku/proto bumped from \* to 0.0.3
+    - @waku/utils bumped from \* to 0.0.2
 
 ## [Unreleased]
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The file is maintained by [Release Please](https://github.com/googleapis/release-please) based on [Conventional Commits](https://www.conventionalcommits.org) specification,
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.15](https://www.npmjs.com/package/@waku/core/v/0.0.15) (2023-03-31)
+
+Published to replicate 0.0.13 to have correct latest version.
+
 ## [0.0.14](https://www.npmjs.com/package/@waku/core/v/0.0.14) (2023-03-29)
 
 Was published by mistake and does not contain valid code.
@@ -13,87 +17,80 @@ Was published by mistake and does not contain valid code.
 
 ### Bug Fixes
 
-* **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
-
+- **utils:** Include all ts files ([#1267](https://github.com/waku-org/js-waku/issues/1267)) ([c284159](https://github.com/waku-org/js-waku/commit/c284159ac8eab5bed2313fa5bc7fbea0e83d390f))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.9 to 0.0.10
-    * @waku/proto bumped from 0.0.3 to 0.0.4
-    * @waku/utils bumped from 0.0.2 to 0.0.3
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.9 to 0.0.10
+    - @waku/proto bumped from 0.0.3 to 0.0.4
+    - @waku/utils bumped from 0.0.2 to 0.0.3
 
 ## [0.0.12](https://github.com/waku-org/js-waku/compare/core-v0.0.11...core-v0.0.12) (2023-03-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
+- use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217))
 
 ### Features
 
-* Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
-* Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
-
+- Add getActiveSubscriptions method ([#1249](https://github.com/waku-org/js-waku/issues/1249)) ([45284db](https://github.com/waku-org/js-waku/commit/45284db963d6d4c90a014391551604c236906b88))
+- Use ISender and deprecate Light Push .push ([#1217](https://github.com/waku-org/js-waku/issues/1217)) ([0f6a594](https://github.com/waku-org/js-waku/commit/0f6a59464426b94dd14841de075ff10a4ad52e33))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from 0.0.8 to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from 0.0.8 to 0.0.9
 
 ## [0.0.11](https://github.com/waku-org/js-waku/compare/core-v0.0.10...core-v0.0.11) (2023-03-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
-* add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
-* enable encoding of `meta` field
-* expose pubsub topic in `IDecodedMessage`
-* update store.proto
-* update message.proto: payload and content topic are always defined
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
-* bump typescript
-* bump all prod dependencies
-* bump libp2p dependencies
+- add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213))
+- add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201))
+- enable encoding of `meta` field
+- expose pubsub topic in `IDecodedMessage`
+- update store.proto
+- update message.proto: payload and content topic are always defined
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135))
+- bump typescript
+- bump all prod dependencies
+- bump libp2p dependencies
 
 ### Features
 
-* Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
-* Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
-* ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
-* Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
-* Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
-* Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
-* **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
-
+- Add custom events to Relay and make observers private ([#1213](https://github.com/waku-org/js-waku/issues/1213)) ([275b166](https://github.com/waku-org/js-waku/commit/275b16641e620956a5f8ebbb3a8c4156149d489e))
+- Codec as a property of the protocol implementations ([a5ff788](https://github.com/waku-org/js-waku/commit/a5ff788eed419556e11319f22ca9e3109c81df92))
+- ConnectionManager and KeepAliveManager ([#1135](https://github.com/waku-org/js-waku/issues/1135)) ([24c24cc](https://github.com/waku-org/js-waku/commit/24c24cc27d83ec12de45ef3cf3d00f6eb817e4ca))
+- Enable encoding of `meta` field ([bd983ea](https://github.com/waku-org/js-waku/commit/bd983ea48ee73fda5a7137d5ef681965aeabb4a5))
+- Export `Decoder`, `Encoder` and `DecodedMessage` types from root ([da1b18d](https://github.com/waku-org/js-waku/commit/da1b18d9956259af4cb2e6f7c1f06de52b6ec3ac)), closes [#1010](https://github.com/waku-org/js-waku/issues/1010)
+- Expose pubsub topic in `IDecodedMessage` ([628ac50](https://github.com/waku-org/js-waku/commit/628ac50d7104ec3c1dff44db58077a85db6b6aa1)), closes [#1208](https://github.com/waku-org/js-waku/issues/1208)
+- **relay:** Validate waku message at gossip layer ([9684737](https://github.com/waku-org/js-waku/commit/96847374d6c61f3372a16185d9fff93e582505bb))
 
 ### Bug Fixes
 
-* Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
-* Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
-* Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
-
+- Add payload to relay ping messages to avoid poor relay peer scoring ([560c393](https://github.com/waku-org/js-waku/commit/560c39366259f9902cac7f2afd0d301c49e13f4c))
+- Prettier and cspell ignore CHANGELOG ([#1235](https://github.com/waku-org/js-waku/issues/1235)) ([4d7b3e3](https://github.com/waku-org/js-waku/commit/4d7b3e39e6761afaf5d05a13cc4b3c23e15f9bd5))
+- Remove initialising peer-exchange while creating a node ([#1158](https://github.com/waku-org/js-waku/issues/1158)) ([1b41569](https://github.com/waku-org/js-waku/commit/1b4156902387ea35b24b3d6f5d22e4635ea8cf18))
 
 ### Miscellaneous Chores
 
-* Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
-* Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
-* Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
-* Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
-* Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
-* Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
-
+- Add exports map to @waku/utils ([#1201](https://github.com/waku-org/js-waku/issues/1201)) ([a30b2bd](https://github.com/waku-org/js-waku/commit/a30b2bd747dedeef69b46cfafb88898ba35d8f67))
+- Bump all prod dependencies ([88cc76d](https://github.com/waku-org/js-waku/commit/88cc76d2b811e1fa4460207f38704ecfe18fb260))
+- Bump libp2p dependencies ([803ae7b](https://github.com/waku-org/js-waku/commit/803ae7bd8ed3de665026446c23cde90e7eba9d36))
+- Bump typescript ([12d86e6](https://github.com/waku-org/js-waku/commit/12d86e6abcc68e27c39ca86b4f0dc2b68cdd6000))
+- Update message.proto: payload and content topic are always defined ([5cf8ed2](https://github.com/waku-org/js-waku/commit/5cf8ed2030c9efbc4c4b66aa801827482c1e4249))
+- Update store.proto ([967e6ff](https://github.com/waku-org/js-waku/commit/967e6ffc7ec6f780094e29599c47b723fa222dcc))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @waku/interfaces bumped from * to 0.0.8
-    * @waku/proto bumped from * to 0.0.3
-    * @waku/utils bumped from * to 0.0.2
+- The following workspace dependencies were updated
+  - dependencies
+    - @waku/interfaces bumped from \* to 0.0.8
+    - @waku/proto bumped from \* to 0.0.3
+    - @waku/utils bumped from \* to 0.0.2
 
 ## [Unreleased]
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waku/core",
-  "version": "0.0.15",
+  "version": "0.0.14",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waku/core",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waku/core",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -53,7 +53,7 @@
     "@chainsafe/libp2p-noise": "^11.0.0",
     "@libp2p/mplex": "^7.1.1",
     "@libp2p/websockets": "^5.0.3",
-    "@waku/core": "0.0.13",
+    "@waku/core": "0.0.14",
     "@waku/dns-discovery": "0.0.9",
     "libp2p": "^0.42.2"
   },

--- a/packages/message-encryption/package.json
+++ b/packages/message-encryption/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.7.1",
-    "@waku/core": "0.0.13",
+    "@waku/core": "0.0.14",
     "@waku/interfaces": "0.0.10",
     "@waku/proto": "0.0.4",
     "@waku/utils": "0.0.3",

--- a/packages/peer-exchange/package.json
+++ b/packages/peer-exchange/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@libp2p/interface-peer-discovery": "^1.0.5",
     "@libp2p/interfaces": "^3.3.1",
-    "@waku/core": "0.0.13",
+    "@waku/core": "0.0.14",
     "@waku/enr": "0.0.9",
     "@waku/proto": "0.0.4",
     "@waku/utils": "0.0.3",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@libp2p/peer-id": "^2.0.2",
-    "@waku/core": "*",
+    "@waku/core": "0.0.15",
     "@waku/enr": "*",
     "@waku/interfaces": "*",
     "@waku/utils": "*",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@libp2p/peer-id": "^2.0.2",
-    "@waku/core": "0.0.15",
+    "@waku/core": "0.0.14",
     "@waku/enr": "*",
     "@waku/interfaces": "*",
     "@waku/utils": "*",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@libp2p/peer-id": "^2.0.2",
-    "@waku/core": "0.0.14",
+    "@waku/core": "*",
     "@waku/enr": "*",
     "@waku/interfaces": "*",
     "@waku/utils": "*",


### PR DESCRIPTION
## Problem

Because of a wrong publish of `@waku/core` I caused the next version should be skipped.

## Solution

Manually bump it's value in the repo.
