### PR TITLE
chore: disable paralles runs locally

### DIFF
--- a/packages/tests/.mocharc.json
+++ b/packages/tests/.mocharc.json
@@ -8,6 +8,6 @@
   ],
   "exit": true,
   "retries": 4,
-  "parallel": true,
+  "parallel": false,
   "jobs": 6
 }

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -40,6 +40,7 @@ Therefore, you need to have `docker` installed on your machine to run the tests.
     WAKUNODE_IMAGE=image-name npm run test:node
     ```
 
+- Locally, tests are executed serially, allowing the use of **.only** for focused testing. If you wish to run all tests locally and expedite the process, you can enable parallel execution in the Mocha configuration.
 
 # Running tests in the CI
 

--- a/packages/tests/src/run-tests.js
+++ b/packages/tests/src/run-tests.js
@@ -15,21 +15,24 @@ async function main() {
     console.log("Image pulled");
   }
 
+  const mochaArgs = [
+    "mocha",
+    "--require",
+    "ts-node/register",
+    "--project",
+    "./tsconfig.dev.json",
+    ...process.argv.slice(2)
+  ];
+
+  // If in CI, add --parallel
+  if (process.env.CI) {
+    mochaArgs.push("--parallel");
+  }
+
   // Run mocha tests
-  const mocha = spawn(
-    "npx",
-    [
-      "mocha",
-      "--require",
-      "ts-node/register",
-      "--project",
-      "./tsconfig.dev.json",
-      ...process.argv.slice(2)
-    ],
-    {
-      stdio: "inherit"
-    }
-  );
+  const mocha = spawn("npx", mochaArgs, {
+    stdio: "inherit"
+  });
 
   mocha.on("error", (error) => {
     console.log(`Error running mocha tests: ${error.message}`);

--- a/packages/tests/src/run-tests.js
+++ b/packages/tests/src/run-tests.js
@@ -27,6 +27,11 @@ async function main() {
   // If in CI, add --parallel
   if (process.env.CI) {
     mochaArgs.push("--parallel");
+    console.log("Running tests in parallel");
+  } else {
+    console.log(
+      "Running tests serially. To enable parallel execution update mocha config"
+    );
   }
 
   // Run mocha tests


### PR DESCRIPTION
## Problem

With parallel mode we cannot single out tests locally

## Solution

Disabling parallel mode for local execution

