### PR TITLE
chore: fix karma webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "karma-firefox-launcher": "^2.1.2",
         "karma-mocha": "^2.0.1",
         "karma-webkit-launcher": "^2.1.0",
-        "karma-webpack": "^5.0.0",
+        "karma-webpack": "github:codymikol/karma-webpack#2337a82beb078c0d8e25ae8333a06249b8e72828",
         "lint-staged": "^14.0.1",
         "playwright": "^1.38.1",
         "size-limit": "^9.0.0",
@@ -12845,15 +12845,17 @@
     },
     "node_modules/karma-webpack": {
       "version": "5.0.0",
+      "resolved": "git+ssh://git@github.com/codymikol/karma-webpack.git#2337a82beb078c0d8e25ae8333a06249b8e72828",
+      "integrity": "sha512-UBHuEnrcPRKo+8YQjvGZyinVQbvJ3Ib078ToIB5uEGoK5iSuOQrOTZFNQdNiodSbWFO3aX0LcerQVK0T81hXmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^9.0.3",
         "webpack-merge": "^4.1.5"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 18"
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
@@ -12876,6 +12878,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/karma-webpack/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/karma-webpack/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/karma-webpack/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/karma/node_modules/ansi-regex": {
@@ -34518,11 +34556,13 @@
       }
     },
     "karma-webpack": {
-      "version": "5.0.0",
+      "version": "git+ssh://git@github.com/codymikol/karma-webpack.git#2337a82beb078c0d8e25ae8333a06249b8e72828",
+      "integrity": "sha512-UBHuEnrcPRKo+8YQjvGZyinVQbvJ3Ib078ToIB5uEGoK5iSuOQrOTZFNQdNiodSbWFO3aX0LcerQVK0T81hXmg==",
       "dev": true,
+      "from": "karma-webpack@github:codymikol/karma-webpack#2337a82beb078c0d8e25ae8333a06249b8e72828",
       "requires": {
         "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^9.0.3",
         "webpack-merge": "^4.1.5"
       },
       "dependencies": {
@@ -34536,6 +34576,37 @@
             "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -50,19 +50,19 @@
     "eslint-plugin-prettier": "^5.0.0",
     "gh-pages": "^6.0.0",
     "husky": "^8.0.3",
-    "lint-staged": "^14.0.1",
-    "size-limit": "^9.0.0",
-    "ts-loader": "^9.4.2",
-    "ts-node": "^10.9.1",
-    "typedoc": "^0.25.1",
-    "typescript": "^5.2.2",
     "karma": "^6.4.2",
     "karma-chrome-launcher": "^3.2.0",
     "karma-firefox-launcher": "^2.1.2",
     "karma-mocha": "^2.0.1",
     "karma-webkit-launcher": "^2.1.0",
-    "karma-webpack": "^5.0.0",
-    "playwright": "^1.38.1"
+    "karma-webpack": "github:codymikol/karma-webpack#2337a82beb078c0d8e25ae8333a06249b8e72828",
+    "lint-staged": "^14.0.1",
+    "playwright": "^1.38.1",
+    "size-limit": "^9.0.0",
+    "ts-loader": "^9.4.2",
+    "ts-node": "^10.9.1",
+    "typedoc": "^0.25.1",
+    "typescript": "^5.2.2"
   },
   "lint-staged": {
     "*.{ts,js}": [


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

Running browser tests using Karma was not working locally on macOS https://github.com/waku-org/js-waku/issues/1707

## Solution

<!-- describe the new behavior --> 

The main culprit was the `karma-webpack` plugin. This PR modifies `package.json` to use the latest commit of the github repository instead of published npm package. The code in the repository has the fix, but the npm package has not been published since Feb 2021.

## Notes

<!-- Remove items that are not relevant -->

- Resolves #1707 
