### PR TITLE
chore: remove forced relay version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,8 +16,6 @@
     "packages/dns-discovery": {},
     "packages/message-encryption": {},
     "packages/create": {},
-    "packages/relay": {
-      "release-as": "0.0.1"
-    }
+    "packages/relay": {}
   }
 }


### PR DESCRIPTION
## Problem

Had to apply fix to force `release-please` to release `relay` package as `0.0.1`.

## Solution

Remove enforcement. 

https://github.com/waku-org/js-waku/pull/1366