### PR TITLE
feat: use sha256 for Relay msgIdFn

### DIFF
--- a/packages/core/src/lib/relay/index.ts
+++ b/packages/core/src/lib/relay/index.ts
@@ -8,6 +8,7 @@ import type { PeerIdStr, TopicStr } from "@chainsafe/libp2p-gossipsub/types";
 import { SignaturePolicy } from "@chainsafe/libp2p-gossipsub/types";
 import type { Libp2p } from "@libp2p/interface-libp2p";
 import type { PubSub } from "@libp2p/interface-pubsub";
+import { sha256 } from "@noble/hashes/sha256";
 import type {
   ActiveSubscriptions,
   Callback,
@@ -228,6 +229,7 @@ export function wakuGossipSub(
   return (components: GossipSubComponents) => {
     init = {
       ...init,
+      msgIdFn: ({ data }) => sha256(data),
       // Ensure that no signature is included nor expected in the messages.
       globalSignaturePolicy: SignaturePolicy.StrictNoSign,
       fallbackToFloodsub: false,


### PR DESCRIPTION
## Problem

There is an assumption that `StrictNoSign` messages always have `msgId` generated by `sha256`.

## Solution

To reduce potential problems explicitly define `msgIdFn` and pass to `GossipSub`.

## Notes

- Resolves https://github.com/waku-org/js-waku/issues/1179
