### PR TITLE
chore: fix export of crypto submodule

### DIFF
--- a/packages/message-encryption/src/index.ts
+++ b/packages/message-encryption/src/index.ts
@@ -10,4 +10,4 @@ export type { DecodedMessage };
 
 export * as ecies from "./ecies.js";
 export * as symmetric from "./symmetric.js";
-export * as crypto from "./crypto";
+export * as crypto from "./crypto/index.js";


### PR DESCRIPTION
## Problem

In some cases export of `./crypto` is braking some build systems.

## Solution

Make export explicit.

