### PR TITLE
feat: forbid identifiers with camelcase pubSub

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,7 +72,8 @@
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/no-misused-promises": "error",
-    "@typescript-eslint/no-explicit-any": "warn"
+    "@typescript-eslint/no-explicit-any": "warn",
+    "id-match": ["error", "^(?!.*[pP]ubSub)"]
   },
   "overrides": [
     {


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

cspell does not allow flagging of words based on patterns, making it difficult it to enforce usage of `pubsub` over `pubSub` https://github.com/waku-org/js-waku/issues/1704

## Solution

<!-- describe the new behavior --> 

Add a rule to eslint the use of any identifier which contains the string `pubSub` or `PubSub`.

From this point on, any commits that include an identifier which matches the above condition will be caught via pre commit hook. This does not apply to files which are not checked by eslint, and does not catch the pattern if it's used outside of an identifier (e.g. comments or string literals)

## Notes

<!-- Remove items that are not relevant -->

- Resolves https://github.com/waku-org/js-waku/issues/1704
