### PR TITLE
feat: peer-exchange uses error codes

### DIFF
--- a/packages/core/src/lib/light_push/index.ts
+++ b/packages/core/src/lib/light_push/index.ts
@@ -6,7 +6,8 @@ import {
   IMessage,
   Libp2p,
   ProtocolCreateOptions,
-  ProtocolError
+  ProtocolError,
+  ProtocolResult
 } from "@waku/interfaces";
 import { PushResponse } from "@waku/proto";
 import { isMessageSizeUnderCap } from "@waku/utils";
@@ -25,25 +26,9 @@ const log = new Logger("light-push");
 export const LightPushCodec = "/vac/waku/lightpush/2.0.0-beta1";
 export { PushResponse };
 
-type PreparePushMessageResult =
-  | {
-      query: PushRpc;
-      error: null;
-    }
-  | {
-      query: null;
-      error: ProtocolError;
-    };
+type PreparePushMessageResult = ProtocolResult<"query", PushRpc>;
 
-type CoreSendResult =
-  | {
-      success: null;
-      failure: Failure;
-    }
-  | {
-      success: PeerId;
-      failure: null;
-    };
+type CoreSendResult = ProtocolResult<"success", PeerId, "failure", Failure>;
 
 /**
  * Implements the [Waku v2 Light Push protocol](https://rfc.vac.dev/spec/19/).

--- a/packages/discovery/src/peer-exchange/waku_peer_exchange_discovery.ts
+++ b/packages/discovery/src/peer-exchange/waku_peer_exchange_discovery.ts
@@ -7,7 +7,12 @@ import type {
   PeerId,
   PeerInfo
 } from "@libp2p/interface";
-import { Libp2pComponents, PubsubTopic, Tags } from "@waku/interfaces";
+import {
+  Libp2pComponents,
+  PeerExchangeResult,
+  PubsubTopic,
+  Tags
+} from "@waku/interfaces";
 import { encodeRelayShard, Logger } from "@waku/utils";
 
 import { PeerExchangeCodec, WakuPeerExchange } from "./waku_peer_exchange.js";
@@ -160,15 +165,15 @@ export class PeerExchangeDiscovery
     }, queryInterval * currentAttempt);
   };
 
-  private async query(peerId: PeerId): Promise<void> {
-    const peerInfos = await this.peerExchange.query({
+  private async query(peerId: PeerId): Promise<PeerExchangeResult> {
+    const { error, peerInfos } = await this.peerExchange.query({
       numPeers: DEFAULT_PEER_EXCHANGE_REQUEST_NODES,
       peerId
     });
 
-    if (!peerInfos) {
-      log.error("Peer exchange query failed, no peer info returned");
-      return;
+    if (error) {
+      log.error("Peer exchange query failed", error);
+      return { error, peerInfos: null };
     }
 
     for (const _peerInfo of peerInfos) {
@@ -214,6 +219,8 @@ export class PeerExchangeDiscovery
         })
       );
     }
+
+    return { error: null, peerInfos };
   }
 
   private abortQueriesForPeer(peerIdStr: string): void {

--- a/packages/interfaces/src/metadata.ts
+++ b/packages/interfaces/src/metadata.ts
@@ -1,21 +1,13 @@
 import type { PeerId } from "@libp2p/interface";
 
-import type { ShardInfo } from "./enr.js";
+import { type ShardInfo } from "./enr.js";
 import type {
   IBaseProtocolCore,
-  ProtocolError,
+  ProtocolResult,
   ShardingParams
 } from "./protocols.js";
 
-export type QueryResult =
-  | {
-      shardInfo: ShardInfo;
-      error: null;
-    }
-  | {
-      shardInfo: null;
-      error: ProtocolError;
-    };
+export type QueryResult = ProtocolResult<"shardInfo", ShardInfo>;
 
 // IMetadata always has shardInfo defined while it is optionally undefined in IBaseProtocol
 export interface IMetadata extends Omit<IBaseProtocolCore, "shardInfo"> {

--- a/packages/interfaces/src/peer_exchange.ts
+++ b/packages/interfaces/src/peer_exchange.ts
@@ -3,11 +3,13 @@ import type { PeerStore } from "@libp2p/interface";
 import type { ConnectionManager } from "@libp2p/interface-internal";
 
 import { IEnr } from "./enr.js";
-import { IBaseProtocolCore } from "./protocols.js";
+import { IBaseProtocolCore, ProtocolResult } from "./protocols.js";
 
 export interface IPeerExchange extends IBaseProtocolCore {
-  query(params: PeerExchangeQueryParams): Promise<PeerInfo[] | undefined>;
+  query(params: PeerExchangeQueryParams): Promise<PeerExchangeResult>;
 }
+
+export type PeerExchangeResult = ProtocolResult<"peerInfos", PeerInfo[]>;
 
 export interface PeerExchangeQueryParams {
   numPeers: number;

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -101,6 +101,16 @@ export type Callback<T extends IDecodedMessage> = (
   msg: T
 ) => void | Promise<void>;
 
+// K = key name
+// T = value type
+export type ProtocolResult<K extends string, T> =
+  | ({
+      [key in K]: T;
+    } & { error: null })
+  | ({
+      [key in K]: null;
+    } & { error: ProtocolError });
+
 export enum ProtocolError {
   /** Could not determine the origin of the fault. Best to check connectivity and try again */
   GENERIC_FAIL = "Generic error",

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -101,15 +101,26 @@ export type Callback<T extends IDecodedMessage> = (
   msg: T
 ) => void | Promise<void>;
 
