### PR TITLE
chore: upgrade playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.38.0-jammy
+      image: mcr.microsoft.com/playwright:v1.40.1-jammy
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "karma-webkit-launcher": "^2.1.0",
         "karma-webpack": "github:codymikol/karma-webpack#2337a82beb078c0d8e25ae8333a06249b8e72828",
         "lint-staged": "^14.0.1",
-        "playwright": "^1.38.1",
+        "playwright": "^1.40.1",
         "size-limit": "^11.0.1",
         "ts-loader": "^9.4.2",
         "ts-node": "^10.9.1",
@@ -2887,11 +2887,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.38.1",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.38.1"
+        "playwright": "1.40.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -20782,11 +20783,12 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.38.1",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.40.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -20799,9 +20801,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.38.1",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -26260,7 +26263,7 @@
       "name": "@waku/browser-tests",
       "version": "0.1.0",
       "devDependencies": {
-        "@playwright/test": "^1.37.1",
+        "@playwright/test": "^1.40.1",
         "@waku/create-app": "^0.1.1-7c24ffa",
         "dotenv-flow": "^3.3.0",
         "serve": "^14.2.1"
@@ -26273,14 +26276,14 @@
     },
     "packages/core": {
       "name": "@waku/core",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/enr": "^0.0.19",
-        "@waku/interfaces": "0.0.20",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.13",
+        "@waku/enr": "^0.0.20",
+        "@waku/interfaces": "0.0.21",
+        "@waku/proto": "0.0.6",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "it-all": "^3.0.4",
         "it-length-prefixed": "^9.0.1",
@@ -26324,11 +26327,11 @@
     },
     "packages/dns-discovery": {
       "name": "@waku/dns-discovery",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@waku/enr": "0.0.19",
-        "@waku/utils": "0.0.13",
+        "@waku/enr": "0.0.20",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "dns-query": "^0.11.2",
         "hi-base32": "^0.5.1",
@@ -26343,7 +26346,7 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/chai": "^4.3.11",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.20",
+        "@waku/interfaces": "0.0.21",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "mocha": "^10.2.0",
@@ -26356,7 +26359,7 @@
     },
     "packages/enr": {
       "name": "@waku/enr",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@ethersproject/rlp": "^5.7.0",
@@ -26364,7 +26367,7 @@
         "@libp2p/peer-id": "^3.0.3",
         "@multiformats/multiaddr": "^12.0.0",
         "@noble/secp256k1": "^1.7.1",
-        "@waku/utils": "0.0.13",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "js-sha3": "^0.9.2"
       },
@@ -26376,7 +26379,7 @@
         "@types/chai": "^4.3.11",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.20",
