### PR TITLE
chore: fix go-waku interop tests

### DIFF
--- a/packages/tests/src/lib/service_node.ts
+++ b/packages/tests/src/lib/service_node.ts
@@ -264,6 +264,10 @@ export class ServiceNode {
       [pubsubTopic]
     );
 
+    if (!msgs) {
+      return [];
+    }
+
     return msgs.filter(isDefined);
   }
 
@@ -276,6 +280,10 @@ export class ServiceNode {
       "get_waku_v2_relay_v1_auto_messages",
       [contentTopic]
     );
+
+    if (!msgs) {
+      return [];
+    }
 
     return msgs.filter(isDefined);
   }

--- a/packages/tests/tests/metadata.spec.ts
+++ b/packages/tests/tests/metadata.spec.ts
@@ -54,7 +54,7 @@ describe("Metadata Protocol", () => {
 
       const shardInfoRes =
         await waku.libp2p.services.metadata?.query(nwaku1PeerId);
-      expect(shardInfoRes).to.not.be.undefined;
+      expect(shardInfoRes).to.not.eq(undefined);
       expect(shardInfoRes?.clusterId).to.equal(shardInfo.clusterId);
       expect(shardInfoRes?.shards).to.deep.equal(shardInfo.shards);
 
@@ -92,7 +92,7 @@ describe("Metadata Protocol", () => {
 
       const shardInfoRes =
         await waku.libp2p.services.metadata?.query(nwaku1PeerId);
-      expect(shardInfoRes).to.not.be.undefined;
+      expect(shardInfoRes).to.not.eq(undefined);
       expect(shardInfoRes?.clusterId).to.equal(shardInfo1.clusterId);
       expect(shardInfoRes?.shards).to.deep.equal(shardInfo1.shards);
 
@@ -196,10 +196,10 @@ describe("Metadata Protocol", () => {
     const encodedShardInfo = (
       await waku.libp2p.peerStore.get(nwaku1PeerId)
     ).metadata.get("shardInfo");
-    expect(encodedShardInfo).to.not.be.undefined;
+    expect(encodedShardInfo).to.not.eq(undefined);
 
     const metadataShardInfo = decodeRelayShard(encodedShardInfo!);
-    expect(metadataShardInfo).not.be.undefined;
+    expect(metadataShardInfo).to.not.eq(undefined);
 
     expect(metadataShardInfo!.clusterId).to.eq(shardInfo.clusterId);
     expect(metadataShardInfo.shards).to.deep.eq(shardInfo.shards);


### PR DESCRIPTION
## Problem

`js-waku` tests fail against latest `go-waku`

## Solution

Improve code to catch problematic places earlier. 
Tests started to fail at this commit [1ca39fce428e6b7e2e6c5790bec7e498d20fa41b](https://github.com/waku-org/js-waku/commit/1ca39fce428e6b7e2e6c5790bec7e498d20fa41b) but I couldn't find particular commit in `go-waku`. 
In terms of versions failures happen in `v0.9.0`. 

Major reasons for failures are RPC endpoints that have different behavior than before:
- `get_waku_v2_relay_v1_messages`
- `get_waku_v2_relay_v1_auto_messages`
- `get_waku_v2_admin_v1_peers`

Apart from that:
- seems that ability to subscribe to more than 30 topics in Filter also changed in `v0.9.0`;
- metadata is not populated for messages;


