### PR TITLE
chore: sanitize test log names before uploading

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -92,6 +92,7 @@ jobs:
           path: debug.log
 
       - name: Sanitize log filenames
+        if: failure()
         run: |
           find packages/tests/log/ -type f | while read fname; do
               dir=$(dirname "$fname")
@@ -104,6 +105,7 @@ jobs:
 
       - name: Upload logs on failure
         uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: ${{ inputs.test_type }}-logs
           path: packages/tests/log/

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -97,12 +97,13 @@ jobs:
               dir=$(dirname "$fname")
               base=$(basename "$fname")
               sanitized_base=$(echo $base | tr -d '\"*:<>?|' | sed 's/[\\/\r\n]/_/g' | sed 's/_$//')
-              mv "$fname" "$dir/$sanitized_base"
+              if [ "$base" != "$sanitized_base" ]; then
+                  mv "$fname" "$dir/$sanitized_base"
+              fi
           done
 
       - name: Upload logs on failure
         uses: actions/upload-artifact@v3
-        if: failure()
         with:
           name: ${{ inputs.test_type }}-logs
           path: packages/tests/log/

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -91,6 +91,15 @@ jobs:
           name: ${{ inputs.test_type }}-debug.log
           path: debug.log
 
+      - name: Sanitize log filenames
+        run: |
+          find packages/tests/log/ -type f | while read fname; do
+              dir=$(dirname "$fname")
+              base=$(basename "$fname")
+              sanitized_base=$(echo $base | tr -d '\"*:<>?|' | sed 's/[\\/\r\n]/_/g' | sed 's/_$//')
+              mv "$fname" "$dir/$sanitized_base"
+          done
+
       - name: Upload logs on failure
         uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
## Problem

I saw that some logs are causing [failures](https://github.com/waku-org/js-waku/actions/runs/7269288370/job/19806681485#step:13:19) in the CI

## Solution

Added a script that should sanitize the log names
