### PR TITLE
feat: migrates e2e tests to use rest instead of rpc

### DIFF
--- a/packages/tests/src/constants.ts
+++ b/packages/tests/src/constants.ts
@@ -58,8 +58,7 @@ export const TEST_TIMESTAMPS = [
   BigInt(Date.now()) * BigInt(1000000),
   Date.now(),
   1649153314,
-  1949153314000,
-  undefined
+  1949153314000
 ];
 
 export const MOCHA_HOOK_MAX_TIMEOUT = 50_000;

--- a/packages/tests/src/types.ts
+++ b/packages/tests/src/types.ts
@@ -5,6 +5,7 @@ export interface Args {
   relay?: boolean;
   rest?: boolean;
   rpc?: boolean;
+  restAdmin?: boolean;
   rpcAdmin?: boolean;
   nodekey?: string;
   portsShift?: number;

--- a/packages/tests/tests/filter/push.node.spec.ts
+++ b/packages/tests/tests/filter/push.node.spec.ts
@@ -79,8 +79,7 @@ const runTests = (strictCheckNodes: boolean): void => {
             payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
             timestamp: testItem as any
           },
-          DefaultPubsubTopic,
-          true
+          DefaultPubsubTopic
         );
 
         expect(await serviceNodes.messageCollector.waitForMessages(1)).to.eq(
@@ -118,8 +117,7 @@ const runTests = (strictCheckNodes: boolean): void => {
           payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
           timestamp: "2023-09-06T12:05:38.609Z" as any
         },
-        DefaultPubsubTopic,
-        true
+        DefaultPubsubTopic
       );
 
       // Verify that no message was received
@@ -142,28 +140,6 @@ const runTests = (strictCheckNodes: boolean): void => {
           timestamp: BigInt(Date.now()) * BigInt(1000000)
         },
         "DefaultPubsubTopic"
