### PR TITLE
fix: explicit nwaku subscriptions in tests

### DIFF
--- a/packages/tests/src/node/node.ts
+++ b/packages/tests/src/node/node.ts
@@ -209,6 +209,17 @@ export class NimGoNode {
     return this.rpcCall<RpcInfoResponse>("get_waku_v2_debug_v1_info", []);
   }
 
+  async sendSubscriptions(
+    pubsubTopics: [string] = [DefaultPubSubTopic]
+  ): Promise<boolean> {
+    this.checkProcess();
+
+    return this.rpcCall<boolean>(
+      "post_waku_v2_relay_v1_subscriptions",
+      pubsubTopics
+    );
+  }
+
   async sendMessage(
     message: MessageRpcQuery,
     pubSubTopic: string = DefaultPubSubTopic

--- a/packages/tests/src/node/node.ts
+++ b/packages/tests/src/node/node.ts
@@ -209,7 +209,7 @@ export class NimGoNode {
     return this.rpcCall<RpcInfoResponse>("get_waku_v2_debug_v1_info", []);
   }
 
-  async sendSubscriptions(
+  async ensureSubscriptions(
     pubsubTopics: [string] = [DefaultPubSubTopic]
   ): Promise<boolean> {
     this.checkProcess();

--- a/packages/tests/tests/filter/subscribe.node.spec.ts
+++ b/packages/tests/tests/filter/subscribe.node.spec.ts
@@ -42,6 +42,9 @@ describe("Waku Filter V2: Subscribe", function () {
     [nwaku, waku] = await runNodes(this);
     subscription = await waku.filter.createSubscription();
     messageCollector = new MessageCollector(TestContentTopic);
+
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.ensureSubscriptions();
   });
 
   this.afterEach(async function () {

--- a/packages/tests/tests/filter/subscribe.node.spec.ts
+++ b/packages/tests/tests/filter/subscribe.node.spec.ts
@@ -49,6 +49,9 @@ describe("Waku Filter V2: Subscribe", function () {
   });
 
   it("Subscribe and receive messages via lightPush", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     await subscription.subscribe([TestDecoder], messageCollector.callback);
 
     await waku.lightPush.send(TestEncoder, messagePayload);
@@ -61,6 +64,9 @@ describe("Waku Filter V2: Subscribe", function () {
   });
 
   it("Subscribe and receive messages via waku relay post", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     await subscription.subscribe([TestDecoder], messageCollector.callback);
 
     await delay(400);
@@ -81,6 +87,9 @@ describe("Waku Filter V2: Subscribe", function () {
   });
 
   it("Subscribe and receive 2 messages on the same topic", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     await subscription.subscribe([TestDecoder], messageCollector.callback);
 
     await waku.lightPush.send(TestEncoder, messagePayload);
@@ -105,6 +114,9 @@ describe("Waku Filter V2: Subscribe", function () {
   });
 
   it("Subscribe and receive messages on 2 different content topics", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     // Subscribe to the first content topic and send a message.
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await waku.lightPush.send(TestEncoder, messagePayload);

--- a/packages/tests/tests/filter/subscribe.node.spec.ts
+++ b/packages/tests/tests/filter/subscribe.node.spec.ts
@@ -49,9 +49,6 @@ describe("Waku Filter V2: Subscribe", function () {
   });
 
   it("Subscribe and receive messages via lightPush", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     await subscription.subscribe([TestDecoder], messageCollector.callback);
 
     await waku.lightPush.send(TestEncoder, messagePayload);
@@ -64,9 +61,6 @@ describe("Waku Filter V2: Subscribe", function () {
   });
 
   it("Subscribe and receive messages via waku relay post", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     await subscription.subscribe([TestDecoder], messageCollector.callback);
 
     await delay(400);
@@ -87,9 +81,6 @@ describe("Waku Filter V2: Subscribe", function () {
   });
 
   it("Subscribe and receive 2 messages on the same topic", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     await subscription.subscribe([TestDecoder], messageCollector.callback);
 
     await waku.lightPush.send(TestEncoder, messagePayload);
@@ -114,9 +105,6 @@ describe("Waku Filter V2: Subscribe", function () {
   });
 
   it("Subscribe and receive messages on 2 different content topics", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     // Subscribe to the first content topic and send a message.
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await waku.lightPush.send(TestEncoder, messagePayload);

--- a/packages/tests/tests/filter/unsubscribe.node.spec.ts
+++ b/packages/tests/tests/filter/unsubscribe.node.spec.ts
@@ -35,9 +35,6 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribe 1 topic - node subscribed to 1 topic", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await waku.lightPush.send(TestEncoder, messagePayload);
     expect(await messageCollector.waitForMessages(1)).to.eq(true);
@@ -56,9 +53,6 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribe 1 topic - node subscribed to 2 topics", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     // Subscribe to 2 topics and send messages
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     const newContentTopic = "/test/2/waku-filter";
@@ -81,9 +75,6 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribe 2 topics - node subscribed to 2 topics", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     // Subscribe to 2 topics and send messages
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     const newContentTopic = "/test/2/waku-filter";
@@ -106,9 +97,6 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribe topics the node is not subscribed to", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     // Subscribe to 1 topic and send message
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await waku.lightPush.send(TestEncoder, { payload: utf8ToBytes("M1") });
@@ -128,9 +116,6 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribes all - node subscribed to 1 topic", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await waku.lightPush.send(TestEncoder, { payload: utf8ToBytes("M1") });
     expect(await messageCollector.waitForMessages(1)).to.eq(true);
@@ -147,9 +132,6 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribes all - node subscribed to 10 topics", async function () {
-    // Nwaku subscribe to the default pubsub topic
-    await nwaku.sendSubscriptions();
-
     // Subscribe to 10 topics and send message
     const topicCount = 10;
     const td = generateTestData(topicCount);

--- a/packages/tests/tests/filter/unsubscribe.node.spec.ts
+++ b/packages/tests/tests/filter/unsubscribe.node.spec.ts
@@ -35,6 +35,9 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribe 1 topic - node subscribed to 1 topic", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await waku.lightPush.send(TestEncoder, messagePayload);
     expect(await messageCollector.waitForMessages(1)).to.eq(true);
@@ -53,6 +56,9 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribe 1 topic - node subscribed to 2 topics", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     // Subscribe to 2 topics and send messages
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     const newContentTopic = "/test/2/waku-filter";
@@ -75,6 +81,9 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribe 2 topics - node subscribed to 2 topics", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     // Subscribe to 2 topics and send messages
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     const newContentTopic = "/test/2/waku-filter";
@@ -97,6 +106,9 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribe topics the node is not subscribed to", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     // Subscribe to 1 topic and send message
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await waku.lightPush.send(TestEncoder, { payload: utf8ToBytes("M1") });
@@ -116,6 +128,9 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribes all - node subscribed to 1 topic", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await waku.lightPush.send(TestEncoder, { payload: utf8ToBytes("M1") });
     expect(await messageCollector.waitForMessages(1)).to.eq(true);
@@ -132,6 +147,9 @@ describe("Waku Filter V2: Unsubscribe", function () {
   });
 
   it("Unsubscribes all - node subscribed to 10 topics", async function () {
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.sendSubscriptions();
+
     // Subscribe to 10 topics and send message
     const topicCount = 10;
     const td = generateTestData(topicCount);

--- a/packages/tests/tests/filter/unsubscribe.node.spec.ts
+++ b/packages/tests/tests/filter/unsubscribe.node.spec.ts
@@ -28,6 +28,9 @@ describe("Waku Filter V2: Unsubscribe", function () {
     [nwaku, waku] = await runNodes(this);
     subscription = await waku.filter.createSubscription();
     messageCollector = new MessageCollector(TestContentTopic);
+
+    // Nwaku subscribe to the default pubsub topic
+    await nwaku.ensureSubscriptions();
   });
 
   this.afterEach(async function () {

--- a/packages/tests/tests/relay.node.spec.ts
+++ b/packages/tests/tests/relay.node.spec.ts
@@ -437,6 +437,9 @@ describe("Waku Relay [node only]", () => {
     it("Publishes to nwaku", async function () {
       this.timeout(30000);
 
+      // Nwaku subscribe to the default pubsub topic
+      await nwaku.sendSubscriptions();
+
       const messageText = "This is a message";
       await waku.relay.send(TestEncoder, { payload: utf8ToBytes(messageText) });
 

--- a/packages/tests/tests/relay.node.spec.ts
+++ b/packages/tests/tests/relay.node.spec.ts
@@ -411,6 +411,9 @@ describe("Waku Relay [node only]", () => {
 
       await waku.dial(await nwaku.getMultiaddrWithId());
       await waitForRemotePeer(waku, [Protocols.Relay]);
+
+      // Nwaku subscribe to the default pubsub topic
+      await nwaku.ensureSubscriptions();
     });
 
     afterEach(async function () {
@@ -436,9 +439,6 @@ describe("Waku Relay [node only]", () => {
 
     it("Publishes to nwaku", async function () {
       this.timeout(30000);
-
-      // Nwaku subscribe to the default pubsub topic
-      await nwaku.sendSubscriptions();
 
       const messageText = "This is a message";
       await waku.relay.send(TestEncoder, { payload: utf8ToBytes(messageText) });


### PR DESCRIPTION
## Problem
When interop testing with nwaku, tests did not subscribe nwaku to the default pubsub topic. Those tests only worked so far because of the default behavior of nwaku WAS to subscribe to the default pubsub topic and cache messages received on it.

With https://github.com/waku-org/nwaku/pull/1983 this is no longer the case.

## Solution

Tests that call "get_waku_v2_relay_v1_messages" must call "post_waku_v2_relay_v1_subscriptions" before hand. Otherwise no messages will be cached.