### PR TITLE
fix: diplay workspace name & disable no-console for .js/.cjs files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,7 +53,7 @@
   },
   "overrides": [
     {
-      "files": ["*.spec.ts", "**/test_utils/*.ts"],
+      "files": ["*.spec.ts", "**/test_utils/*.ts", "*.js", "*.cjs"],
       "rules": {
         "@typescript-eslint/no-non-null-assertion": "off",
         "no-console": "off"

--- a/ci/publish.js
+++ b/ci/publish.js
@@ -1,8 +1,8 @@
+import cp from "child_process";
 import fs from "fs";
 import path from "path";
-import cp from "child_process";
-import { promisify } from "util";
 import { fileURLToPath } from "url";
+import { promisify } from "util";
 
 const PACKAGE_JSON = "package.json";
 // hack to get __dirname
@@ -45,7 +45,7 @@ async function run() {
             `npm publish --workspace ${info.workspace} --tag latest --access public`
           );
           console.info(
-            `Successfully published ${info.name} with version ${info.version}.`
+            `Successfully published ${info.workspace} with version ${info.version}.`
           );
         } catch (err) {
           console.error(


### PR DESCRIPTION
## Problem

- Reading wrong field while trying to display workspace's name.
- ESlint prevents us to use `console.*` in servicing files. 

## Solution

- Read correct property
- Disable the rule for `.js` and `.cjs`.

