### PR TITLE
chore: use updated flag values for vscode eslint settings 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "cSpell.enabled": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": false, // Disable general format on save
   "typescript.tsdk": "node_modules/typescript/lib",


### PR DESCRIPTION
## Problem

The flag `source.fixAll.eslint` supports new values on new versions of VSCode that seem to slip in automatically.

## Solution

VSCode true is set to "explicit" since VSCode 1.85.0. It seems boolean values were supported until 1.84.0.

## Notes

- Reference: https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto
- https://stackoverflow.com/questions/77637621/vscode-workspace-settings-change-on-its-own
