### PR TITLE
fix: use correct shard index when creating encoder

### DIFF
--- a/packages/core/src/lib/message/version_0.spec.ts
+++ b/packages/core/src/lib/message/version_0.spec.ts
@@ -137,3 +137,27 @@ describe("Ensures content topic is defined", () => {
     expect(wrapper).to.throw("Content topic must be specified");
   });
 });
+
+describe("Sets sharding configuration correctly", () => {
+  it("uses static shard pubsub topic instead of autosharding when set", async () => {
+    // Create an encoder setup to use autosharding
+    const ContentTopic = "/waku/2/content/test.js";
+    const autoshardingEncoder = createEncoder({
+      pubsubTopicShardInfo: { clusterId: 0 },
+      contentTopic: ContentTopic
+    });
+
+    // When autosharding is enabled, we expect the shard index to be 1
+    expect(autoshardingEncoder.pubsubTopic).to.be.eq("/waku/2/rs/0/1");
+
+    // Create an encoder setup to use static sharding with the same content topic
+    const singleShardInfo = { clusterId: 0, shard: 0 };
+    const staticshardingEncoder = createEncoder({
+      contentTopic: ContentTopic,
+      pubsubTopicShardInfo: singleShardInfo
+    });
+
+    // When static sharding is enabled, we expect the shard index to be 0
+    expect(staticshardingEncoder.pubsubTopic).to.be.eq("/waku/2/rs/0/0");
+  });
+});

--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -5,7 +5,7 @@ export interface SingleShardInfo {
   /**
    * Specifying this field indicates to the encoder/decoder that static sharding must be used.
    */
-  shard: number;
+  shard?: number;
 }
 
 export interface IRateLimitProof {

--- a/packages/utils/src/common/sharding.spec.ts
+++ b/packages/utils/src/common/sharding.spec.ts
@@ -409,7 +409,7 @@ describe("determinePubsubTopic", () => {
 
   it("should process correctly when SingleShardInfo has no clusterId but has a shard", () => {
     const info = { shard: 0 };
-    const expectedTopic = `/waku/2/rs/${DEFAULT_CLUSTER_ID}/6`;
+    const expectedTopic = `/waku/2/rs/${DEFAULT_CLUSTER_ID}/0`;
     expect(determinePubsubTopic(contentTopic, info as any)).to.equal(
       expectedTopic
     );

--- a/packages/utils/src/common/sharding.ts
+++ b/packages/utils/src/common/sharding.ts
@@ -13,10 +13,9 @@ import { concat, utf8ToBytes } from "../bytes/index.js";
 export const singleShardInfoToPubsubTopic = (
   shardInfo: SingleShardInfo
 ): PubsubTopic => {
-  if (shardInfo.clusterId === undefined || shardInfo.shard === undefined)
-    throw new Error("Invalid shard");
+  if (shardInfo.shard === undefined) throw new Error("Invalid shard");
 
-  return `/waku/2/rs/${shardInfo.clusterId}/${shardInfo.shard}`;
+  return `/waku/2/rs/${shardInfo.clusterId ?? DEFAULT_CLUSTER_ID}/${shardInfo.shard}`;
 };
 
 export const singleShardInfosToShardInfo = (
@@ -232,7 +231,7 @@ export function determinePubsubTopic(
     return pubsubTopicShardInfo;
   } else {
     return pubsubTopicShardInfo
-      ? pubsubTopicShardInfo.shard
+      ? pubsubTopicShardInfo.shard !== undefined
         ? singleShardInfoToPubsubTopic(pubsubTopicShardInfo)
         : contentTopicToPubsubTopic(
             contentTopic,
@@ -301,7 +300,7 @@ export const ensureShardingConfigured = (
       shardingParams: { clusterId, application, version },
       shardInfo: {
         clusterId,
-        shards: [pubsubTopicToSingleShardInfo(pubsubTopic).shard]
+        shards: [pubsubTopicToSingleShardInfo(pubsubTopic).shard!]
       },
       pubsubTopics: [pubsubTopic]
     };


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

When library consumer specifies a cluster ID and shard index when creating an encoder, it means they are using static sharding and explicitly specifying which shard index (and thus pubsub topic) should be used.

Currently, when an encoder is created this way, it uses the autosharding algorithm to determine the shard index based on content topic, which can lead to unexpected results if it doesn't match the shard index specified by the consumer.

## Solution

<!-- describe the new behavior --> 

- Make `shard` property optional in `SingleShardInfo`.
- Fix conditional that evaluates to falsy when `shard` is set to `0` (this was preventing static sharding from being used)

## Notes

<!-- Remove items that are not relevant -->

- Resolves #1874
