### PR TITLE
chore: force discovery release version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,5 +8,6 @@
   "packages/message-encryption": "0.0.25",
   "packages/relay": "0.0.10",
   "packages/sdk": "0.0.23",
-  "packages/react-native-polyfills": "0.0.1"
+  "packages/react-native-polyfills": "0.0.1",
+  "packages/discovery": "0.0.1"
 }


### PR DESCRIPTION
## Problem

Similarly to https://github.com/waku-org/js-waku/pull/1937 release of `discovery` starts with `1.0.0`.

## Solution

Force it to start with `0.0.2`.
