### PR TITLE
feat: set cluster ID as optional when specifying shard info

### DIFF
--- a/packages/core/src/lib/base_protocol.ts
+++ b/packages/core/src/lib/base_protocol.ts
@@ -7,7 +7,11 @@ import type {
   PubsubTopic
 } from "@waku/interfaces";
 import { DefaultPubsubTopic } from "@waku/interfaces";
-import { Logger, shardInfoToPubsubTopics } from "@waku/utils";
+import {
+  ensureShardingConfigured,
+  Logger,
+  shardInfoToPubsubTopics
+} from "@waku/utils";
 import {
   getConnectedPeersForProtocolAndShard,
   getPeersForProtocol,
@@ -108,6 +112,8 @@ export class BaseProtocol implements IBaseProtocol {
         this.peerStore,
         [this.multicodec],
         this.options?.shardInfo
+          ? ensureShardingConfigured(this.options.shardInfo).shardInfo
+          : undefined
       );
 
     // Filter the peers based on discovery & number of peers requested

--- a/packages/core/src/lib/metadata/index.ts
+++ b/packages/core/src/lib/metadata/index.ts
@@ -132,7 +132,7 @@ class Metadata extends BaseProtocol implements IMetadata {
 }
 
 export function wakuMetadata(
-  shardInfo: ShardingParams
+  shardInfo: ShardInfo
 ): (components: Libp2pComponents) => IMetadata {
   return (components: Libp2pComponents) => new Metadata(shardInfo, components);
 }

--- a/packages/interfaces/src/constants.ts
+++ b/packages/interfaces/src/constants.ts
@@ -2,3 +2,8 @@
  * DefaultPubsubTopic is the default gossipsub topic to use for Waku.
  */
 export const DefaultPubsubTopic = "/waku/2/default-waku/proto";
+
+/**
+ * The default cluster ID for The Waku Network
+ */
+export const DEFAULT_CLUSTER_ID = 1;

--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -5,7 +5,7 @@ export interface SingleShardInfo {
   /**
    * Specifying this field indicates to the encoder/decoder that static sharding must be used.
    */
-  shard?: number;
+  shard: number;
 }
 
 export interface IRateLimitProof {

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -60,7 +60,7 @@ export type ProtocolCreateOptions = {
    * See [Waku v2 Topic Usage Recommendations](https://rfc.vac.dev/spec/23/) for details.
    *
    */
-  shardInfo?: ShardingParams;
+  shardInfo?: Partial<ShardingParams>;
   /**
    * You can pass options to the `Libp2p` instance used by {@link @waku/core!WakuNode} using the `libp2p` property.
    * This property is the same type as the one passed to [`Libp2p.create`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#create)

--- a/packages/sdk/src/relay/index.ts
+++ b/packages/sdk/src/relay/index.ts
@@ -1,6 +1,7 @@
 import { WakuNode, WakuOptions } from "@waku/core";
 import type { ProtocolCreateOptions, RelayNode } from "@waku/interfaces";
 import { RelayCreateOptions, wakuGossipSub, wakuRelay } from "@waku/relay";
+import { ensureShardingConfigured } from "@waku/utils";
 
 import { defaultLibp2p, defaultPeerDiscoveries } from "../create.js";
 
@@ -26,8 +27,12 @@ export async function createRelayNode(
     Object.assign(libp2pOptions, { peerDiscovery });
   }
 
+  const shardInfo = options.shardInfo
+    ? ensureShardingConfigured(options.shardInfo)
+    : undefined;
+
   const libp2p = await defaultLibp2p(
-    options.shardInfo,
+    shardInfo?.shardInfo,
     wakuGossipSub(options),
     libp2pOptions,
     options?.userAgent
@@ -39,7 +44,7 @@ export async function createRelayNode(
     options,
     options.pubsubTopics,
     libp2p,
-    options.shardInfo,
+    shardInfo?.shardingParams,
     undefined,
     undefined,
     undefined,

--- a/packages/tests/tests/filter/single_node/multiple_pubsub.node.spec.ts
+++ b/packages/tests/tests/filter/single_node/multiple_pubsub.node.spec.ts
@@ -9,6 +9,7 @@ import type {
 import { Protocols } from "@waku/interfaces";
 import {
   contentTopicToPubsubTopic,
+  contentTopicToShardIndex,
   pubsubTopicToSingleShardInfo,
   singleShardInfoToPubsubTopic
 } from "@waku/utils";
@@ -207,17 +208,25 @@ describe("Waku Filter V2 (Autosharding): Multiple PubsubTopics", function () {
   const customEncoder1 = createEncoder({
     contentTopic: customContentTopic1,
     pubsubTopicShardInfo: {
-      clusterId: 3
+      clusterId: 3,
+      shard: contentTopicToShardIndex(customContentTopic1)
     }
   });
-  const customDecoder1 = createDecoder(customContentTopic1, { clusterId: 3 });
+  const customDecoder1 = createDecoder(customContentTopic1, {
+    clusterId: 3,
+    shard: contentTopicToShardIndex(customContentTopic1)
+  });
   const customEncoder2 = createEncoder({
     contentTopic: customContentTopic2,
     pubsubTopicShardInfo: {
-      clusterId: 3
+      clusterId: 3,
+      shard: contentTopicToShardIndex(customContentTopic2)
     }
   });
-  const customDecoder2 = createDecoder(customContentTopic2, { clusterId: 3 });
+  const customDecoder2 = createDecoder(customContentTopic2, {
+    clusterId: 3,
+    shard: contentTopicToShardIndex(customContentTopic2)
+  });
 
   this.beforeEach(async function () {
     this.timeout(15000);

--- a/packages/tests/tests/getPeers.spec.ts
+++ b/packages/tests/tests/getPeers.spec.ts
@@ -11,7 +11,7 @@ import {
   Tags,
   utf8ToBytes
 } from "@waku/sdk";
-import { shardInfoToPubsubTopics } from "@waku/utils";
+import { ensureShardingConfigured, shardInfoToPubsubTopics } from "@waku/utils";
 import { getConnectedPeersForProtocolAndShard } from "@waku/utils/libp2p";
 import { expect } from "chai";
 import fc from "fast-check";
@@ -237,7 +237,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
       waku.libp2p.getConnections(),
       waku.libp2p.peerStore,
       waku.libp2p.getProtocols(),
-      shardInfo
+      ensureShardingConfigured(shardInfo).shardInfo
     );
     expect(peers.length).to.be.greaterThan(0);
   });
@@ -289,7 +289,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
       waku.libp2p.getConnections(),
       waku.libp2p.peerStore,
       waku.libp2p.getProtocols(),
-      shardInfo2
+      ensureShardingConfigured(shardInfo2).shardInfo
     );
     expect(peers.length).to.be.equal(1);
   });
@@ -341,7 +341,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
       waku.libp2p.getConnections(),
       waku.libp2p.peerStore,
       waku.libp2p.getProtocols(),
-      shardInfo2
+      ensureShardingConfigured(shardInfo2).shardInfo
     );
     expect(peers.length).to.be.equal(1);
   });
@@ -393,7 +393,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
       waku.libp2p.getConnections(),
       waku.libp2p.peerStore,
       waku.libp2p.getProtocols(),
-      shardInfo2
+      ensureShardingConfigured(shardInfo2).shardInfo
     );
     expect(peers.length).to.be.equal(1);
   });

--- a/packages/tests/tests/light-push/single_node/multiple_pubsub.node.spec.ts
+++ b/packages/tests/tests/light-push/single_node/multiple_pubsub.node.spec.ts
@@ -10,6 +10,8 @@ import {
 } from "@waku/interfaces";
 import {
   contentTopicToPubsubTopic,
+  contentTopicToShardIndex,
+  pubsubTopicToSingleShardInfo,
   singleShardInfoToPubsubTopic
 } from "@waku/utils";
 import { utf8ToBytes } from "@waku/utils/bytes";
@@ -202,11 +204,11 @@ describe("Waku Light Push (Autosharding): Multiple PubsubTopics", function () {
   };
   const customEncoder1 = createEncoder({
     contentTopic: customContentTopic1,
-    pubsubTopicShardInfo: shardInfo
+    pubsubTopicShardInfo: pubsubTopicToSingleShardInfo(autoshardingPubsubTopic1)
   });
   const customEncoder2 = createEncoder({
     contentTopic: customContentTopic2,
-    pubsubTopicShardInfo: shardInfo
+    pubsubTopicShardInfo: pubsubTopicToSingleShardInfo(autoshardingPubsubTopic2)
   });
 
   let nimPeerId: PeerId;
@@ -356,12 +358,16 @@ describe("Waku Light Push (named sharding): Multiple PubsubTopics", function () 
   const customEncoder1 = createEncoder({
     contentTopic: customContentTopic1,
     pubsubTopicShardInfo: {
-      clusterId
+      clusterId,
+      shard: contentTopicToShardIndex(customContentTopic1)
     }
   });
   const customEncoder2 = createEncoder({
     contentTopic: customContentTopic2,
-    pubsubTopicShardInfo: { clusterId }
+    pubsubTopicShardInfo: {
+      clusterId,
+      shard: contentTopicToShardIndex(customContentTopic2)
+    }
   });
 
   let nimPeerId: PeerId;

--- a/packages/tests/tests/relay/multiple_pubsub.node.spec.ts
+++ b/packages/tests/tests/relay/multiple_pubsub.node.spec.ts
@@ -14,6 +14,7 @@ import { Protocols } from "@waku/interfaces";
 import { createRelayNode } from "@waku/sdk/relay";
 import {
   contentTopicToPubsubTopic,
+  pubsubTopicToSingleShardInfo,
   singleShardInfoToPubsubTopic
 } from "@waku/utils";
 import { bytesToUtf8, utf8ToBytes } from "@waku/utils/bytes";
@@ -340,16 +341,20 @@ describe("Waku Relay (Autosharding), multiple pubsub topics", function () {
   };
   const customEncoder1 = createEncoder({
     contentTopic: customContentTopic1,
-    pubsubTopicShardInfo: {
-      clusterId: 3
-    }
+    pubsubTopicShardInfo: pubsubTopicToSingleShardInfo(autoshardingPubsubTopic1)
   });
-  const customDecoder1 = createDecoder(customContentTopic1, { clusterId: 3 });
+  const customDecoder1 = createDecoder(
+    customContentTopic1,
+    pubsubTopicToSingleShardInfo(autoshardingPubsubTopic1)
+  );
   const customEncoder2 = createEncoder({
     contentTopic: customContentTopic2,
-    pubsubTopicShardInfo: { clusterId: 3 }
+    pubsubTopicShardInfo: pubsubTopicToSingleShardInfo(autoshardingPubsubTopic2)
   });
-  const customDecoder2 = createDecoder(customContentTopic2, { clusterId: 3 });
+  const customDecoder2 = createDecoder(
+    customContentTopic2,
+    pubsubTopicToSingleShardInfo(autoshardingPubsubTopic2)
+  );
   const contentTopicInfoBothShards: ContentTopicInfo = {
     clusterId: 3,
     contentTopics: [customContentTopic1, customContentTopic2]

--- a/packages/tests/tests/sharding/running_nodes.spec.ts
+++ b/packages/tests/tests/sharding/running_nodes.spec.ts
@@ -10,7 +10,10 @@ import {
   utf8ToBytes,
   waitForRemotePeer
 } from "@waku/sdk";
-import { singleShardInfoToPubsubTopic } from "@waku/utils";
+import {
+  contentTopicToShardIndex,
+  singleShardInfoToPubsubTopic
+} from "@waku/utils";
 import { expect } from "chai";
 
 import {
@@ -138,12 +141,18 @@ describe("Autosharding: Running Nodes", () => {
 
     const encoder1 = createEncoder({
       contentTopic: ContentTopic,
-      pubsubTopicShardInfo: { clusterId: 0 }
+      pubsubTopicShardInfo: {
+        clusterId: 0,
+        shard: contentTopicToShardIndex(ContentTopic)
+      }
     });
 
     const encoder2 = createEncoder({
       contentTopic: ContentTopic,
-      pubsubTopicShardInfo: { clusterId: 0 }
+      pubsubTopicShardInfo: {
+        clusterId: 0,
+        shard: contentTopicToShardIndex(ContentTopic2)
+      }
     });
 
     const request1 = await waku.lightPush.send(encoder1, {

--- a/packages/tests/tests/store/multiple_pubsub.spec.ts
+++ b/packages/tests/tests/store/multiple_pubsub.spec.ts
@@ -3,6 +3,7 @@ import type { ContentTopicInfo, IMessage, LightNode } from "@waku/interfaces";
 import { createLightNode, Protocols } from "@waku/sdk";
 import {
   contentTopicToPubsubTopic,
+  pubsubTopicToSingleShardInfo,
   singleShardInfosToShardInfo
 } from "@waku/utils";
 import { expect } from "chai";
@@ -200,12 +201,14 @@ describe("Waku Store (Autosharding), custom pubsub topic", function () {
     clusterId,
     contentTopics: [customContentTopic1]
   };
-  const customDecoder1 = createDecoder(customContentTopic1, {
-    clusterId
-  });
-  const customDecoder2 = createDecoder(customContentTopic2, {
-    clusterId
-  });
+  const customDecoder1 = createDecoder(
+    customContentTopic1,
+    pubsubTopicToSingleShardInfo(autoshardingPubsubTopic1)
+  );
+  const customDecoder2 = createDecoder(
+    customContentTopic2,
+    pubsubTopicToSingleShardInfo(autoshardingPubsubTopic2)
+  );
   const contentTopicInfoBothShards: ContentTopicInfo = {
     clusterId,
     contentTopics: [customContentTopic1, customContentTopic2]

--- a/packages/utils/src/libp2p/index.ts
+++ b/packages/utils/src/libp2p/index.ts
@@ -1,5 +1,5 @@
 import type { Connection, Peer, PeerStore } from "@libp2p/interface";
-import { ShardingParams } from "@waku/interfaces";
+import { ShardInfo } from "@waku/interfaces";
 
 import { bytesToUtf8 } from "../bytes/index.js";
 import { decodeRelayShard } from "../common/relay_shard_codec.js";
@@ -74,7 +74,7 @@ export async function getConnectedPeersForProtocolAndShard(
   connections: Connection[],
   peerStore: PeerStore,
   protocols: string[],
-  shardInfo?: ShardingParams
+  shardInfo?: ShardInfo
 ): Promise<Peer[]> {
   const openConnections = connections.filter(
     (connection) => connection.status === "open"


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

To setup a node for autosharding, a user needs to explicitly specify both content topics and a cluster id to determine the pubsub topics. According to the [RFC](https://rfc.vac.dev/spec/64/#network-shards), the Waku Network always uses a cluster id of 1.

## Solution

<!-- describe the new behavior --> 

Makes `clusterId` (and all other fields in `ShardingParams`) optional when user creates a node using the sdk functions, by accepting `Partial<ShardingParams>`.
Each sdk function calls a sharding util function to validated the parameters and replace any missing ones with defaults where possible.
Internally, we mostly use `ShardingParams` where all fields are required.

## Notes

<!-- Remove items that are not relevant -->

- Resolves #1776 
