### PR TITLE
chore: add iterator timeout

### DIFF
--- a/packages/tests/tests/utils.spec.ts
+++ b/packages/tests/tests/utils.spec.ts
@@ -48,7 +48,12 @@ describe("Util: toAsyncIterator", () => {
     const messageText = "hey, what's up?";
     const sent = { payload: utf8ToBytes(messageText) };
 
-    const { iterator } = await toAsyncIterator(waku.filter, TestDecoder);
+    const { iterator } = await toAsyncIterator(
+      waku.filter,
+      TestDecoder,
+      {},
+      { timeoutMs: 1000 }
+    );
 
     await waku.lightPush.send(TestEncoder, sent);
     const { value } = await iterator.next();
@@ -60,7 +65,12 @@ describe("Util: toAsyncIterator", () => {
 
   it("handles multiple messages", async function () {
     this.timeout(10000);
-    const { iterator } = await toAsyncIterator(waku.filter, TestDecoder);
+    const { iterator } = await toAsyncIterator(
+      waku.filter,
+      TestDecoder,
+      {},
+      { timeoutMs: 1000 }
+    );
 
     await waku.lightPush.send(TestEncoder, {
       payload: utf8ToBytes("Filtering works!"),
@@ -78,7 +88,12 @@ describe("Util: toAsyncIterator", () => {
 
   it("unsubscribes", async function () {
     this.timeout(10000);
-    const { iterator, stop } = await toAsyncIterator(waku.filter, TestDecoder);
+    const { iterator, stop } = await toAsyncIterator(
+      waku.filter,
+      TestDecoder,
+      {},
+      { timeoutMs: 1000 }
+    );
 
     await waku.lightPush.send(TestEncoder, {
       payload: utf8ToBytes("This should be received"),

--- a/packages/utils/src/common/to_async_iterator.ts
+++ b/packages/utils/src/common/to_async_iterator.ts
@@ -38,6 +38,8 @@ export async function toAsyncIterator<T extends IDecodedMessage>(
         return;
       }
 
+      await wait(60);
+
       const message = messages.shift() as T;
 
       if (!unsubscribe && messages.length === 0) {
@@ -61,4 +63,10 @@ export async function toAsyncIterator<T extends IDecodedMessage>(
       }
     },
   };
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }

--- a/packages/utils/src/common/to_async_iterator.ts
+++ b/packages/utils/src/common/to_async_iterator.ts
@@ -9,14 +9,27 @@ import type {
 
 type IteratorOptions = {
   timeoutMs?: number;
+  iteratorDelay?: number;
 };
 
+const FRAME_RATE = 60;
+
+/**
+ * Function that transforms IReceiver subscription to iterable stream of data.
+ * @param receiver - object that allows to be subscribed to;
+ * @param decoder - parameter to be passed to receiver for subscription;
+ * @param options - options for receiver for subscription;
+ * @param iteratorOptions - optional configuration for iterator;
+ * @returns iterator and stop function to terminate it.
+ */
 export async function toAsyncIterator<T extends IDecodedMessage>(
   receiver: IReceiver,
   decoder: IDecoder<T> | IDecoder<T>[],
   options?: ProtocolOptions,
   iteratorOptions?: IteratorOptions
 ): Promise<IAsyncIterator<T>> {
+  const iteratorDelay = iteratorOptions?.iteratorDelay ?? FRAME_RATE;
+
   const messages: T[] = [];
 
   let unsubscribe: undefined | Unsubscribe;
@@ -38,7 +51,7 @@ export async function toAsyncIterator<T extends IDecodedMessage>(
         return;
       }
 
-      await wait(60);
+      await wait(iteratorDelay);
 
       const message = messages.shift() as T;
 


### PR DESCRIPTION
## Problem

Because iterator is using `while true` inside it is not getting terminated by `mocha` timeouts in local and sometime in pipeline environment.
It also is capable of blocking the main thread.

## Solution

Add options to configure timeout.
Add idle state to the generator.

