### PR TITLE
feat: Add github action for publishing packages tagged as dev

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,25 @@
+on:
+    workflow_dispatch:
+
+jobs:
+    pre-release:
+        name: pre-release
+        runs-on: ubuntu-latest
+        if: github.event_name == 'workflow_dispatch'
+        steps:
+          - uses: actions/checkout@v3
+            with:
+              repository: waku-org/js-waku
+
+          - uses: actions/setup-node@v3
+            with:
+              node-version: ${{ env.NODE_JS }}
+              registry-url: "https://registry.npmjs.org"
+
+          - run: npm install
+
+          - run: npm run build
+
+          - run: npm run publish -- --tag next
+            env:
+              NODE_AUTH_TOKEN: ${{ secrets.NPM_JS_WAKU_PUBLISH }}


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

Current github actions only allows publishing a pre-release package based off master, tagged as next

## Solution

<!-- describe the new behavior --> 

Add an action that allows manually publishing the package based off any branch, tagged as dev

## Notes

<!-- Remove items that are not relevant -->
