### PR TITLE
chore: update release-please config and fix missing dependency on discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36536,6 +36536,7 @@
       "version": "0.0.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
+        "@waku/core": "0.0.27",
         "@waku/enr": "0.0.21",
         "@waku/interfaces": "0.0.22",
         "@waku/proto": "^0.0.6",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -54,6 +54,7 @@
     "@waku/interfaces": "0.0.22",
     "@waku/proto": "^0.0.6",
     "@waku/enr": "0.0.21",
+    "@waku/core": "0.0.27",
     "@waku/utils": "0.0.15",
     "debug": "^4.3.4",
     "dns-query": "^0.11.2",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,12 @@
 {
   "bootstrap-sha": "aead369227b49ea9c4619dec48f079ebfc0c85db",
-  "plugins": ["node-workspace", "sentence-case"],
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "updatePeerDependencies": true
+    },
+    "sentence-case"
+  ],
   "release-type": "node",
   "separate-pull-requests": false,
   "versioning": "always-bump-patch",
@@ -15,7 +21,11 @@
     "packages/message-encryption": {},
     "packages/sdk": {},
     "packages/relay": {},
-    "packages/discovery": { "release-as": "0.0.1" },
-    "packages/react-native-polyfills": { "release-as": "0.0.1" }
+    "packages/discovery": {
+      "release-as": "0.0.1"
+    },
+    "packages/react-native-polyfills": {
+      "release-as": "0.0.1"
+    }
   }
 }


### PR DESCRIPTION
## Problem

`@waku/discovery` is missing `core` as dependency
`release-please` is not bumping `peer` dependencies

## Solution

Add dependency
Update config