### PR TITLE
feat: expose `meta` on `IDecodedMessage`

### DIFF
--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -65,6 +65,7 @@ export interface IDecodedMessage {
   timestamp: Date | undefined;
   rateLimitProof: IRateLimitProof | undefined;
   ephemeral: boolean | undefined;
+  meta: Uint8Array | undefined;
 }
 
 export interface IDecoder<T extends IDecodedMessage> {


### PR DESCRIPTION
Decoders are expected to expose this field in their return type. Somehow missed in previous PRs.