### PR TITLE
fix: store digest changes

### DIFF
--- a/packages/core/src/lib/store/index.ts
+++ b/packages/core/src/lib/store/index.ts
@@ -416,8 +416,18 @@ export async function createCursor(message: IDecodedMessage): Promise<Cursor> {
   }
 
   const contentTopicBytes = utf8ToBytes(message.contentTopic);
+  const pubSubTopicBytes = utf8ToBytes(message.pubsubTopic);
 
-  const digest = sha256(concat([contentTopicBytes, message.payload]));
+  let metaBytes: Uint8Array;
+  if (message.meta instanceof Uint8Array) {
+    metaBytes = message.meta;
+  } else {
+    metaBytes = new Uint8Array(); // default value
+  }
+
+  const digest = sha256(
+    concat([pubSubTopicBytes, message.payload, contentTopicBytes, metaBytes])
+  );
 
   const messageTime = BigInt(message.timestamp.getTime()) * BigInt(1000000);
 


### PR DESCRIPTION
## Problem

As corresponding to the changes done in [nWaku](https://github.com/waku-org/nwaku/pull/2132) and [goWaku](https://github.com/waku-org/go-waku/pull/820) digest computing-related functions, same changes are made in jsWaku.

The older behavior was prone to errors as it was not computing the hash uniquely.

## Solution

Now the digest is computed over pubSubTopic, messagePayload, contentTopic, and messageMeta fields. 

## Notes

<!-- Remove items that are not relevant -->

- Resolves #1681
- Related to [RFC](https://rfc.vac.dev/spec/14/#deterministic-message-hashing)
