### PR TITLE
fix: enable npm ci to targeted branches 

### DIFF
--- a/.github/actions/npm/action.yml
+++ b/.github/actions/npm/action.yml
@@ -3,8 +3,22 @@ name: npm i
 runs:
   using: "composite"
   steps:
+    - run: echo "$IF_RUN $BRANCH"
+      shell: bash
+      env:
+        IF_RUN: ${{ contains('
+          refs/heads/master
+          refs/heads/release-please--branches--master
+          ', github.ref) }}
+        BRANCH: ${{ github.ref }}
     - run: npm i
       shell: bash
-      if: true
+      if: ${{ contains('
+        refs/heads/master
+        refs/heads/release-please--branches--master
+        ', github.ref) }}
     - uses: bahmutov/npm-install@v1
-      if: false
+      if: ${{ contains('
+        refs/heads/master
+        refs/heads/release-please--branches--master
+        ', github.ref) == false }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26979,13 +26979,13 @@
     },
     "packages/core": {
       "name": "@waku/core",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/interfaces": "0.0.17",
+        "@waku/interfaces": "0.0.18",
         "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/utils": "0.0.11",
         "debug": "^4.3.4",
         "it-all": "^3.0.3",
         "it-length-prefixed": "^9.0.1",
@@ -27044,11 +27044,11 @@
     },
     "packages/dns-discovery": {
       "name": "@waku/dns-discovery",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@waku/enr": "0.0.16",
-        "@waku/utils": "0.0.10",
+        "@waku/enr": "0.0.17",
+        "@waku/utils": "0.0.11",
         "debug": "^4.3.4",
         "dns-query": "^0.11.2",
         "hi-base32": "^0.5.1",
@@ -27063,7 +27063,7 @@
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@types/chai": "^4.3.5",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.17",
+        "@waku/interfaces": "0.0.18",
         "chai": "^4.3.7",
         "cspell": "^7.3.2",
         "karma": "^6.4.1",
@@ -27082,7 +27082,7 @@
     },
     "packages/enr": {
       "name": "@waku/enr",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@ethersproject/rlp": "^5.7.0",
@@ -27090,7 +27090,7 @@
         "@libp2p/peer-id": "^3.0.2",
         "@multiformats/multiaddr": "^12.0.0",
         "@noble/secp256k1": "^1.7.1",
-        "@waku/utils": "0.0.10",
+        "@waku/utils": "0.0.11",
         "debug": "^4.3.4",
         "js-sha3": "^0.8.0"
       },
@@ -27102,7 +27102,7 @@
         "@types/chai": "^4.3.5",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.17",
+        "@waku/interfaces": "0.0.18",
         "chai": "^4.3.7",
         "cspell": "^7.3.2",
         "karma": "^6.4.1",
@@ -27124,7 +27124,7 @@
     },
     "packages/interfaces": {
       "name": "@waku/interfaces",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@chainsafe/libp2p-gossipsub": "^10.1.0",
@@ -27140,14 +27140,14 @@
     },
     "packages/message-encryption": {
       "name": "@waku/message-encryption",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@noble/secp256k1": "^1.7.1",
-        "@waku/core": "0.0.22",
-        "@waku/interfaces": "0.0.17",
+        "@waku/core": "0.0.23",
+        "@waku/interfaces": "0.0.18",
         "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/utils": "0.0.11",
         "debug": "^4.3.4",
         "js-sha3": "^0.8.0"
       },
@@ -27179,11 +27179,11 @@
     },
     "packages/message-hash": {
       "name": "@waku/message-hash",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/utils": "0.0.10"
+        "@waku/utils": "0.0.11"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.4",
@@ -27193,7 +27193,7 @@
         "@types/debug": "^4.1.8",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.17",
+        "@waku/interfaces": "0.0.18",
         "chai": "^4.3.7",
         "cspell": "^7.3.2",
         "fast-check": "^3.12.0",
@@ -27218,15 +27218,15 @@
     },
     "packages/peer-exchange": {
       "name": "@waku/peer-exchange",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@libp2p/interfaces": "^3.3.2",
-        "@waku/core": "0.0.22",
-        "@waku/enr": "0.0.16",
-        "@waku/interfaces": "0.0.17",
+        "@waku/core": "0.0.23",
+        "@waku/enr": "0.0.17",
+        "@waku/interfaces": "0.0.18",
         "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/utils": "0.0.11",
         "debug": "^4.3.4",
         "it-all": "^3.0.3",
         "it-length-prefixed": "^9.0.1",
@@ -27274,15 +27274,15 @@
     },
     "packages/relay": {
       "name": "@waku/relay",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^10.1.0",
         "@noble/hashes": "^1.3.2",
-        "@waku/core": "0.0.22",
-        "@waku/interfaces": "0.0.17",
+        "@waku/core": "0.0.23",
+        "@waku/interfaces": "0.0.18",
         "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/utils": "0.0.11",
         "chai": "^4.3.7",
         "debug": "^4.3.4",
         "fast-check": "^3.12.0"
@@ -27303,18 +27303,18 @@
     },
     "packages/sdk": {
       "name": "@waku/sdk",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^13.0.0",
         "@libp2p/mplex": "^9.0.2",
         "@libp2p/websockets": "^7.0.5",
-        "@waku/core": "0.0.22",
-        "@waku/dns-discovery": "0.0.16",
-        "@waku/interfaces": "0.0.17",
-        "@waku/peer-exchange": "^0.0.15",
-        "@waku/relay": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/core": "0.0.23",
+        "@waku/dns-discovery": "0.0.17",
+        "@waku/interfaces": "0.0.18",
+        "@waku/peer-exchange": "^0.0.16",
+        "@waku/relay": "0.0.6",
+        "@waku/utils": "0.0.11",
         "libp2p": "^0.46.9"
       },
       "devDependencies": {
@@ -27629,10 +27629,10 @@
     },
     "packages/utils": {
       "name": "@waku/utils",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@waku/interfaces": "^0.0.17",
+        "@waku/interfaces": "0.0.18",
         "debug": "^4.3.4",
         "uint8arrays": "^4.0.4"
       },
@@ -27647,6 +27647,15 @@
         "rollup": "^3.29.0",
         "typescript": "^5.0.4"
       },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "packages/utils/node_modules/@waku/interfaces": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.17.tgz",
+      "integrity": "sha512-/3HrMhpjMwpArm73L05Q7xLPKFeGjvpDlrFq4lqrXjKa8J2VUmiZh6fD9LdYP1ZvhPdzrCRAL+o7+Lb9kt4fvQ==",
+      "dev": true,
       "engines": {
         "node": ">=16"
       }
@@ -31141,9 +31150,9 @@
         "@types/mocha": "^10.0.1",
         "@types/uuid": "^9.0.3",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.17",
+        "@waku/interfaces": "0.0.18",
         "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/utils": "0.0.11",
         "chai": "^4.3.7",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -31186,9 +31195,9 @@
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@types/chai": "^4.3.5",
         "@waku/build-utils": "*",
-        "@waku/enr": "0.0.16",
-        "@waku/interfaces": "0.0.17",
-        "@waku/utils": "0.0.10",
+        "@waku/enr": "0.0.17",
+        "@waku/interfaces": "0.0.18",
+        "@waku/utils": "0.0.11",
         "chai": "^4.3.7",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -31221,8 +31230,8 @@
         "@types/chai": "^4.3.5",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.17",
-        "@waku/utils": "0.0.10",
+        "@waku/interfaces": "0.0.18",
+        "@waku/utils": "0.0.11",
         "chai": "^4.3.7",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -31262,10 +31271,10 @@
         "@types/chai": "^4.3.5",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.22",
-        "@waku/interfaces": "0.0.17",
+        "@waku/core": "0.0.23",
+        "@waku/interfaces": "0.0.18",
         "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/utils": "0.0.11",
         "chai": "^4.3.7",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -31295,8 +31304,8 @@
         "@types/debug": "^4.1.8",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.17",
-        "@waku/utils": "0.0.10",
+        "@waku/interfaces": "0.0.18",
+        "@waku/utils": "0.0.11",
         "chai": "^4.3.7",
         "cspell": "^7.3.2",
         "fast-check": "^3.12.0",
@@ -31324,11 +31333,11 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.22",
-        "@waku/enr": "0.0.16",
-        "@waku/interfaces": "0.0.17",
+        "@waku/core": "0.0.23",
+        "@waku/enr": "0.0.17",
+        "@waku/interfaces": "0.0.18",
         "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/utils": "0.0.11",
         "chai": "^4.3.7",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -31367,10 +31376,10 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.22",
-        "@waku/interfaces": "0.0.17",
+        "@waku/core": "0.0.23",
+        "@waku/interfaces": "0.0.18",
         "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/utils": "0.0.11",
         "chai": "^4.3.7",
         "debug": "^4.3.4",
         "fast-check": "^3.12.0",
@@ -31391,12 +31400,12 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.22",
-        "@waku/dns-discovery": "0.0.16",
-        "@waku/interfaces": "0.0.17",
-        "@waku/peer-exchange": "^0.0.15",
-        "@waku/relay": "0.0.5",
-        "@waku/utils": "0.0.10",
+        "@waku/core": "0.0.23",
+        "@waku/dns-discovery": "0.0.17",
+        "@waku/interfaces": "0.0.18",
+        "@waku/peer-exchange": "^0.0.16",
+        "@waku/relay": "0.0.6",
+        "@waku/utils": "0.0.11",
         "cspell": "^7.3.2",
         "interface-datastore": "^7.0.4",
         "libp2p": "^0.46.9",
@@ -31578,6 +31587,14 @@
         "rollup": "^3.29.0",
         "typescript": "^5.0.4",
         "uint8arrays": "^4.0.4"
+      },
+      "dependencies": {
+        "@waku/interfaces": {
+          "version": "0.0.17",
+          "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.17.tgz",
+          "integrity": "sha512-/3HrMhpjMwpArm73L05Q7xLPKFeGjvpDlrFq4lqrXjKa8J2VUmiZh6fD9LdYP1ZvhPdzrCRAL+o7+Lb9kt4fvQ==",
+          "dev": true
+        }
       }
     },
     "@webassemblyjs/ast": {


### PR DESCRIPTION
## Problem

Due to broken behavior of `npm` action release PR was broken and wasn't able to succeed due to `npm ci` not working on release. It is expected because of `package-lock` and `package` filed being out of sync so `npm i` should be used. For some reason action was misfunctioning and using `npm ci`.

## Solution



## Notes

- Related to https://github.com/waku-org/js-waku/pull/1557, https://github.com/waku-org/js-waku/issues/1455
