### PR TITLE
chore: fix encoder creation

### DIFF
--- a/packages/core/src/lib/message/version_0.ts
+++ b/packages/core/src/lib/message/version_0.ts
@@ -128,7 +128,7 @@ export function createEncoder({
   return new Encoder(
     contentTopic,
     ephemeral,
-    pubsubTopicShardInfo?.index
+    pubsubTopicShardInfo
       ? singleShardInfoToPubsubTopic(pubsubTopicShardInfo)
       : DefaultPubsubTopic,
     metaSetter
@@ -193,7 +193,7 @@ export function createDecoder(
   pubsubTopicShardInfo?: SingleShardInfo
 ): Decoder {
   return new Decoder(
-    pubsubTopicShardInfo?.index
+    pubsubTopicShardInfo
       ? singleShardInfoToPubsubTopic(pubsubTopicShardInfo)
       : DefaultPubsubTopic,
     contentTopic

--- a/packages/message-encryption/src/ecies.ts
+++ b/packages/message-encryption/src/ecies.ts
@@ -107,7 +107,7 @@ export function createEncoder({
   metaSetter
 }: EncoderOptions): Encoder {
   return new Encoder(
-    pubsubTopicShardInfo?.index
+    pubsubTopicShardInfo
       ? singleShardInfoToPubsubTopic(pubsubTopicShardInfo)
       : DefaultPubsubTopic,
     contentTopic,
@@ -200,7 +200,7 @@ export function createDecoder(
   pubsubTopicShardInfo?: SingleShardInfo
 ): Decoder {
   return new Decoder(
-    pubsubTopicShardInfo?.index
+    pubsubTopicShardInfo
       ? singleShardInfoToPubsubTopic(pubsubTopicShardInfo)
       : DefaultPubsubTopic,
     contentTopic,

--- a/packages/message-encryption/src/symmetric.ts
+++ b/packages/message-encryption/src/symmetric.ts
@@ -107,7 +107,7 @@ export function createEncoder({
   metaSetter
 }: EncoderOptions): Encoder {
   return new Encoder(
-    pubsubTopicShardInfo?.index
+    pubsubTopicShardInfo
       ? singleShardInfoToPubsubTopic(pubsubTopicShardInfo)
       : DefaultPubsubTopic,
     contentTopic,
@@ -200,7 +200,7 @@ export function createDecoder(
   pubsubTopicShardInfo?: SingleShardInfo
 ): Decoder {
   return new Decoder(
-    pubsubTopicShardInfo?.index
+    pubsubTopicShardInfo
       ? singleShardInfoToPubsubTopic(pubsubTopicShardInfo)
       : DefaultPubsubTopic,
     contentTopic,


### PR DESCRIPTION
## Problem

With #1697, setting pubsub topic based on `shardInfo` was introduced.
a bug was spotted during property check where if the `index` is `0`, it falls back to the `DefaultPubsubTopic`.


## Solution

The PR removes the property check, and just checks the definition on `pubsubTopicShardInfo`

Another solution could be to add a specific `unedefined` check like: `pubsubTopicShardInfo !== undefined` but there are very little benefits of additional property checking on a type-safe system. (ref: https://github.com/waku-org/js-waku/pull/1697#discussion_r1407025600)