-      );
-
-      expect(await serviceNodes.messageCollector.waitForMessages(1)).to.eq(
-        false
-      );
-    });
-
-    it("Check message with no pubsub topic is not received", async function () {
-      await subscription.subscribe(
-        [TestDecoder],
-        serviceNodes.messageCollector.callback
-      );
-      await delay(400);
-
-      await serviceNodes.sendRelayMessage(
-        {
-          contentTopic: TestContentTopic,
-          payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
-          timestamp: BigInt(Date.now()) * BigInt(1000000)
-        },
-        undefined,
-        true
       );
 
       expect(await serviceNodes.messageCollector.waitForMessages(1)).to.eq(
@@ -204,8 +180,7 @@ const runTests = (strictCheckNodes: boolean): void => {
           timestamp: BigInt(Date.now()) * BigInt(1000000),
           payload: undefined as any
         },
-        DefaultPubsubTopic,
-        true
+        DefaultPubsubTopic
       );
 
       // For go-waku the message is received (it is possible to send a message with no payload)

--- a/packages/tests/tests/filter/single_node/push.node.spec.ts
+++ b/packages/tests/tests/filter/single_node/push.node.spec.ts
@@ -64,14 +64,17 @@ describe("Waku Filter V2: FilterPush", function () {
       await subscription.subscribe([TestDecoder], messageCollector.callback);
       await delay(400);
 
-      await nwaku.rpcCall("post_waku_v2_relay_v1_message", [
-        DefaultPubsubTopic,
+      await nwaku.restCall<boolean>(
+        `/relay/v1/messages/${encodeURIComponent(DefaultPubsubTopic)}`,
+        "POST",
         {
           contentTopic: TestContentTopic,
           payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
-          timestamp: testItem
-        }
-      ]);
+          timestamp: testItem,
+          version: 0
+        },
+        async (res) => res.status === 200
+      );
 
       expect(await messageCollector.waitForMessages(1)).to.eq(true);
       messageCollector.verifyReceivedMessage(0, {
@@ -95,14 +98,16 @@ describe("Waku Filter V2: FilterPush", function () {
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await delay(400);
 
-    await nwaku.rpcCall("post_waku_v2_relay_v1_message", [
-      DefaultPubsubTopic,
+    await nwaku.restCall<boolean>(
+      `/relay/v1/messages/${encodeURIComponent(DefaultPubsubTopic)}`,
+      "POST",
       {
         contentTopic: TestContentTopic,
         payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
         timestamp: "2023-09-06T12:05:38.609Z"
-      }
-    ]);
+      },
+      async (res) => res.status === 200
+    );
 
     // Verify that no message was received
     expect(await messageCollector.waitForMessages(1)).to.eq(false);
@@ -112,14 +117,16 @@ describe("Waku Filter V2: FilterPush", function () {
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await delay(400);
 
-    await nwaku.rpcCall("post_waku_v2_relay_v1_message", [
-      "DefaultPubsubTopic",
+    await nwaku.restCall<boolean>(
+      `/relay/v1/messages/${encodeURIComponent("/othertopic")}`,
+      "POST",
       {
         contentTopic: TestContentTopic,
         payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
         timestamp: BigInt(Date.now()) * BigInt(1000000)
-      }
-    ]);
+      },
+      async (res) => res.status === 200
+    );
 
     expect(await messageCollector.waitForMessages(1)).to.eq(false);
   });
@@ -128,13 +135,16 @@ describe("Waku Filter V2: FilterPush", function () {
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await delay(400);
 
-    await nwaku.rpcCall("post_waku_v2_relay_v1_message", [
+    await nwaku.restCall<boolean>(
+      `/relay/v1/messages/`,
+      "POST",
       {
         contentTopic: TestContentTopic,
         payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
         timestamp: BigInt(Date.now()) * BigInt(1000000)
-      }
-    ]);
+      },
+      async (res) => res.status === 200
+    );
 
     expect(await messageCollector.waitForMessages(1)).to.eq(false);
   });
@@ -143,13 +153,15 @@ describe("Waku Filter V2: FilterPush", function () {
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await delay(400);
 
-    await nwaku.rpcCall("post_waku_v2_relay_v1_message", [
-      DefaultPubsubTopic,
+    await nwaku.restCall<boolean>(
+      `/relay/v1/messages/${encodeURIComponent(DefaultPubsubTopic)}`,
+      "POST",
       {
         payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
         timestamp: BigInt(Date.now()) * BigInt(1000000)
-      }
-    ]);
+      },
+      async (res) => res.status === 200
+    );
 
     expect(await messageCollector.waitForMessages(1)).to.eq(false);
   });
@@ -158,13 +170,15 @@ describe("Waku Filter V2: FilterPush", function () {
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await delay(400);
 
-    await nwaku.rpcCall("post_waku_v2_relay_v1_message", [
-      DefaultPubsubTopic,
+    await nwaku.restCall<boolean>(
+      `/relay/v1/messages/${encodeURIComponent(DefaultPubsubTopic)}`,
+      "POST",
       {
         contentTopic: TestContentTopic,
         timestamp: BigInt(Date.now()) * BigInt(1000000)
-      }
-    ]);
+      },
+      async (res) => res.status === 200
+    );
 
     // For go-waku the message is received (it is possible to send a message with no payload)
     if (nwaku.type == "go-waku") {
@@ -178,54 +192,18 @@ describe("Waku Filter V2: FilterPush", function () {
     await subscription.subscribe([TestDecoder], messageCollector.callback);
     await delay(400);
 
-    await nwaku.rpcCall("post_waku_v2_relay_v1_message", [
-      DefaultPubsubTopic,
+    await nwaku.restCall<boolean>(
+      `/relay/v1/messages/${encodeURIComponent(DefaultPubsubTopic)}`,
+      "POST",
       {
         contentTopic: TestContentTopic,
         payload: 12345,
         timestamp: BigInt(Date.now()) * BigInt(1000000)
-      }
-    ]);
+      },
+      async (res) => res.status === 200
+    );
 
     expect(await messageCollector.waitForMessages(1)).to.eq(false);
-  });
-
-  it("Check message with extra parameter is not received", async function () {
-    await subscription.subscribe([TestDecoder], messageCollector.callback);
-    await delay(400);
-
-    await nwaku.rpcCall("post_waku_v2_relay_v1_message", [
-      DefaultPubsubTopic,
-      "extraField",
-      {
-        contentTopic: TestContentTopic,
-        payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
-        timestamp: BigInt(Date.now()) * BigInt(1000000)
-      }
-    ]);
-
-    expect(await messageCollector.waitForMessages(1)).to.eq(false);
-  });
-
-  it("Check received message with extra option is received", async function () {
-    await subscription.subscribe([TestDecoder], messageCollector.callback);
-    await delay(400);
-
-    await nwaku.rpcCall("post_waku_v2_relay_v1_message", [
-      DefaultPubsubTopic,
-      {
-        contentTopic: TestContentTopic,
-        payload: Buffer.from(utf8ToBytes(messageText)).toString("base64"),
-        timestamp: BigInt(Date.now()) * BigInt(1000000),
-        extraOption: "extraOption"
-      }
-    ]);
-
-    expect(await messageCollector.waitForMessages(1)).to.eq(true);
-    messageCollector.verifyReceivedMessage(0, {
-      expectedMessageText: messageText,
-      expectedContentTopic: TestContentTopic
-    });
   });
 
   // Will be skipped until https://github.com/waku-org/js-waku/issues/1464 si done

--- a/packages/tests/tests/filter/utils.ts
+++ b/packages/tests/tests/filter/utils.ts
@@ -9,7 +9,11 @@ import {
   Waku
 } from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
-import { Logger } from "@waku/utils";
+import {
+  ensureShardingConfigured,
+  Logger,
+  shardInfoToPubsubTopics
+} from "@waku/utils";
 import { utf8ToBytes } from "@waku/utils/bytes";
 import { Context } from "mocha";
 import pRetry from "p-retry";
@@ -64,7 +68,7 @@ export async function runMultipleNodes(
     pubsubTopics,
     numServiceNodes,
     strictChecking,
-    shardInfo,
+    shardInfo ? ensureShardingConfigured(shardInfo).shardInfo : shardInfo,
     undefined,
     withoutFilter
   );
@@ -74,7 +78,7 @@ export async function runMultipleNodes(
     libp2p: {
       addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] }
     },
-    pubsubTopics: shardInfo ? undefined : pubsubTopics,
+    pubsubTopics: shardInfo ? shardInfoToPubsubTopics(shardInfo) : pubsubTopics,
     ...((pubsubTopics.length !== 1 ||
       pubsubTopics[0] !== DefaultPubsubTopic) && {
       shardInfo: shardInfo

--- a/packages/tests/tests/nwaku.node.spec.ts
+++ b/packages/tests/tests/nwaku.node.spec.ts
@@ -16,6 +16,7 @@ describe("nwaku", () => {
       "--relay=false",
       "--rest=true",
       "--rpc-admin=true",
+      "--rest-admin=true",
       "--websocket-support=true",
       "--log-level=TRACE",
       "--ports-shift=42"


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

nwaku is deprecating the JSON RPC api for communicating with a node. js-waku uses the api when running e2e tests.

## Solution

<!-- describe the new behavior --> 

- Replace all use of JSON RPC API with REST API
- Update docker settings to run nwaku in tests with REST enabled
- remove already deprecated endpoints from `/private`

## Notes

<!-- Remove items that are not relevant -->

- Resolves #1826 
