### PR TITLE
feat: dial multiple peers in parallel

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -50,8 +50,6 @@
     "ihave",
     "ihaves",
     "ineed",
-    "initalised",
-    "initialisation",
     "IPAM",
     "ipfs",
     "iwant",

--- a/.cspell.json
+++ b/.cspell.json
@@ -50,6 +50,8 @@
     "ihave",
     "ihaves",
     "ineed",
+    "initalised",
+    "initialisation",
     "IPAM",
     "ipfs",
     "iwant",

--- a/packages/core/src/lib/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager.ts
@@ -66,8 +66,8 @@ export class ConnectionManager {
       .then(() => log(`Connection Manager is now running`))
       .catch((error) => log(`Unexpected error while running service`, error));
 
-    // libp2p emits `peer:discovery` events during its initialisation
-    // which means that before the ConnectionManager is initalised, some peers may have been discovered
+    // libp2p emits `peer:discovery` events during its initialization
+    // which means that before the ConnectionManager is initialized, some peers may have been discovered
     // we will dial the peers in peerStore ONCE before we start to listen to the `peer:discovery` events within the ConnectionManager
     this.dialPeerStorePeers();
   }

--- a/packages/interfaces/src/connection_manager.ts
+++ b/packages/interfaces/src/connection_manager.ts
@@ -14,4 +14,8 @@ export interface ConnectionManagerOptions {
    * This is used to increase intention of dialing non-bootstrap peers, found using other discovery mechanisms (like Peer Exchange)
    */
   maxBootstrapPeersAllowed: number;
+  /**
+   * Max number of parallel dials allowed
+   */
+  maxParallelDials: number;
 }


### PR DESCRIPTION
## Problem

This PR addresses point 2 & point 3 of https://github.com/waku-org/js-waku/issues/1326


## Solution

- multiple discovered peers are dialed in parallel until max limit is reached
- connection to a bootstrap peer is dropped if more than >set bootstrap connections are formed

## Notes
- https://github.com/waku-org/js-waku/pull/1379 should be merged first


