### PR TITLE
fix(tests): sharding: same cluster, different shard

### DIFF
--- a/packages/tests/tests/getPeers.spec.ts
+++ b/packages/tests/tests/getPeers.spec.ts
@@ -72,33 +72,45 @@ describe("getConnectedPeersForProtocolAndShard", function () {
     expect(peers.length).to.be.greaterThan(0);
   });
 
-  // Had to use cluster 0 because of https://github.com/waku-org/js-waku/issues/1848
-  it("same cluster, different shard: nodes connect", async function () {
+  it("same cluster, different shard: nodes don't connect", async function () {
     this.timeout(15000);
 
-    const shardInfo: ShardInfo = {
-      clusterId: 0,
+    const shardInfo1: ShardInfo = {
+      clusterId: 2,
       shards: [1]
     };
 
-    const shardInfoServiceNode: ShardInfo = {
-      clusterId: 0,
-      shards: [1]
+    const shardInfo2: ShardInfo = {
+      clusterId: 2,
+      shards: [2]
     };
 
+    // Separate shard
     await serviceNode1.start({
       discv5Discovery: true,
       peerExchange: true,
-      clusterId: shardInfoServiceNode.clusterId,
-      pubsubTopic: shardInfoToPubsubTopics(shardInfoServiceNode),
+      clusterId: shardInfo1.clusterId,
+      pubsubTopic: shardInfoToPubsubTopics(shardInfo1),
       lightpush: true,
       relay: true
     });
 
-    const serviceNodeMa = await serviceNode1.getMultiaddrWithId();
+    // Same shard
+    await serviceNode2.start({
+      discv5Discovery: true,
+      peerExchange: true,
+      clusterId: shardInfo2.clusterId,
+      pubsubTopic: shardInfoToPubsubTopics(shardInfo2),
+      lightpush: true,
+      relay: true
+    });
 
-    waku = await createLightNode({ shardInfo });
-    await waku.libp2p.dialProtocol(serviceNodeMa, LightPushCodec);
+    const serviceNode1Ma = await serviceNode1.getMultiaddrWithId();
+    const serviceNode2Ma = await serviceNode2.getMultiaddrWithId();
+
+    waku = await createLightNode({ shardInfo: shardInfo2 });
+    await waku.libp2p.dialProtocol(serviceNode1Ma, LightPushCodec);
+    await waku.libp2p.dialProtocol(serviceNode2Ma, LightPushCodec);
     await waku.start();
     await waitForRemotePeer(waku, [Protocols.LightPush]);
 
@@ -106,9 +118,9 @@ describe("getConnectedPeersForProtocolAndShard", function () {
       waku.libp2p.getConnections(),
       waku.libp2p.peerStore,
       waku.libp2p.getProtocols(),
-      shardInfo
+      ensureShardingConfigured(shardInfo2).shardInfo
     );
-    expect(peers.length).to.be.greaterThan(0);
+    expect(peers.length).to.be.equal(1);
   });
 
   it("different cluster, same shard: nodes don't connect", async function () {


### PR DESCRIPTION
## Problem

The tests written to check connection for nodes when the cluster is same, but the shard is different, was expected to have the nodes connect. This worked fine interop until nwaku rc 0.24.0
With the introduction of the metadata protocol, the tests started to fail since this should not be allowed and the actual expectation from the test is that the nodes **should not connect**

## Solution


## Notes

- Resolves https://github.com/waku-org/js-waku/issues/1848

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
