### PR TITLE
chore: remove reviewers for dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     open-pull-requests-limit: 2
     schedule:
       interval: "daily"
-    reviewers: ["fryorcraken","danisharora099","weboko"]
     versioning-strategy: increase
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
js-waku developers are automatically added as reviewers.