### PR TITLE
fix!: catch stream creation promise rejection for lightPush.send

### DIFF
--- a/packages/core/src/lib/light_push/index.ts
+++ b/packages/core/src/lib/light_push/index.ts
@@ -146,13 +146,18 @@ class LightPush extends BaseProtocol implements ILightPush {
         return { recipients, error: SendError.DECODE_FAILED };
       }
 
-      if (response?.isSuccess) {
-        recipients.some((recipient) => recipient.equals(peer.id)) ||
-          recipients.push(peer.id);
-      } else {
+      if (!response) {
         log("Remote peer fault: No response in PushRPC");
         return { recipients, error: SendError.REMOTE_PEER_FAULT };
       }
+
+      if (!response.isSuccess) {
+        log("Remote peer rejected the message: ", response.info);
+        return { recipients, error: SendError.REMOTE_PEER_REJECTED };
+      }
+
+      recipients.some((recipient) => recipient.equals(peer.id)) ||
+        recipients.push(peer.id);
 
       return { recipients };
     });

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -63,7 +63,8 @@ export enum SendError {
   ENCODE_FAILED = "Failed to encode",
   DECODE_FAILED = "Failed to decode",
   SIZE_TOO_BIG = "Size is too big",
-  NO_RPC_RESPONSE = "No RPC response"
+  NO_PEER_AVAILABLE = "No peer available",
+  REMOTE_PEER_FAULT = "Remote peer fault"
 }
 
 export interface SendResult {

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -79,10 +79,16 @@ export enum SendError {
    */
   NO_PEER_AVAILABLE = "No peer available",
   /**
-   * The remote peer did not behave as expected. Mitigation from `NO_PEER_AVAILABLE`
+   * The remote peer did not behave as expected. Mitigation for `NO_PEER_AVAILABLE`
    * or `DECODE_FAILED` can be used.
    */
-  REMOTE_PEER_FAULT = "Remote peer fault"
+  REMOTE_PEER_FAULT = "Remote peer fault",
+  /**
+   * The remote peer rejected the message. Information provided by the remote peer
+   * is logged. Review message validity, or mitigation for `NO_PEER_AVAILABLE`
+   * or `DECODE_FAILED` can be used.
+   */
+  REMOTE_PEER_REJECTED = "Remote peer rejected"
 }
 
 export interface SendResult {

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -59,11 +59,29 @@ export type Callback<T extends IDecodedMessage> = (
 ) => void | Promise<void>;
 
 export enum SendError {
+  /** Could not determine the origin of the fault. Best to check connectivity and try again */
   GENERIC_FAIL = "Generic error",
+  /** Failure to protobuf encode the message. This is not recoverable and needs
+   * further investigation. */
   ENCODE_FAILED = "Failed to encode",
+  /** Failure to protobuf decode the message. May be due to a remote peer issue,
+   * ensuring that messages are sent via several peer enable mitigation of this error.. */
   DECODE_FAILED = "Failed to decode",
+  /** The message size is above the maximum message size allowed on the Waku Network.
+   * Compressing the message or using an alternative strategy for large messages is recommended.
+   */
   SIZE_TOO_BIG = "Size is too big",
+  /**
+   * Failure to find a peer with suitable protocols. This may due to a connection issue.
+   * Mitigation can be: retrying after a given time period, display connectivity issue
+   * to user or listening for `peer:connected:bootstrap` or `peer:connected:peer-exchange`
+   * on the connection manager before retrying.
+   */
   NO_PEER_AVAILABLE = "No peer available",
+  /**
+   * The remote peer did not behave as expected. Mitigation from `NO_PEER_AVAILABLE`
+   * or `DECODE_FAILED` can be used.
+   */
   REMOTE_PEER_FAULT = "Remote peer fault"
 }
 

--- a/packages/tests/tests/light-push/index.spec.ts
+++ b/packages/tests/tests/light-push/index.spec.ts
@@ -86,7 +86,8 @@ describe("Waku Light Push [node only]", function () {
       });
     } else {
       expect(pushResponse.recipients.length).to.eq(0);
-      expect(pushResponse.errors).to.include(SendError.REMOTE_PEER_REJECTED);
+      // This should be `REMOTE_PEER_REJECTED`, tracked with https://github.com/waku-org/nwaku/issues/1641
+      expect(pushResponse.errors).to.include(SendError.REMOTE_PEER_FAULT);
       expect(await messageCollector.waitForMessages(1)).to.eq(false);
     }
   });
@@ -158,7 +159,8 @@ describe("Waku Light Push [node only]", function () {
       });
     } else {
       expect(pushResponse.recipients.length).to.eq(0);
-      expect(pushResponse.errors).to.include(SendError.REMOTE_PEER_REJECTED);
+      // Should be `REMOTE_PEER_REJECTED`, tracked with https://github.com/waku-org/nwaku/issues/2059
+      expect(pushResponse.errors).to.include(SendError.REMOTE_PEER_FAULT);
       expect(await messageCollector.waitForMessages(1)).to.eq(false);
     }
   });

--- a/packages/tests/tests/light-push/index.spec.ts
+++ b/packages/tests/tests/light-push/index.spec.ts
@@ -86,7 +86,7 @@ describe("Waku Light Push [node only]", function () {
       });
     } else {
       expect(pushResponse.recipients.length).to.eq(0);
-      expect(pushResponse.errors).to.include(SendError.NO_RPC_RESPONSE);
+      expect(pushResponse.errors).to.include(SendError.REMOTE_PEER_REJECTED);
       expect(await messageCollector.waitForMessages(1)).to.eq(false);
     }
   });
@@ -158,7 +158,7 @@ describe("Waku Light Push [node only]", function () {
       });
     } else {
       expect(pushResponse.recipients.length).to.eq(0);
-      expect(pushResponse.errors).to.include(SendError.NO_RPC_RESPONSE);
+      expect(pushResponse.errors).to.include(SendError.REMOTE_PEER_REJECTED);
       expect(await messageCollector.waitForMessages(1)).to.eq(false);
     }
   });


### PR DESCRIPTION
`SendError.NO_RPC_RESPONSE` has been removed in favour of `SendError.REMOTE_PEER_FAULT` and `SendError.REMOTE_PEER_REJECTED`.

Resolves #1553