### PR TITLE
feat: support creating node using application info

### DIFF
--- a/packages/sdk/src/create.ts
+++ b/packages/sdk/src/create.ts
@@ -6,6 +6,15 @@ import { CreateWakuNodeOptions, WakuNode, WakuOptions } from "./waku.js";
 
 export { Libp2pComponents };
 
+export async function createApplicationNode(
+  application: string,
+  version: string,
+  options: CreateWakuNodeOptions = { pubsubTopics: [] }
+): Promise<LightNode> {
+  options = options ?? {};
+  options.shardInfo = { application, version };
+  return createNode(options);
+}
 /**
  * Create a Waku node configured to use autosharding or static sharding.
  */

--- a/packages/tests/tests/sdk/application_version.spec.ts
+++ b/packages/tests/tests/sdk/application_version.spec.ts
@@ -1,0 +1,21 @@
+import { createApplicationNode, WakuNode } from "@waku/sdk";
+import {
+  contentTopicToPubsubTopic,
+  ensureValidContentTopic
+} from "@waku/utils";
+import { expect } from "chai";
+
+describe("SDK: Creating by Application and Version", function () {
+  const ContentTopic = "/myapp/1/latest/proto";
+
+  it("given an application and version, creates a waku node with the correct pubsub topic", async function () {
+    const contentTopic = ensureValidContentTopic(ContentTopic);
+    const waku = await createApplicationNode(
+      contentTopic.application,
+      contentTopic.version
+    );
+    const expectedPubsubTopic = contentTopicToPubsubTopic(ContentTopic);
+
+    expect((waku as WakuNode).pubsubTopics).to.include(expectedPubsubTopic);
+  });
+});


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

All functions to create a node allow it to be setup for either autosharding or static sharding depending on which options are passed. However, we want to encourage users to run nodes with autosharding. Requiring specific configuration options in order to set up a node to run autosharding makes it more difficult to do so.

## Solution

<!-- describe the new behavior --> 

This commit adds SDK functions for creating a node configured to use autosharding by providing an application/version or a list of content topics.
## Notes

<!-- Remove items that are not relevant -->

- Resolves #1783 
- Depends on #1780 
