### PR TITLE
chore: remove forced release version of sdk

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,9 +15,7 @@
     "packages/core": {},
     "packages/dns-discovery": {},
     "packages/message-encryption": {},
-    "packages/sdk": {
-      "release-as": "0.0.16"
-    },
+    "packages/sdk": {},
     "packages/relay": {}
   }
 }


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->
In order to release `@waku/sdk` as `0.0.16` enforced version was used.

## Solution

Remove forced version

## Notes

- Related to #1353
