### PR TITLE
chore: update ecmascript version

### DIFF
--- a/packages/core/src/lib/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager.ts
@@ -103,8 +103,10 @@ export class ConnectionManager {
 
         this.dialAttemptsForPeer.delete(peerId.toString());
         return;
-      } catch (error: any) {
+      } catch (e) {
+        const error = e as AggregateError;
         this.dialErrorsForPeer.set(peerId.toString(), error);
+
         log(`Error dialing peer ${peerId.toString()} - ${error.errors}`);
 
         dialAttempt = this.dialAttemptsForPeer.get(peerId.toString()) ?? 1;

--- a/packages/core/src/lib/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager.ts
@@ -106,7 +106,6 @@ export class ConnectionManager {
       } catch (e) {
         const error = e as AggregateError;
         this.dialErrorsForPeer.set(peerId.toString(), error);
-
         log(`Error dialing peer ${peerId.toString()} - ${error.errors}`);
 
         dialAttempt = this.dialAttemptsForPeer.get(peerId.toString()) ?? 1;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "incremental": true,
-    "target": "es2020",
+    "target": "ES2022",
     "moduleResolution": "node16",
-    "module": "es2020",
+    "module": "ES2022",
     "declaration": true,
     "sourceMap": true,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
@@ -38,7 +38,7 @@
     // "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
     // "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
 
-    "lib": ["es2020", "dom"],
+    "lib": ["es2022", "dom"],
     "types": ["node", "mocha"],
     "typeRoots": ["node_modules/@types"]
   },


### PR DESCRIPTION
## Problem

Recommendation to bump tsconfig to ES2022 to introduce AggregateError types.

## Solution

- Updates version in tsconfig to ES2022
- Casts `any` to `AggregateError` related to https://github.com/waku-org/js-waku/pull/1303#discussion_r1176799058

## Notes

- Resolves #1325
