### PR TITLE
chore: add js-waku-developers as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @waku/js-waku-developers
+*       @waku-org/js-waku-developers 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @fryorcraken
+*       @waku/js-waku-developers


### PR DESCRIPTION
## Problem

@fryorcraken is the reviewer by default and folks should add others manually

## Solution

use @waku-org/js-waku-developers as code owner
