### PR TITLE
feat!: return response interface for success/error

### DIFF
--- a/packages/core/src/lib/filter/index.ts
+++ b/packages/core/src/lib/filter/index.ts
@@ -116,7 +116,7 @@ class Subscription {
       if (statusCode < 200 || statusCode >= 300) {
         return {
           requestId: requestId,
-          code: statusCode,
+          statusCode: statusCode,
           message: statusDesc
         };
       }
@@ -129,7 +129,7 @@ class Subscription {
       );
       return {
         requestId: requestId,
-        code: statusCode
+        statusCode: statusCode
       };
     } catch (e) {
       throw new Error(
@@ -187,7 +187,7 @@ class Subscription {
       if (statusCode < 200 || statusCode >= 300) {
         return {
           requestId: requestId,
-          code: statusCode,
+          statusCode: statusCode,
           message: statusDesc
         };
       }
@@ -200,7 +200,7 @@ class Subscription {
       );
       return {
         requestId: requestId,
-        code: statusCode
+        statusCode: statusCode
       };
     } catch (error) {
       throw new Error("Unexpected error unsubscribing: " + error);
@@ -237,7 +237,7 @@ class Subscription {
       if (statusCode < 200 || statusCode >= 300) {
         return {
           requestId: requestId,
-          code: statusCode,
+          statusCode: statusCode,
           message: statusDesc
         };
       }
@@ -245,7 +245,7 @@ class Subscription {
       log.info("Ping successful");
       return {
         requestId: requestId,
-        code: statusCode
+        statusCode: statusCode
       };
     } catch (error) {
       log.error("Unexpected error while pinging: ", error);
@@ -281,7 +281,7 @@ class Subscription {
       if (statusCode < 200 || statusCode >= 300) {
         return {
           requestId: requestId,
-          code: statusCode,
+          statusCode: statusCode,
           message: statusDesc
         };
       }
@@ -291,7 +291,7 @@ class Subscription {
 
       return {
         requestId: requestId,
-        code: statusCode
+        statusCode: statusCode
       };
     } catch (error) {
       throw new Error(

--- a/packages/core/src/lib/filter/index.ts
+++ b/packages/core/src/lib/filter/index.ts
@@ -121,26 +121,6 @@ class Subscription {
         };
       }
 
-      log.info(
-        "Subscribed to peer ",
-        this.peer.id.toString(),
-        "for content topics",
-        contentTopics
-      );
-      return {
-        requestId: requestId,
-        statusCode: statusCode
-      };
-    } catch (e) {
-      throw new Error(
-        "Expected Error: Subscribing to peer: " +
-          this.peer.id.toString() +
-          " for content topics: " +
-          contentTopics +
-          ": " +
-          e
-      );
-    } finally {
       // Save the callback functions by content topics so they
       // can easily be removed (reciprocally replaced) if `unsubscribe` (reciprocally `subscribe`)
       // is called for those content topics
@@ -156,6 +136,27 @@ class Subscription {
         // purpose as the user may call `subscribe` to refresh the subscription
         this.subscriptionCallbacks.set(contentTopic, subscriptionCallback);
       });
+
+      log.info(
+        "Subscribed to peer ",
+        this.peer.id.toString(),
+        "for content topics",
+        contentTopics
+      );
+
+      return {
+        requestId: requestId,
+        statusCode: statusCode
+      };
+    } catch (e) {
+      throw new Error(
+        "Expected Error: Subscribing to peer: " +
+          this.peer.id.toString() +
+          " for content topics: " +
+          contentTopics +
+          ": " +
+          e
+      );
     }
   }
 
@@ -192,22 +193,23 @@ class Subscription {
         };
       }
 
+      contentTopics.forEach((contentTopic: string) => {
+        this.subscriptionCallbacks.delete(contentTopic);
+      });
+
       log.info(
         "Unsubscribed from peer ",
         this.peer.id.toString(),
         "for content topics",
         contentTopics
       );
+
       return {
         requestId: requestId,
         statusCode: statusCode
       };
     } catch (error) {
       throw new Error("Unexpected error unsubscribing: " + error);
-    } finally {
-      contentTopics.forEach((contentTopic: string) => {
-        this.subscriptionCallbacks.delete(contentTopic);
-      });
     }
   }
 

--- a/packages/interfaces/src/filter.ts
+++ b/packages/interfaces/src/filter.ts
@@ -20,7 +20,7 @@ export enum EFilterSuccessKind {
 
 export interface IFilterResponse {
   requestId: string;
-  code: EFilterErrorKind | EFilterSuccessKind;
+  statusCode: EFilterErrorKind | EFilterSuccessKind;
   message?: string;
 }
 

--- a/packages/interfaces/src/filter.ts
+++ b/packages/interfaces/src/filter.ts
@@ -5,6 +5,25 @@ import type { ContentTopic } from "./misc.js";
 import type { Callback, IBaseProtocol } from "./protocols.js";
 import type { IReceiver } from "./receiver.js";
 
+export enum EFilterErrorKind {
+  UNKNOWN = 0,
+  PEER_DIAL_FAILURE = 200,
+  BAD_RESPONSE = 300,
+  BAD_REQUEST = 400,
+  NOT_FOUND = 404,
+  SERVICE_UNAVAILABLE = 503
+}
+
+export enum EFilterSuccessKind {
+  OK = 200
+}
+
+export interface IFilterResponse {
+  requestId: string;
+  code: EFilterErrorKind | EFilterSuccessKind;
+  message?: string;
+}
+
 export type ContentFilter = {
   contentTopic: string;
 };
@@ -13,13 +32,13 @@ export interface IFilterSubscription {
   subscribe<T extends IDecodedMessage>(
     decoders: IDecoder<T> | IDecoder<T>[],
     callback: Callback<T>
-  ): Promise<void>;
+  ): Promise<IFilterResponse>;
 
-  unsubscribe(contentTopics: ContentTopic[]): Promise<void>;
+  unsubscribe(contentTopics: ContentTopic[]): Promise<IFilterResponse>;
 
-  ping(): Promise<void>;
+  ping(): Promise<IFilterResponse>;
 
-  unsubscribeAll(): Promise<void>;
+  unsubscribeAll(): Promise<IFilterResponse>;
 }
 
 export type IFilter = IReceiver &

--- a/packages/tests/tests/filter/ping.node.spec.ts
+++ b/packages/tests/tests/filter/ping.node.spec.ts
@@ -71,13 +71,12 @@ describe("Waku Filter V2: Ping", function () {
 
     const pingAndReinitiateSubscription = async (): Promise<void> => {
       try {
-        const { code } = await subscription.ping();
-        if (code !== 200) {
-          // `Ping failed with code ${code} and message ${message}. Reinitiating subscription.`;
+        const { statusCode } = await subscription.ping();
+        if (statusCode !== 200) {
+          // ping failed, reinstantiate subscription
+          await openSubscription();
         }
-        await openSubscription();
       } catch (error) {
-        // to handle unexpected errors
         console.error(error);
       }
     };

--- a/packages/tests/tests/filter/ping.node.spec.ts
+++ b/packages/tests/tests/filter/ping.node.spec.ts
@@ -71,16 +71,14 @@ describe("Waku Filter V2: Ping", function () {
 
     const pingAndReinitiateSubscription = async (): Promise<void> => {
       try {
-        await subscription.ping();
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes("peer has no subscriptions")
-        ) {
-          await openSubscription();
-        } else {
-          throw error;
+        const { code } = await subscription.ping();
+        if (code !== 200) {
+          // `Ping failed with code ${code} and message ${message}. Reinitiating subscription.`;
         }
+        await openSubscription();
+      } catch (error) {
+        // to handle unexpected errors
+        console.error(error);
       }
     };
 

--- a/packages/tests/tests/filter/subscribe.node.spec.ts
+++ b/packages/tests/tests/filter/subscribe.node.spec.ts
@@ -247,20 +247,17 @@ describe("Waku Filter V2: Subscribe", function () {
     const td = generateTestData(topicCount);
 
     // Attempt to subscribe to 31 topics
-    try {
-      await subscription.subscribe(td.decoders, messageCollector.callback);
+    const { statusCode } = await subscription.subscribe(
+      td.decoders,
+      messageCollector.callback
+    );
+
+    if (statusCode !== 200) {
+      return;
+    } else {
       throw new Error(
         "Subscribe to 31 topics was successful but was expected to fail with a specific error."
       );
-    } catch (err) {
-      if (
-        err instanceof Error &&
-        err.message.includes("exceeds maximum content topics: 30")
-      ) {
-        return;
-      } else {
-        throw err;
-      }
     }
   });
 

--- a/packages/tests/tests/filter/utils.ts
+++ b/packages/tests/tests/filter/utils.ts
@@ -20,19 +20,18 @@ export async function validatePingError(
   subscription: IFilterSubscription
 ): Promise<void> {
   try {
-    await subscription.ping();
-    throw new Error(
-      "Ping was successful but was expected to fail with a specific error."
-    );
-  } catch (err) {
-    if (
-      err instanceof Error &&
-      err.message.includes("peer has no subscriptions")
-    ) {
-      return;
+    const { statusCode } = await subscription.ping();
+    if (statusCode === 200) {
+      throw new Error(
+        "Ping was successful but was expected to fail with a specific error."
+      );
     } else {
-      throw err;
+      return;
     }
+  } catch (error) {
+    throw new Error(
+      `Ping failed with an unexpected error. ` + `Error: ${error}`
+    );
   }
 }
 


### PR DESCRIPTION
For the parent issue: https://github.com/waku-org/js-waku/issues/1694, we want to structure all protocols to return error codes & enums over throwing exceptions.

This PR:
- refactors Filter to return `IFilterResponse` which includes `statusCode, message, requestId`

## Notes:
- with this PR, Filter will currently use error codes and messages in tandem with the nwaku Filter implementation: https://github.com/waku-org/nwaku/blob/master/waku/waku_filter_v2/rpc.nim
- [x] linked nwaku PR: https://github.com/waku-org/nwaku/pull/2236
- reference: https://github.com/waku-org/docs.waku.org/pull/132#discussion_r1393600276