### PR TITLE
fix: check if process is defined before accessing it

### DIFF
--- a/packages/sdk/src/utils/libp2p.ts
+++ b/packages/sdk/src/utils/libp2p.ts
@@ -37,7 +37,7 @@ export async function defaultLibp2p(
   options?: Partial<CreateLibp2pOptions>,
   userAgent?: string
 ): Promise<Libp2p> {
-  if (!options?.hideWebSocketInfo && process.env.NODE_ENV !== "test") {
+  if (!options?.hideWebSocketInfo && process?.env?.NODE_ENV !== "test") {
     /* eslint-disable no-console */
     console.info(
       "%cIgnore WebSocket connection failures",


### PR DESCRIPTION
## Problem

When running the js-waku lab examples, accessing `process` directly breaks as the variable is undefined.

## Solution

Check for `process` and `process.env` not being `undefined`

## Notes

<!-- Remove items that are not relevant -->

- Resolves <issue number>
- Related to <link to specs>

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
