### PR TITLE
fix: remove rpc settings when starting nwaku image

### DIFF
--- a/packages/tests/src/lib/dockerode.ts
+++ b/packages/tests/src/lib/dockerode.ts
@@ -92,7 +92,7 @@ export default class Dockerode {
     logPath: string,
     wakuServiceNodeParams?: string
   ): Promise<Docker.Container> {
-    const { rpcPort, restPort, tcpPort, websocketPort, discv5UdpPort } = ports;
+    const { restPort, tcpPort, websocketPort, discv5UdpPort } = ports;
 
     await this.confirmImageExistsOrPull();
 
@@ -110,7 +110,6 @@ export default class Dockerode {
         AutoRemove: true,
         PortBindings: {
           [`${restPort}/tcp`]: [{ HostPort: restPort.toString() }],
-          [`${rpcPort}/tcp`]: [{ HostPort: rpcPort.toString() }],
           [`${tcpPort}/tcp`]: [{ HostPort: tcpPort.toString() }],
           [`${websocketPort}/tcp`]: [{ HostPort: websocketPort.toString() }],
           ...(args?.peerExchange && {
@@ -120,7 +119,6 @@ export default class Dockerode {
       },
       ExposedPorts: {
         [`${restPort}/tcp`]: {},
-        [`${rpcPort}/tcp`]: {},
         [`${tcpPort}/tcp`]: {},
         [`${websocketPort}/tcp`]: {},
         ...(args?.peerExchange && {

--- a/packages/tests/src/types.ts
+++ b/packages/tests/src/types.ts
@@ -4,9 +4,7 @@ export interface Args {
   listenAddress?: string;
   relay?: boolean;
   rest?: boolean;
-  rpc?: boolean;
   restAdmin?: boolean;
-  rpcAdmin?: boolean;
   nodekey?: string;
   portsShift?: number;
   logLevel?: LogLevel;
@@ -17,11 +15,9 @@ export interface Args {
   discv5Discovery?: boolean;
   storeMessageDbUrl?: string;
   pubsubTopic?: Array<string>;
-  rpcPrivate?: boolean;
   websocketSupport?: boolean;
   tcpPort?: number;
   restPort?: number;
-  rpcPort?: number;
   websocketPort?: number;
   discv5BootstrapNode?: string;
   discv5UdpPort?: number;
@@ -31,7 +27,6 @@ export interface Args {
 }
 
 export interface Ports {
-  rpcPort: number;
   tcpPort: number;
   websocketPort: number;
   restPort: number;

--- a/packages/tests/tests/nwaku.node.spec.ts
+++ b/packages/tests/tests/nwaku.node.spec.ts
@@ -12,10 +12,8 @@ describe("nwaku", () => {
 
     const expected = [
       "--listen-address=0.0.0.0",
-      "--rpc=true",
       "--relay=false",
       "--rest=true",
-      "--rpc-admin=true",
       "--rest-admin=true",
       "--websocket-support=true",
       "--log-level=TRACE",


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

Per nwaku team, all rpc flags will no longer exist after v0.26.0 release. Our tests try to start nwaku with those flags passed, and that causes problems when running against newest version.

## Solution

<!-- describe the new behavior --> 

Remove all rpc flags from Docker args when starting nwaku

## Notes

<!-- Remove items that are not relevant -->

- Related to #1826 