### PR TITLE
feat!: ensure content topic is defined

### DIFF
--- a/packages/core/src/lib/message/version_0.spec.ts
+++ b/packages/core/src/lib/message/version_0.spec.ts
@@ -8,8 +8,8 @@ describe("Waku Message version 0", function () {
   it("Round trip binary serialization", async function () {
     await fc.assert(
       fc.asyncProperty(
-        fc.string(),
-        fc.string(),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
         fc.uint8Array({ minLength: 1 }),
         async (contentTopic, pubSubTopic, payload) => {
           const encoder = createEncoder({
@@ -37,8 +37,8 @@ describe("Waku Message version 0", function () {
   it("Ephemeral field set to true", async function () {
     await fc.assert(
       fc.asyncProperty(
-        fc.string(),
-        fc.string(),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
         fc.uint8Array({ minLength: 1 }),
         async (contentTopic, pubSubTopic, payload) => {
           const encoder = createEncoder({
@@ -62,8 +62,8 @@ describe("Waku Message version 0", function () {
   it("Meta field set when metaSetter is specified", async function () {
     await fc.assert(
       fc.asyncProperty(
-        fc.string(),
-        fc.string(),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
         fc.uint8Array({ minLength: 1 }),
         async (contentTopic, pubSubTopic, payload) => {
           // Encode the length of the payload
@@ -104,5 +104,36 @@ describe("Waku Message version 0", function () {
         }
       )
     );
+  });
+});
+
+describe("Ensures content topic is defined", () => {
+  it("Encoder throws on undefined content topic", () => {
+    const wrapper = function (): void {
+      createEncoder({ contentTopic: undefined as unknown as string });
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
+  });
+  it("Encoder throws on empty string content topic", () => {
+    const wrapper = function (): void {
+      createEncoder({ contentTopic: "" });
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
+  });
+  it("Decoder throws on undefined content topic", () => {
+    const wrapper = function (): void {
+      createDecoder(undefined as unknown as string);
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
+  });
+  it("Decoder throws on empty string content topic", () => {
+    const wrapper = function (): void {
+      createDecoder("");
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
   });
 });

--- a/packages/core/src/lib/message/version_0.ts
+++ b/packages/core/src/lib/message/version_0.ts
@@ -71,7 +71,11 @@ export class Encoder implements IEncoder {
     public contentTopic: string,
     public ephemeral: boolean = false,
     public metaSetter?: IMetaSetter
-  ) {}
+  ) {
+    if (!contentTopic || contentTopic === "") {
+      throw new Error("Content topic must be specified");
+    }
+  }
 
   async toWire(message: IMessage): Promise<Uint8Array> {
     return proto.WakuMessage.encode(await this.toProtoObj(message));
@@ -117,7 +121,11 @@ export function createEncoder({
 }
 
 export class Decoder implements IDecoder<DecodedMessage> {
-  constructor(public contentTopic: string) {}
+  constructor(public contentTopic: string) {
+    if (!contentTopic || contentTopic === "") {
+      throw new Error("Content topic must be specified");
+    }
+  }
 
   fromWireToProtoObj(bytes: Uint8Array): Promise<IProtoMessage | undefined> {
     const protoMessage = proto.WakuMessage.decode(bytes);

--- a/packages/message-encryption/src/ecies.spec.ts
+++ b/packages/message-encryption/src/ecies.spec.ts
@@ -9,8 +9,8 @@ describe("Ecies Encryption", function () {
   it("Round trip binary encryption [ecies, no signature]", async function () {
     await fc.assert(
       fc.asyncProperty(
-        fc.string(),
-        fc.string(),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
         async (pubSubTopic, contentTopic, payload, privateKey) => {
@@ -44,8 +44,8 @@ describe("Ecies Encryption", function () {
 
     await fc.assert(
       fc.asyncProperty(
-        fc.string(),
-        fc.string(),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
@@ -86,8 +86,8 @@ describe("Ecies Encryption", function () {
   it("Check meta is set [ecies]", async function () {
     await fc.assert(
       fc.asyncProperty(
-        fc.string(),
-        fc.string(),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
         async (pubSubTopic, contentTopic, payload, privateKey) => {
@@ -128,5 +128,39 @@ describe("Ecies Encryption", function () {
         }
       )
     );
+  });
+});
+
+describe("Ensures content topic is defined", () => {
+  it("Encoder throws on undefined content topic", () => {
+    const wrapper = function (): void {
+      createEncoder({
+        contentTopic: undefined as unknown as string,
+        publicKey: new Uint8Array(),
+      });
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
+  });
+  it("Encoder throws on empty string content topic", () => {
+    const wrapper = function (): void {
+      createEncoder({ contentTopic: "", publicKey: new Uint8Array() });
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
+  });
+  it("Decoder throws on undefined content topic", () => {
+    const wrapper = function (): void {
+      createDecoder(undefined as unknown as string, new Uint8Array());
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
+  });
+  it("Decoder throws on empty string content topic", () => {
+    const wrapper = function (): void {
+      createDecoder("", new Uint8Array());
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
   });
 });

--- a/packages/message-encryption/src/ecies.ts
+++ b/packages/message-encryption/src/ecies.ts
@@ -37,7 +37,11 @@ class Encoder implements IEncoder {
     private sigPrivKey?: Uint8Array,
     public ephemeral: boolean = false,
     public metaSetter?: IMetaSetter
-  ) {}
+  ) {
+    if (!contentTopic || contentTopic === "") {
+      throw new Error("Content topic must be specified");
+    }
+  }
 
   async toWire(message: IMessage): Promise<Uint8Array | undefined> {
     const protoMessage = await this.toProtoObj(message);

--- a/packages/message-encryption/src/symmetric.spec.ts
+++ b/packages/message-encryption/src/symmetric.spec.ts
@@ -9,8 +9,8 @@ describe("Symmetric Encryption", function () {
   it("Round trip binary encryption [symmetric, no signature]", async function () {
     await fc.assert(
       fc.asyncProperty(
-        fc.string(),
-        fc.string(),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
         async (pubSubTopic, contentTopic, payload, symKey) => {
@@ -40,8 +40,8 @@ describe("Symmetric Encryption", function () {
   it("Round trip binary encryption [symmetric, signature]", async function () {
     await fc.assert(
       fc.asyncProperty(
-        fc.string(),
-        fc.string(),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
@@ -75,8 +75,8 @@ describe("Symmetric Encryption", function () {
   it("Check meta is set [symmetric]", async function () {
     await fc.assert(
       fc.asyncProperty(
-        fc.string(),
-        fc.string(),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ min: 1, minLength: 32, maxLength: 32 }),
         async (pubSubTopic, contentTopic, payload, symKey) => {
@@ -116,5 +116,39 @@ describe("Symmetric Encryption", function () {
         }
       )
     );
+  });
+});
+
+describe("Ensures content topic is defined", () => {
+  it("Encoder throws on undefined content topic", () => {
+    const wrapper = function (): void {
+      createEncoder({
+        contentTopic: undefined as unknown as string,
+        symKey: new Uint8Array(),
+      });
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
+  });
+  it("Encoder throws on empty string content topic", () => {
+    const wrapper = function (): void {
+      createEncoder({ contentTopic: "", symKey: new Uint8Array() });
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
+  });
+  it("Decoder throws on undefined content topic", () => {
+    const wrapper = function (): void {
+      createDecoder(undefined as unknown as string, new Uint8Array());
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
+  });
+  it("Decoder throws on empty string content topic", () => {
+    const wrapper = function (): void {
+      createDecoder("", new Uint8Array());
+    };
+
+    expect(wrapper).to.throw("Content topic must be specified");
   });
 });

--- a/packages/message-encryption/src/symmetric.ts
+++ b/packages/message-encryption/src/symmetric.ts
@@ -32,7 +32,11 @@ class Encoder implements IEncoder {
     private sigPrivKey?: Uint8Array,
     public ephemeral: boolean = false,
     public metaSetter?: IMetaSetter
-  ) {}
+  ) {
+    if (!contentTopic || contentTopic === "") {
+      throw new Error("Content topic must be specified");
+    }
+  }
 
   async toWire(message: IMessage): Promise<Uint8Array | undefined> {
     const protoMessage = await this.toProtoObj(message);


### PR DESCRIPTION
Waku Messages are considered invalid if the content topic is undefined or an empty string.

Avoid user error by throwing.