### PR TITLE
feat: use metadata protocol for awaiting connection to remote peer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "cSpell.enabled": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": false, // Disable general format on save
   "typescript.tsdk": "node_modules/typescript/lib",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "cSpell.enabled": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": true
   },
   "editor.formatOnSave": false, // Disable general format on save
   "typescript.tsdk": "node_modules/typescript/lib",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,7 @@ export * as waku_filter from "./lib/filter/index.js";
 export { wakuFilter, FilterCodecs } from "./lib/filter/index.js";
 
 export * as waku_light_push from "./lib/light_push/index.js";
-export { wakuLightPush } from "./lib/light_push/index.js";
+export { LightPushCodec, wakuLightPush } from "./lib/light_push/index.js";
 
 export * as waku_store from "./lib/store/index.js";
 

--- a/packages/core/src/lib/base_protocol.ts
+++ b/packages/core/src/lib/base_protocol.ts
@@ -64,8 +64,17 @@ export class BaseProtocol implements IBaseProtocol {
    * the class protocol. Waku may or may not be currently connected to these
    * peers.
    */
-  public async peers(): Promise<Peer[]> {
+  public async allPeers(): Promise<Peer[]> {
     return getPeersForProtocol(this.peerStore, [this.multicodec]);
+  }
+
+  public async connectedPeers(): Promise<Peer[]> {
+    const peers = await this.allPeers();
+    return peers.filter((peer) => {
+      return (
+        this.components.connectionManager.getConnections(peer.id).length > 0
+      );
+    });
   }
 
   protected async getPeer(peerId?: PeerId): Promise<Peer> {

--- a/packages/core/src/lib/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager.ts
@@ -379,6 +379,8 @@ export class ConnectionManager
     },
     "peer:connect": (evt: CustomEvent<PeerId>): void => {
       void (async () => {
+        log.info(`Connected to peer ${evt.detail.toString()}`);
+
         const peerId = evt.detail;
 
         this.keepAliveManager.start(

--- a/packages/core/src/lib/waku.ts
+++ b/packages/core/src/lib/waku.ts
@@ -57,7 +57,7 @@ export class WakuNode implements Waku {
   constructor(
     options: WakuOptions,
     libp2p: Libp2p,
-    pubsubShardInfo?: ShardInfo,
+    private pubsubShardInfo?: ShardInfo,
     store?: (libp2p: Libp2p) => IStore,
     lightPush?: (libp2p: Libp2p) => ILightPush,
     filter?: (libp2p: Libp2p) => IFilter,
@@ -107,6 +107,10 @@ export class WakuNode implements Waku {
       `relay: ${!!this.relay}, store: ${!!this.store}, light push: ${!!this
         .lightPush}, filter: ${!!this.filter}`
     );
+  }
+
+  get shardInfo(): ShardInfo | undefined {
+    return this.pubsubShardInfo;
   }
 
   /**

--- a/packages/interfaces/src/metadata.ts
+++ b/packages/interfaces/src/metadata.ts
@@ -6,6 +6,6 @@ import type { IBaseProtocol } from "./protocols.js";
 // IMetadata always has shardInfo defined while it is optionally undefined in IBaseProtocol
 export interface IMetadata extends Omit<IBaseProtocol, "shardInfo"> {
   shardInfo: ShardInfo;
-  handshakesConfirmed: PeerId[];
+  confirmOrAttemptHandshake(peerId: PeerId): Promise<void>;
   query(peerId: PeerId): Promise<ShardInfo | undefined>;
 }

--- a/packages/interfaces/src/metadata.ts
+++ b/packages/interfaces/src/metadata.ts
@@ -6,5 +6,6 @@ import type { IBaseProtocol } from "./protocols.js";
 // IMetadata always has shardInfo defined while it is optionally undefined in IBaseProtocol
 export interface IMetadata extends Omit<IBaseProtocol, "shardInfo"> {
   shardInfo: ShardInfo;
+  handshakesConfirmed: PeerId[];
   query(peerId: PeerId): Promise<ShardInfo | undefined>;
 }

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -17,7 +17,8 @@ export interface IBaseProtocol {
   shardInfo?: ShardInfo;
   multicodec: string;
   peerStore: PeerStore;
-  peers: () => Promise<Peer[]>;
+  allPeers: () => Promise<Peer[]>;
+  connectedPeers: () => Promise<Peer[]>;
   addLibp2pEventListener: Libp2p["addEventListener"];
   removeLibp2pEventListener: Libp2p["removeEventListener"];
 }

--- a/packages/interfaces/src/waku.ts
+++ b/packages/interfaces/src/waku.ts
@@ -3,6 +3,7 @@ import type { PeerId } from "@libp2p/interface/peer-id";
 import type { Multiaddr } from "@multiformats/multiaddr";
 
 import { IConnectionManager } from "./connection_manager.js";
+import type { ShardInfo } from "./enr.js";
 import type { IFilter } from "./filter.js";
 import type { Libp2p } from "./libp2p.js";
 import type { ILightPush } from "./light_push.js";
@@ -16,6 +17,8 @@ export interface Waku {
   store?: IStore;
   filter?: IFilter;
   lightPush?: ILightPush;
+
+  shardInfo?: ShardInfo;
 
   connectionManager: IConnectionManager;
 

--- a/packages/tests/tests/filter/utils.ts
+++ b/packages/tests/tests/filter/utils.ts
@@ -59,7 +59,8 @@ export async function runNodes(
       filter: true,
       lightpush: true,
       relay: true,
-      pubsubTopic: pubsubTopics
+      pubsubTopic: pubsubTopics,
+      clusterId: shardInfo?.clusterId
     },
     { retries: 3 }
   );

--- a/packages/tests/tests/filter/utils.ts
+++ b/packages/tests/tests/filter/utils.ts
@@ -60,7 +60,7 @@ export async function runNodes(
       lightpush: true,
       relay: true,
       pubsubTopic: pubsubTopics,
-      clusterId: shardInfo?.clusterId
+      ...(shardInfo && { clusterId: shardInfo.clusterId })
     },
     { retries: 3 }
   );

--- a/packages/tests/tests/getPeers.spec.ts
+++ b/packages/tests/tests/getPeers.spec.ts
@@ -1,10 +1,14 @@
-import { MetadataCodec } from "@waku/core";
-import { createLightNode, type LightNode, ShardInfo } from "@waku/sdk";
+import { LightPushCodec, waitForRemotePeer } from "@waku/core";
+import {
+  createLightNode,
+  type LightNode,
+  Protocols,
+  ShardInfo
+} from "@waku/sdk";
 import { shardInfoToPubsubTopics } from "@waku/utils";
 import { getPeersForProtocolAndShard } from "@waku/utils/libp2p";
 import { expect } from "chai";
 
-import { delay } from "../src/delay.js";
 import { makeLogFileName } from "../src/log_file.js";
 import { NimGoNode } from "../src/node/node.js";
 import { tearDownNodes } from "../src/teardown.js";
@@ -35,18 +39,16 @@ describe("getPeersForProtocolAndShard", function () {
       discv5Discovery: true,
       peerExchange: true,
       clusterId: shardInfo.clusterId,
-      pubsubTopic: shardInfoToPubsubTopics(shardInfo)
+      pubsubTopic: shardInfoToPubsubTopics(shardInfo),
+      lightpush: true
     });
 
     const serviceNodeMa = await serviceNode.getMultiaddrWithId();
 
     waku = await createLightNode({ shardInfo });
-    await waku.libp2p.dialProtocol(serviceNodeMa, MetadataCodec);
     await waku.start();
-    // The delay is added to give time for the metadata protocol to be processed
-    //TODO: remove delay
-    await delay(100);
-
+    await waku.libp2p.dialProtocol(serviceNodeMa, LightPushCodec);
+    await waitForRemotePeer(waku, [Protocols.LightPush]);
     const peers = await getPeersForProtocolAndShard(
       waku.libp2p.peerStore,
       waku.libp2p.getProtocols(),
@@ -67,16 +69,16 @@ describe("getPeersForProtocolAndShard", function () {
       discv5Discovery: true,
       peerExchange: true,
       clusterId: shardInfo.clusterId,
-      pubsubTopic: shardInfoToPubsubTopics(shardInfo)
+      pubsubTopic: shardInfoToPubsubTopics(shardInfo),
+      lightpush: true
     });
 
     const serviceNodeMa = await serviceNode.getMultiaddrWithId();
 
     waku = await createLightNode({ shardInfo });
-    await waku.libp2p.dialProtocol(serviceNodeMa, MetadataCodec);
+    await waku.libp2p.dialProtocol(serviceNodeMa, LightPushCodec);
     await waku.start();
-    // The delay is added to give time for the metadata protocol to be processed
-    await delay(100);
+    await waitForRemotePeer(waku, [Protocols.LightPush]);
 
     const peers = await getPeersForProtocolAndShard(
       waku.libp2p.peerStore,
@@ -103,16 +105,16 @@ describe("getPeersForProtocolAndShard", function () {
       discv5Discovery: true,
       peerExchange: true,
       clusterId: shardInfo1.clusterId,
-      pubsubTopic: shardInfoToPubsubTopics(shardInfo1)
+      pubsubTopic: shardInfoToPubsubTopics(shardInfo1),
+      lightpush: true
     });
 
     const serviceNodeMa = await serviceNode.getMultiaddrWithId();
 
     waku = await createLightNode({ shardInfo: shardInfo2 });
-    await waku.libp2p.dialProtocol(serviceNodeMa, MetadataCodec);
+    await waku.libp2p.dialProtocol(serviceNodeMa, LightPushCodec);
     await waku.start();
-    // add a delay to make sure the connection is closed from the other side
-    await delay(100);
+    await waitForRemotePeer(waku, [Protocols.LightPush]);
 
     const peers = await getPeersForProtocolAndShard(
       waku.libp2p.peerStore,
@@ -139,16 +141,16 @@ describe("getPeersForProtocolAndShard", function () {
       discv5Discovery: true,
       peerExchange: true,
       clusterId: shardInfo1.clusterId,
-      pubsubTopic: shardInfoToPubsubTopics(shardInfo1)
+      pubsubTopic: shardInfoToPubsubTopics(shardInfo1),
+      lightpush: true
     });
 
     const serviceNodeMa = await serviceNode.getMultiaddrWithId();
 
     waku = await createLightNode({ shardInfo: shardInfo2 });
-    await waku.libp2p.dialProtocol(serviceNodeMa, MetadataCodec);
+    await waku.libp2p.dialProtocol(serviceNodeMa, LightPushCodec);
     await waku.start();
-    // add a delay to make sure the connection is closed from the other side
-    await delay(100);
+    await waitForRemotePeer(waku, [Protocols.LightPush]);
 
     const peers = await getPeersForProtocolAndShard(
       waku.libp2p.peerStore,

--- a/packages/tests/tests/light-push/multiple_pubsub.node.spec.ts
+++ b/packages/tests/tests/light-push/multiple_pubsub.node.spec.ts
@@ -20,7 +20,7 @@ import {
 
 import { messageText, runNodes } from "./utils.js";
 
-describe.only("Waku Light Push : Multiple PubsubTopics", function () {
+describe("Waku Light Push : Multiple PubsubTopics", function () {
   this.timeout(30000);
   let waku: LightNode;
   let nwaku: NimGoNode;
@@ -120,7 +120,7 @@ describe.only("Waku Light Push : Multiple PubsubTopics", function () {
     });
   });
 
-  it.only("Light push messages to 2 nwaku nodes each with different pubsubtopics", async function () {
+  it("Light push messages to 2 nwaku nodes each with different pubsubtopics", async function () {
     // Set up and start a new nwaku node with Default PubsubTopic
     nwaku2 = new NimGoNode(makeLogFileName(this) + "2");
     await nwaku2.start({

--- a/packages/tests/tests/light-push/utils.ts
+++ b/packages/tests/tests/light-push/utils.ts
@@ -27,7 +27,7 @@ export async function runNodes(
       lightpush: true,
       relay: true,
       pubsubTopic: pubsubTopics,
-      clusterId: shardInfo?.clusterId
+      ...(shardInfo && { clusterId: shardInfo.clusterId })
     },
     { retries: 3 }
   );

--- a/packages/tests/tests/light-push/utils.ts
+++ b/packages/tests/tests/light-push/utils.ts
@@ -23,7 +23,12 @@ export async function runNodes(
 ): Promise<[NimGoNode, LightNode]> {
   const nwaku = new NimGoNode(makeLogFileName(context));
   await nwaku.start(
-    { lightpush: true, relay: true, pubsubTopic: pubsubTopics },
+    {
+      lightpush: true,
+      relay: true,
+      pubsubTopic: pubsubTopics,
+      clusterId: shardInfo?.clusterId
+    },
     { retries: 3 }
   );
 

--- a/packages/tests/tests/store/multiple_pubsub.spec.ts
+++ b/packages/tests/tests/store/multiple_pubsub.spec.ts
@@ -18,6 +18,7 @@ import {
   customShardedPubsubTopic1,
   customShardedPubsubTopic2,
   customShardInfo1,
+  customShardInfo2,
   processQueriedMessages,
   sendMessages,
   shardInfo1,
@@ -123,6 +124,7 @@ describe("Waku Store, custom pubsub topic", function () {
     await nwaku2.start({
       store: true,
       pubsubTopic: [customShardedPubsubTopic2],
+      clusterId: customShardInfo2.clusterId,
       relay: true
     });
     await nwaku2.ensureSubscriptions([customShardedPubsubTopic2]);

--- a/packages/tests/tests/store/multiple_pubsub.spec.ts
+++ b/packages/tests/tests/store/multiple_pubsub.spec.ts
@@ -17,6 +17,7 @@ import {
   customDecoder2,
   customShardedPubsubTopic1,
   customShardedPubsubTopic2,
+  customShardInfo1,
   processQueriedMessages,
   sendMessages,
   shardInfo1,
@@ -37,6 +38,7 @@ describe("Waku Store, custom pubsub topic", function () {
     await nwaku.start({
       store: true,
       pubsubTopic: [customShardedPubsubTopic1, customShardedPubsubTopic2],
+      clusterId: customShardInfo1.clusterId,
       relay: true
     });
     await nwaku.ensureSubscriptions([

--- a/packages/tests/tests/store/utils.ts
+++ b/packages/tests/tests/store/utils.ts
@@ -6,7 +6,12 @@ import {
   DefaultPubsubTopic,
   waitForRemotePeer
 } from "@waku/core";
-import { LightNode, Protocols, ShardInfo } from "@waku/interfaces";
+import {
+  LightNode,
+  Protocols,
+  ShardInfo,
+  type SingleShardInfo
+} from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
 import { Logger, singleShardInfoToPubsubTopic } from "@waku/utils";
 import { expect } from "chai";
@@ -18,14 +23,13 @@ export const log = new Logger("test:store");
 export const TestContentTopic = "/test/1/waku-store/utf8";
 export const TestEncoder = createEncoder({ contentTopic: TestContentTopic });
 export const TestDecoder = createDecoder(TestContentTopic);
-export const customShardedPubsubTopic1 = singleShardInfoToPubsubTopic({
-  clusterId: 3,
-  shard: 1
-});
-export const customShardedPubsubTopic2 = singleShardInfoToPubsubTopic({
-  clusterId: 3,
-  shard: 2
-});
+export const customShardInfo1: SingleShardInfo = { clusterId: 3, shard: 1 };
+export const customShardedPubsubTopic1 =
+  singleShardInfoToPubsubTopic(customShardInfo1);
+
+export const customShardInfo2: SingleShardInfo = { clusterId: 3, shard: 2 };
+export const customShardedPubsubTopic2 =
+  singleShardInfoToPubsubTopic(customShardInfo2);
 export const shardInfo1: ShardInfo = { clusterId: 3, shards: [1] };
 export const customContentTopic1 = "/test/2/waku-store/utf8";
 export const customContentTopic2 = "/test/3/waku-store/utf8";

--- a/packages/tests/tests/wait_for_remote_peer.node.spec.ts
+++ b/packages/tests/tests/wait_for_remote_peer.node.spec.ts
@@ -114,7 +114,9 @@ describe("Wait for remote peer", function () {
     await delay(1000);
     await waitForRemotePeer(waku2, [Protocols.Store]);
 
-    const peers = (await waku2.store.peers()).map((peer) => peer.id.toString());
+    const peers = (await waku2.store.connectedPeers()).map((peer) =>
+      peer.id.toString()
+    );
     const nimPeerId = multiAddrWithId.getPeerId();
 
     expect(nimPeerId).to.not.be.undefined;
@@ -141,7 +143,9 @@ describe("Wait for remote peer", function () {
     await waku2.dial(multiAddrWithId);
     await waitPromise;
 
-    const peers = (await waku2.store.peers()).map((peer) => peer.id.toString());
+    const peers = (await waku2.store.connectedPeers()).map((peer) =>
+      peer.id.toString()
+    );
 
     const nimPeerId = multiAddrWithId.getPeerId();
 
@@ -167,7 +171,7 @@ describe("Wait for remote peer", function () {
     await waku2.dial(multiAddrWithId);
     await waitForRemotePeer(waku2, [Protocols.LightPush]);
 
-    const peers = (await waku2.lightPush.peers()).map((peer) =>
+    const peers = (await waku2.lightPush.connectedPeers()).map((peer) =>
       peer.id.toString()
     );
 
@@ -195,7 +199,7 @@ describe("Wait for remote peer", function () {
     await waku2.dial(multiAddrWithId);
     await waitForRemotePeer(waku2, [Protocols.Filter]);
 
-    const peers = (await waku2.filter.peers()).map((peer) =>
+    const peers = (await waku2.filter.connectedPeers()).map((peer) =>
       peer.id.toString()
     );
 
@@ -227,14 +231,14 @@ describe("Wait for remote peer", function () {
       Protocols.LightPush
     ]);
 
-    const filterPeers = (await waku2.filter.peers()).map((peer) =>
+    const filterPeers = (await waku2.filter.connectedPeers()).map((peer) =>
       peer.id.toString()
     );
-    const storePeers = (await waku2.store.peers()).map((peer) =>
+    const storePeers = (await waku2.store.connectedPeers()).map((peer) =>
       peer.id.toString()
     );
-    const lightPushPeers = (await waku2.lightPush.peers()).map((peer) =>
-      peer.id.toString()
+    const lightPushPeers = (await waku2.lightPush.connectedPeers()).map(
+      (peer) => peer.id.toString()
     );
 
     const nimPeerId = multiAddrWithId.getPeerId();


### PR DESCRIPTION
## Problem

Parent/origin: #https://github.com/waku-org/js-waku/pull/1756

There is a requirement to wait for ~50/100ms after a `peer:connect` event is fired as the Metadata Protocol is an async operation for which we need to wait to populate shard info, or we are disconnected if there is a cluster ID mismatch.

We need to wait for the Metadata protocol to complete before we can assume the peer is ready to be used to open connections reliably.

## Solution

- Add check for successful metadata handshakes in `waitForRemotePeer`
- Also make fixes around enabling sharding for nwaku nodes (https://github.com/waku-org/nwaku/issues/2259)

## Notes

Can still foresee a case where a peer that is connected is used for a protocol instantly, thus creating a race condition. 
Perhaps a more protocol-knit check should be added. Will also be helped with #1463 
