### PR TITLE
chore: initialize new packages from 0.0.0 version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,5 +8,6 @@
   "packages/message-encryption": "0.0.25",
   "packages/relay": "0.0.10",
   "packages/sdk": "0.0.23",
-  "packages/react-native-polyfills": "0.0.1"
+  "packages/react-native-polyfills": "0.0.1",
+  "packages/discovery": "0.0.1"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,6 +8,6 @@
   "packages/message-encryption": "0.0.25",
   "packages/relay": "0.0.10",
   "packages/sdk": "0.0.23",
-  "packages/react-native-polyfills": "0.0.1",
-  "packages/discovery": "0.0.1"
+  "packages/react-native-polyfills": "0.0.0",
+  "packages/discovery": "0.0.0"
 }


### PR DESCRIPTION
## Problem

Since `discovery` is consumed and locked to 0.0.1 in other packages and release bot tries to bump it to 0.0.2 - it fails.

## Solution

We should seed release with 0.0.0 to have 0.0.1 as the first version to be released. According [to docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#bootstrapping) it seems the most straightforward way 
