### PR TITLE
chore: added workflow_call to the ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
         description: "Docker hub image name taken from https://hub.docker.com/r/statusteam/nim-waku/tags. Format: statusteam/nim-waku:v0.19.0"
         required: false
         type: string
+  workflow_call:
+    inputs:
+      nim_wakunode_image:
+        required: false
+        type: string
 
 env:
   NODE_JS: "18"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with: 
+          repository: nwaku-test-org/js-waku
+          
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_JS }}
@@ -40,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with: 
+          repository: nwaku-test-org/js-waku
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_JS }}
@@ -59,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with: 
+          repository: nwaku-test-org/js-waku
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_JS }}
@@ -72,6 +79,8 @@ jobs:
       WAKUNODE_IMAGE: ${{ github.event.inputs.nim_wakunode_image || 'statusteam/nim-waku:v0.19.0' }}
     steps:
       - uses: actions/checkout@v3
+        with: 
+          repository: nwaku-test-org/js-waku
 
       - uses: actions/setup-node@v3
         with:
@@ -109,6 +118,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with: 
+          repository: nwaku-test-org/js-waku
 
       - uses: actions/setup-node@v3
         with:
@@ -133,6 +144,8 @@ jobs:
       DEBUG: "waku*"
     steps:
       - uses: actions/checkout@v3
+        with: 
+          repository: nwaku-test-org/js-waku
 
       - name: Install NodeJS
         uses: actions/setup-node@v3
@@ -171,6 +184,8 @@ jobs:
       WAKUNODE_IMAGE: "statusteam/nim-waku:deploy-wakuv2-test"
     steps:
       - uses: actions/checkout@v3
+        with: 
+          repository: nwaku-test-org/js-waku
 
       - uses: actions/setup-node@v3
         with:
@@ -215,6 +230,8 @@ jobs:
           token: ${{ secrets.CI_TOKEN }}
 
       - uses: actions/checkout@v3
+        with: 
+          repository: nwaku-test-org/js-waku
         if: ${{ steps.release.outputs.releases_created }}
 
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
       nim_wakunode_image:
         required: false
         type: string
+      caller:
+        required: false
+        type: string
 
 env:
   NODE_JS: "18"
@@ -62,6 +65,7 @@ jobs:
 
   browser:
     runs-on: ubuntu-latest
+    if: ${{ inputs.caller == null || inputs.caller != 'nwaku' }}
     steps:
       - uses: actions/checkout@v3
         with: 
@@ -138,6 +142,7 @@ jobs:
 
   node_with_go_waku_master:
     runs-on: ubuntu-latest
+    if: ${{ inputs.caller == null || inputs.caller != 'nwaku' }}
     env:
       WAKUNODE_IMAGE: "statusteam/go-waku:latest"
       WAKU_SERVICE_NODE_PARAMS: "--min-relay-peers-to-publish=0" # Can be removed once https://github.com/status-im/nwaku/issues/1004 is done
@@ -179,6 +184,7 @@ jobs:
 
   node_with_nwaku_master:
     runs-on: ubuntu-latest
+    if: ${{ inputs.caller == null || inputs.caller != 'nwaku' }}
     env:
       DEBUG: "waku*"
       WAKUNODE_IMAGE: "statusteam/nim-waku:deploy-wakuv2-test"
@@ -219,7 +225,10 @@ jobs:
   maybe-release:
     name: release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: >
+      github.event_name == 'push' && 
+      github.ref == 'refs/heads/master' &&
+      (github.event.inputs.caller == null || github.event.inputs.caller != 'nwaku')
     needs: [check, proto, browser, node]
     steps:
       - uses: google-github-actions/release-please-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with: 
-          repository: nwaku-test-org/js-waku
+          repository: waku-org/js-waku
           
       - uses: actions/setup-node@v3
         with:
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with: 
-          repository: nwaku-test-org/js-waku
+          repository: waku-org/js-waku
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_JS }}
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with: 
-          repository: nwaku-test-org/js-waku
+          repository: waku-org/js-waku
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_JS }}
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with: 
-          repository: nwaku-test-org/js-waku
+          repository: waku-org/js-waku
 
       - uses: actions/setup-node@v3
         with:
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with: 
-          repository: nwaku-test-org/js-waku
+          repository: waku-org/js-waku
 
       - uses: actions/setup-node@v3
         with:
@@ -145,7 +145,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with: 
-          repository: nwaku-test-org/js-waku
+          repository: waku-org/js-waku
 
       - name: Install NodeJS
         uses: actions/setup-node@v3
@@ -185,7 +185,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with: 
-          repository: nwaku-test-org/js-waku
+          repository: waku-org/js-waku
 
       - uses: actions/setup-node@v3
         with:
@@ -231,7 +231,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with: 
-          repository: nwaku-test-org/js-waku
+          repository: waku-org/js-waku
         if: ${{ steps.release.outputs.releases_created }}
 
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
   node:
     runs-on: ubuntu-latest
     env:
-      WAKUNODE_IMAGE: ${{ github.event.inputs.nim_wakunode_image || 'statusteam/nim-waku:v0.19.0' }}
+      WAKUNODE_IMAGE: ${{ inputs.nim_wakunode_image || 'statusteam/nim-waku:v0.19.0' }}
     steps:
       - uses: actions/checkout@v3
         with: 
@@ -114,7 +114,7 @@ jobs:
   node_optional:
     runs-on: ubuntu-latest
     env:
-      WAKUNODE_IMAGE: ${{ github.event.inputs.nim_wakunode_image || 'statusteam/nim-waku:v0.19.0' }}
+      WAKUNODE_IMAGE: ${{ inputs.nim_wakunode_image || 'statusteam/nim-waku:v0.19.0' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ env:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: ${{ inputs.caller == null || inputs.caller != 'nwaku' }}
     steps:
       - uses: actions/checkout@v3
         with: 
@@ -44,6 +45,7 @@ jobs:
 
   proto:
     runs-on: ubuntu-latest
+    if: ${{ inputs.caller == null || inputs.caller != 'nwaku' }}
     steps:
       - uses: actions/checkout@v3
         with: 


### PR DESCRIPTION
## Problem

When nwaku creates a release it needs to run the jswaku tests (ideally automatically) against the release

## Solution

Added workflow_call so the ci can be invoked via reusable workflows
Exclude based on the caller input the un-needed jobs 

## Notes

