### PR TITLE
chore: dispatch events for unknown discovery

### DIFF
--- a/packages/core/src/lib/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager.ts
@@ -317,12 +317,18 @@ export class ConnectionManager
         const isBootstrap = (await this.getTagNamesForPeer(peerId)).includes(
           Tags.BOOTSTRAP
         );
+        const isPeerExchange = (await this.getTagNamesForPeer(peerId)).includes(
+          Tags.PEER_EXCHANGE
+        );
 
         this.dispatchEvent(
           new CustomEvent<PeerId>(
             isBootstrap
               ? EPeersByDiscoveryEvents.PEER_DISCOVERY_BOOTSTRAP
-              : EPeersByDiscoveryEvents.PEER_DISCOVERY_PEER_EXCHANGE,
+              : isPeerExchange
+              ? EPeersByDiscoveryEvents.PEER_DISCOVERY_PEER_EXCHANGE
+              : EPeersByDiscoveryEvents.PEER_DISCOVERY_UNKNOWN,
+
             {
               detail: peerId,
             }
@@ -346,6 +352,10 @@ export class ConnectionManager
           Tags.BOOTSTRAP
         );
 
+        const isPeerExchange = (await this.getTagNamesForPeer(peerId)).includes(
+          Tags.PEER_EXCHANGE
+        );
+
         if (isBootstrap) {
           const bootstrapConnections = this.libp2p
             .getConnections()
@@ -366,10 +376,19 @@ export class ConnectionManager
               )
             );
           }
-        } else {
+        } else if (isPeerExchange) {
           this.dispatchEvent(
             new CustomEvent<PeerId>(
               EPeersByDiscoveryEvents.PEER_CONNECT_PEER_EXCHANGE,
+              {
+                detail: peerId,
+              }
+            )
+          );
+        } else {
+          this.dispatchEvent(
+            new CustomEvent<PeerId>(
+              EPeersByDiscoveryEvents.PEER_CONNECT_UNKNOWN,
               {
                 detail: peerId,
               }

--- a/packages/interfaces/src/connection_manager.ts
+++ b/packages/interfaces/src/connection_manager.ts
@@ -27,15 +27,19 @@ export interface ConnectionManagerOptions {
 export enum EPeersByDiscoveryEvents {
   PEER_DISCOVERY_BOOTSTRAP = "peer:discovery:bootstrap",
   PEER_DISCOVERY_PEER_EXCHANGE = "peer:discovery:peer-exchange",
+  PEER_DISCOVERY_UNKNOWN = "peer:discovery:unknown",
   PEER_CONNECT_BOOTSTRAP = "peer:connected:bootstrap",
   PEER_CONNECT_PEER_EXCHANGE = "peer:connected:peer-exchange",
+  PEER_CONNECT_UNKNOWN = "peer:connected:unknown",
 }
 
 export interface IPeersByDiscoveryEvents {
   [EPeersByDiscoveryEvents.PEER_DISCOVERY_BOOTSTRAP]: CustomEvent<PeerId>;
   [EPeersByDiscoveryEvents.PEER_DISCOVERY_PEER_EXCHANGE]: CustomEvent<PeerId>;
+  [EPeersByDiscoveryEvents.PEER_DISCOVERY_UNKNOWN]: CustomEvent<PeerId>;
   [EPeersByDiscoveryEvents.PEER_CONNECT_BOOTSTRAP]: CustomEvent<PeerId>;
   [EPeersByDiscoveryEvents.PEER_CONNECT_PEER_EXCHANGE]: CustomEvent<PeerId>;
+  [EPeersByDiscoveryEvents.PEER_CONNECT_UNKNOWN]: CustomEvent<PeerId>;
 }
 
 export interface PeersByDiscoveryResult {


### PR DESCRIPTION
## Problem

Discovery events are being dispatched by the Connection Manager as:
```
if (bootstrap) dispatch(bootstrapEvent) else dispatch(peerExchange)
```

However, with work on https://github.com/orgs/waku-org/projects/2/views/1?pane=issue&itemId=27330364 [5], js-waku can "discover" nodes from the local storage from previous discoveries

## Solution

Dispatch an `unknown` discovery event if it's not `bootstrap` or `peer-exchange`

```
if (bootstrap) dispatch(bootstrapEvent) 
else if (peer-exchange) dispatch(peerExchangeEvent) 
else dispatch(unknownEvent)
```


