### PR TITLE
chore: add local peer discovery package to release tracking

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,7 @@
     "packages/dns-discovery": {},
     "packages/message-encryption": {},
     "packages/sdk": {},
-    "packages/relay": {}
+    "packages/relay": {},
+    "packages/local-peer-cache-discovery": {}
   }
 }


### PR DESCRIPTION
## Problem

`@waku/local-peer-cache-discovery` wasn't added as a tracked package for release

## Solution

Add it
