### PR TITLE
fix: handle all empty responses in filter

### DIFF
--- a/packages/core/src/lib/filter/index.ts
+++ b/packages/core/src/lib/filter/index.ts
@@ -184,6 +184,12 @@ class Subscription {
         async (source) => await all(source)
       );
 
+      if (!res || !res.length) {
+        throw Error(
+          `No response received for request ${request.requestId}: ${res}`
+        );
+      }
+
       const { statusCode, requestId, statusDesc } =
         FilterSubscribeResponse.decode(res[0].slice());
 
@@ -215,6 +221,12 @@ class Subscription {
         lp.decode,
         async (source) => await all(source)
       );
+
+      if (!res || !res.length) {
+        throw Error(
+          `No response received for request ${request.requestId}: ${res}`
+        );
+      }
 
       const { statusCode, requestId, statusDesc } =
         FilterSubscribeResponse.decode(res[0].slice());


### PR DESCRIPTION
## Problem
I got an exception about undefined res - seems 
```
waku:filter:v2 Error pinging:  +11ms TypeError: res[0] is undefined
```

Seems like this https://github.com/waku-org/js-waku/commit/d049ebbc3417e5c20eccba3aa1b9fc5382e8d7fc only fixed `subscribe` and `ping` and `unsubscribe` still needed the check
## Solution

Add check and throw an error for empty response

## Notes

<!-- Remove items that are not relevant -->

- Resolves <issue number>
- Related to <link to specs>