+        "@waku/interfaces": "0.0.21",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "fast-check": "^3.14.0",
@@ -26392,7 +26395,7 @@
     },
     "packages/interfaces": {
       "name": "@waku/interfaces",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@chainsafe/libp2p-gossipsub": "^10.1.1",
@@ -26407,14 +26410,14 @@
     },
     "packages/message-encryption": {
       "name": "@waku/message-encryption",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@noble/secp256k1": "^1.7.1",
-        "@waku/core": "0.0.25",
-        "@waku/interfaces": "0.0.20",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.13",
+        "@waku/core": "0.0.26",
+        "@waku/interfaces": "0.0.21",
+        "@waku/proto": "0.0.6",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "js-sha3": "^0.9.2",
         "uint8arrays": "^5.0.0"
@@ -26448,11 +26451,11 @@
     },
     "packages/message-hash": {
       "name": "@waku/message-hash",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/utils": "0.0.13"
+        "@waku/utils": "0.0.14"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -26462,7 +26465,7 @@
         "@types/debug": "^4.1.12",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.20",
+        "@waku/interfaces": "0.0.21",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "fast-check": "^3.14.0",
@@ -26479,15 +26482,15 @@
     },
     "packages/peer-exchange": {
       "name": "@waku/peer-exchange",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@libp2p/interfaces": "^3.3.2",
-        "@waku/core": "0.0.25",
-        "@waku/enr": "0.0.19",
-        "@waku/interfaces": "0.0.20",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.13",
+        "@waku/core": "0.0.26",
+        "@waku/enr": "0.0.20",
+        "@waku/interfaces": "0.0.21",
+        "@waku/proto": "0.0.6",
+        "@waku/utils": "0.0.14",
         "debug": "^4.3.4",
         "it-all": "^3.0.4",
         "it-length-prefixed": "^9.0.1",
@@ -26510,7 +26513,7 @@
     },
     "packages/proto": {
       "name": "@waku/proto",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "protons-runtime": "^5.0.2"
@@ -26532,15 +26535,15 @@
     },
     "packages/relay": {
       "name": "@waku/relay",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^10.1.1",
         "@noble/hashes": "^1.3.2",
-        "@waku/core": "0.0.25",
-        "@waku/interfaces": "0.0.20",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.13",
+        "@waku/core": "0.0.26",
+        "@waku/interfaces": "0.0.21",
+        "@waku/proto": "0.0.6",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
         "fast-check": "^3.14.0"
@@ -26558,18 +26561,18 @@
     },
     "packages/sdk": {
       "name": "@waku/sdk",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^13.0.4",
         "@libp2p/mplex": "^9.0.10",
         "@libp2p/websockets": "^7.0.5",
-        "@waku/core": "0.0.25",
-        "@waku/dns-discovery": "0.0.19",
-        "@waku/interfaces": "0.0.20",
-        "@waku/peer-exchange": "^0.0.18",
-        "@waku/relay": "0.0.8",
-        "@waku/utils": "0.0.13",
+        "@waku/core": "0.0.26",
+        "@waku/dns-discovery": "0.0.20",
+        "@waku/interfaces": "0.0.21",
+        "@waku/peer-exchange": "^0.0.19",
+        "@waku/relay": "0.0.9",
+        "@waku/utils": "0.0.14",
         "libp2p": "^0.46.14"
       },
       "devDependencies": {
@@ -26638,11 +26641,11 @@
     },
     "packages/utils": {
       "name": "@waku/utils",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/interfaces": "0.0.20",
+        "@waku/interfaces": "0.0.21",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
         "uint8arrays": "^4.0.4"
@@ -28613,10 +28616,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.38.1",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
       "dev": true,
       "requires": {
-        "playwright": "1.38.1"
+        "playwright": "1.40.1"
       }
     },
     "@pnpm/config.env-replace": {
@@ -29756,7 +29761,7 @@
     "@waku/browser-tests": {
       "version": "file:packages/browser-tests",
       "requires": {
-        "@playwright/test": "^1.37.1",
+        "@playwright/test": "^1.40.1",
         "@waku/create-app": "^0.1.1-7c24ffa",
         "dotenv-flow": "^3.3.0",
         "serve": "^14.2.1"
@@ -29778,10 +29783,10 @@
         "@types/mocha": "^10.0.1",
         "@types/uuid": "^9.0.7",
         "@waku/build-utils": "*",
-        "@waku/enr": "^0.0.19",
-        "@waku/interfaces": "0.0.20",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.13",
+        "@waku/enr": "^0.0.20",
+        "@waku/interfaces": "0.0.21",
+        "@waku/proto": "0.0.6",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -29849,9 +29854,9 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/chai": "^4.3.11",
         "@waku/build-utils": "*",
-        "@waku/enr": "0.0.19",
-        "@waku/interfaces": "0.0.20",
-        "@waku/utils": "0.0.13",
+        "@waku/enr": "0.0.20",
+        "@waku/interfaces": "0.0.21",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -29878,8 +29883,8 @@
         "@types/chai": "^4.3.11",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.20",
-        "@waku/utils": "0.0.13",
+        "@waku/interfaces": "0.0.21",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -29912,10 +29917,10 @@
         "@types/chai": "^4.3.11",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.25",
-        "@waku/interfaces": "0.0.20",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.13",
+        "@waku/core": "0.0.26",
+        "@waku/interfaces": "0.0.21",
+        "@waku/proto": "0.0.6",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -29949,8 +29954,8 @@
         "@types/debug": "^4.1.12",
         "@types/mocha": "^10.0.1",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.20",
-        "@waku/utils": "0.0.13",
+        "@waku/interfaces": "0.0.21",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "fast-check": "^3.14.0",
@@ -29970,11 +29975,11 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.25",
-        "@waku/enr": "0.0.19",
-        "@waku/interfaces": "0.0.20",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.13",
+        "@waku/core": "0.0.26",
+        "@waku/enr": "0.0.20",
+        "@waku/interfaces": "0.0.21",
+        "@waku/proto": "0.0.6",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -30010,10 +30015,10 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.25",
-        "@waku/interfaces": "0.0.20",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.13",
+        "@waku/core": "0.0.26",
+        "@waku/interfaces": "0.0.21",
+        "@waku/proto": "0.0.6",
+        "@waku/utils": "0.0.14",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
         "fast-check": "^3.14.0",
@@ -30031,12 +30036,12 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@waku/build-utils": "*",
-        "@waku/core": "0.0.25",
-        "@waku/dns-discovery": "0.0.19",
-        "@waku/interfaces": "0.0.20",
-        "@waku/peer-exchange": "^0.0.18",
-        "@waku/relay": "0.0.8",
-        "@waku/utils": "0.0.13",
+        "@waku/core": "0.0.26",
+        "@waku/dns-discovery": "0.0.20",
+        "@waku/interfaces": "0.0.21",
+        "@waku/peer-exchange": "^0.0.19",
+        "@waku/relay": "0.0.9",
+        "@waku/utils": "0.0.14",
         "cspell": "^7.3.2",
         "interface-datastore": "^8.2.5",
         "libp2p": "^0.46.14",
@@ -30093,7 +30098,7 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@waku/build-utils": "*",
-        "@waku/interfaces": "0.0.20",
+        "@waku/interfaces": "0.0.21",
         "chai": "^4.3.10",
         "cspell": "^7.3.2",
         "debug": "^4.3.4",
@@ -39735,11 +39740,13 @@
       "version": "1.3.6"
     },
     "playwright": {
-      "version": "1.38.1",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.40.1"
       },
       "dependencies": {
         "fsevents": {
@@ -39750,7 +39757,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.38.1",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
       "dev": true
     },
     "playwright-test": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "karma-webkit-launcher": "^2.1.0",
     "karma-webpack": "github:codymikol/karma-webpack#2337a82beb078c0d8e25ae8333a06249b8e72828",
     "lint-staged": "^14.0.1",
-    "playwright": "^1.38.1",
+    "playwright": "^1.40.1",
     "size-limit": "^11.0.1",
     "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",

--- a/packages/browser-tests/package.json
+++ b/packages/browser-tests/package.json
@@ -11,7 +11,7 @@
     "test": "npx playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.37.1",
+    "@playwright/test": "^1.40.1",
     "@waku/create-app": "^0.1.1-7c24ffa",
     "dotenv-flow": "^3.3.0",
     "serve": "^14.2.1"


### PR DESCRIPTION
## Problem

Auto upgrade didn't handle `playwright` due to additional package present in `browser-tests`.

## Solution

Upgrade manually. 

## Notes

- Related to https://github.com/waku-org/js-waku/pull/1752
