### PR TITLE
feat: add mapping function to multiaddr of peerid

### DIFF
--- a/packages/core/src/lib/waku.ts
+++ b/packages/core/src/lib/waku.ts
@@ -1,4 +1,3 @@
-import { multicodec } from "@chainsafe/libp2p-gossipsub";
 import type { Stream } from "@libp2p/interface-connection";
 import type { Libp2p } from "@libp2p/interface-libp2p";
 import type { PeerId } from "@libp2p/interface-peer-id";


### PR DESCRIPTION
## Problem

In new version of `@libp2p` they removed internal mapping from string to `Multiaddr` 

## Solution

Create transform function on our side and update types.
