### PR TITLE
test: remove go waku tests from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,6 @@ jobs:
       nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.22.0' }}
       test_type: node-optional
 
-  node_with_go_waku_master:
-    uses: ./.github/workflows/test-node.yml
-    with:
-      nim_wakunode_image: harbor.status.im/wakuorg/go-waku:latest
-      test_type: go-waku-master
-      debug: waku*
-
   node_with_nwaku_master:
     uses: ./.github/workflows/test-node.yml
     with:


### PR DESCRIPTION
Remove go-waku interop tests from CI based on [discussion](https://github.com/waku-org/pm/pull/113#event-11650239006) and the fact that go-waku interop tests if failing for a long time and taking a lot of time in the CI