### PR TITLE
chore: make pre-release manual

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,29 +96,6 @@ jobs:
       test_type: nwaku-master
       debug: waku*
 
-  pre-release:
-    name: pre-release
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [check, proto, browser, node]
-    steps:
-      - uses: actions/checkout@v3
-        with: 
-          repository: waku-org/js-waku
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_JS }}
-          registry-url: "https://registry.npmjs.org"
-
-      - run: npm install
-
-      - run: npm run build
-
-      - run: npm run publish -- --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_JS_WAKU_PUBLISH }}
-
   maybe-release:
     name: release
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,25 @@
+on:
+    workflow_dispatch:
+
+jobs:
+    pre-release:
+        name: pre-release
+        runs-on: ubuntu-latest
+        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'
+        steps:
+          - uses: actions/checkout@v3
+            with: 
+              repository: waku-org/js-waku
+    
+          - uses: actions/setup-node@v3
+            with:
+              node-version: ${{ env.NODE_JS }}
+              registry-url: "https://registry.npmjs.org"
+    
+          - run: npm install
+    
+          - run: npm run build
+    
+          - run: npm run publish -- --tag next
+            env:
+              NODE_AUTH_TOKEN: ${{ secrets.NPM_JS_WAKU_PUBLISH }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,12 @@ Commit messages should never contain any `@` mentions (usernames prefixed with "
 
 Please refer to the [Git manual](https://git-scm.com/doc) for more information
 about Git.
+
+### Releasing
+
+`js-waku` has two types of releases:
+- public releases;
+- pre releases;
+
+Public releases happen by merging PRs opened by `release-please` action.
+Pre releases happen manually by triggering [this workflow](https://github.com/waku-org/js-waku/actions/workflows/pre-release.yml)


### PR DESCRIPTION
## Problem

`pre-release` on master on every push can create clutter in our npm repository in a long run

## Solution

Make the job run by request

## Notes

Ref: https://github.com/waku-org/js-waku/issues/1543
