### PR TITLE
chore: add test summary to github actions run

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -97,3 +97,11 @@ jobs:
         with:
           name: ${{ inputs.test_type }}-logs
           path: packages/tests/log/
+
+      - name: Create test summary
+        if: always() && env.ALLURE_REPORTS == 'true'
+        run: |
+          echo "## Run Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **NWAKU**: ${{ env.WAKUNODE_IMAGE }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "Allure report will be available at: https://waku-org.github.io/allure-jswaku/${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
An improvement that works fine for interop testing framework and I think it's good to have it here as well.
Jobs will have a summary with the link to the report:
![image](https://github.com/waku-org/js-waku/assets/28725451/4af275d2-702b-4a3a-86e9-8074a7c6f50a)

