### PR TITLE
fix: use npm i always (for now)

### DIFF
--- a/.github/actions/npm/action.yml
+++ b/.github/actions/npm/action.yml
@@ -5,12 +5,6 @@ runs:
   steps:
     - run: npm i
       shell: bash
-      if: contains('
-        refs/heads/master
-        refs/heads/release-please--branches--master
-        ', github.ref)
+      if: true
     - uses: bahmutov/npm-install@v1
-      if: contains('
-        refs/heads/master
-        refs/heads/release-please--branches--master
-        ', github.ref) == false
+      if: false


### PR DESCRIPTION
## Problem

For some reason `npm ci` is used on the release branch and it fails, which is expected.

## Solution

Fall back on plain `npm i` for now before I understand what caused it. 

