### PR TITLE
feat: update enrtree

### DIFF
--- a/packages/dns-discovery/src/constants.ts
+++ b/packages/dns-discovery/src/constants.ts
@@ -1,8 +1,8 @@
 import type { NodeCapabilityCount } from "@waku/interfaces";
 
 export const enrTree = {
-  TEST: "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im",
-  PROD: "enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im"
+  TEST: "enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im",
+  PROD: "enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im"
 };
 
 export const DEFAULT_BOOTSTRAP_TAG_NAME = "bootstrap";


### PR DESCRIPTION
Enrtrees were regenerated. Need to update the old one.
DNS discoverty should continue to work.