### PR TITLE
feat: switches to REST for calling nwaku messages/subscription endpoints

### DIFF
--- a/packages/tests/src/lib/dockerode.ts
+++ b/packages/tests/src/lib/dockerode.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import { Logger } from "@waku/utils";
 import Docker from "dockerode";
 
-import { Args } from "../types.js";
+import { Args, Ports } from "../types.js";
 
 const log = new Logger("test:docker");
 
@@ -87,12 +87,12 @@ export default class Dockerode {
   }
 
   async startContainer(
-    ports: number[],
+    ports: Ports,
     args: Args,
     logPath: string,
     wakuServiceNodeParams?: string
   ): Promise<Docker.Container> {
-    const [rpcPort, tcpPort, websocketPort, discv5UdpPort] = ports;
+    const { rpcPort, restPort, tcpPort, websocketPort, discv5UdpPort } = ports;
 
     await this.confirmImageExistsOrPull();
 
@@ -109,6 +109,7 @@ export default class Dockerode {
       HostConfig: {
         AutoRemove: true,
         PortBindings: {
+          [`${restPort}/tcp`]: [{ HostPort: restPort.toString() }],
           [`${rpcPort}/tcp`]: [{ HostPort: rpcPort.toString() }],
           [`${tcpPort}/tcp`]: [{ HostPort: tcpPort.toString() }],
           [`${websocketPort}/tcp`]: [{ HostPort: websocketPort.toString() }],
@@ -118,6 +119,7 @@ export default class Dockerode {
         }
       },
       ExposedPorts: {
+        [`${restPort}/tcp`]: {},
         [`${rpcPort}/tcp`]: {},
         [`${tcpPort}/tcp`]: {},
         [`${websocketPort}/tcp`]: {},

--- a/packages/tests/src/types.ts
+++ b/packages/tests/src/types.ts
@@ -3,6 +3,7 @@ export interface Args {
   nat?: "none";
   listenAddress?: string;
   relay?: boolean;
+  rest?: boolean;
   rpc?: boolean;
   rpcAdmin?: boolean;
   nodekey?: string;
@@ -18,6 +19,7 @@ export interface Args {
   rpcPrivate?: boolean;
   websocketSupport?: boolean;
   tcpPort?: number;
+  restPort?: number;
   rpcPort?: number;
   websocketPort?: number;
   discv5BootstrapNode?: string;
@@ -25,6 +27,14 @@ export interface Args {
   // `legacyFilter` is required to enable filter v1 with go-waku
   legacyFilter?: boolean;
   clusterId?: number;
+}
+
+export interface Ports {
+  rpcPort: number;
+  tcpPort: number;
+  websocketPort: number;
+  restPort: number;
+  discv5UdpPort: number;
 }
 
 export enum LogLevel {

--- a/packages/tests/tests/nwaku.node.spec.ts
+++ b/packages/tests/tests/nwaku.node.spec.ts
@@ -14,6 +14,7 @@ describe("nwaku", () => {
       "--listen-address=0.0.0.0",
       "--rpc=true",
       "--relay=false",
+      "--rest=true",
       "--rpc-admin=true",
       "--websocket-support=true",
       "--log-level=TRACE",


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

nwaku will be deprecating JSON RPC API. We will no longer be able to use those endpoints in e2e tests and must switch to using the REST API.

## Solution

<!-- describe the new behavior --> 

This PR migrates two endpoints used in e2e from RPC to REST: `GET /relay/v1/messages/` and `POST /relay/v1/subscriptions`
Also updates utils for running the Docker image to provide arguments to enable `rest` and run it on `restPort`

## Notes

<!-- Remove items that are not relevant -->

- Related to #1826 