-// K = key name
-// T = value type
-export type ProtocolResult<K extends string, T> =
+// SK = success key name
+// SV = success value type
+// EK = error key name (default: "error")
+// EV = error value type (default: ProtocolError)
+export type ProtocolResult<
+  SK extends string,
+  SV,
+  EK extends string = "error",
+  EV = ProtocolError
+> =
   | ({
-      [key in K]: T;
-    } & { error: null })
+      [key in SK]: SV;
+    } & {
+      [key in EK]: null;
+    })
   | ({
-      [key in K]: null;
-    } & { error: ProtocolError });
+      [key in SK]: null;
+    } & {
+      [key in EK]: EV;
+    });
 
 export enum ProtocolError {
   /** Could not determine the origin of the fault. Best to check connectivity and try again */

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -167,7 +167,12 @@ export enum ProtocolError {
    * is logged. Review message validity, or mitigation for `NO_PEER_AVAILABLE`
    * or `DECODE_FAILED` can be used.
    */
-  REMOTE_PEER_REJECTED = "Remote peer rejected"
+  REMOTE_PEER_REJECTED = "Remote peer rejected",
+  /**
+   * The protocol request timed out without a response. This may be due to a connection issue.
+   * Mitigation can be: retrying after a given time period
+   */
+  REQUEST_TIMEOUT = "Request timeout"
 }
 
 export interface Failure {

--- a/packages/tests/tests/peer-exchange/query.spec.ts
+++ b/packages/tests/tests/peer-exchange/query.spec.ts
@@ -137,7 +137,7 @@ describe("Peer Exchange Query", function () {
     await tearDownNodes([nwaku1, nwaku2, nwaku3], waku);
   });
 
-  // slow and flaky in CI
+  // slow and flaky in CI: https://github.com/waku-org/js-waku/issues/1911
   it.skip("connected peers and dial", async function () {
     expect(queryResult.error).to.be.null;
 
@@ -164,7 +164,7 @@ describe("Peer Exchange Query", function () {
     await waitForRemotePeerWithCodec(waku, PeerExchangeCodec, foundNodePeerId);
   });
 
-  // slow and flaky in CI
+  // slow and flaky in CI: https://github.com/waku-org/js-waku/issues/1911
   it.skip("more peers than existing", async function () {
     const result = await peerExchange.query({
       peerId: nwaku3PeerId,
@@ -174,7 +174,7 @@ describe("Peer Exchange Query", function () {
     expect(result.peerInfos?.length).to.be.eq(numPeersToRequest);
   });
 
-  // slow and flaky in CI
+  // slow and flaky in CI: https://github.com/waku-org/js-waku/issues/1911
   it.skip("less peers than existing", async function () {
     const result = await peerExchange.query({
       peerId: nwaku3PeerId,
@@ -184,7 +184,7 @@ describe("Peer Exchange Query", function () {
     expect(result.peerInfos?.length).to.be.eq(1);
   });
 
-  // slow and flaky in CI
+  // slow and flaky in CI: https://github.com/waku-org/js-waku/issues/1911
   it.skip("non connected peers", async function () {
     // querying the non connected peer
     const result = await peerExchange.query({


### PR DESCRIPTION
## Problem

Protocols currently use different pattern to handle errors: #1694.

## Solution

- addresses the peer-exchange protocol to use error codes
- introduces a generic that can be reused in each protocol with flexibility (DRY)
- gives a much better error handling since `error` (with `unknown` type) is not thrown, but returned with a predetermined type

## Notes

- Related to https://github.com/waku-org/js-waku/issues/1694

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
