### PR TITLE
fix: Added missing values for HistoryError to be sync with nwaku

### DIFF
--- a/packages/proto/src/generated/store.ts
+++ b/packages/proto/src/generated/store.ts
@@ -376,12 +376,16 @@ export interface HistoryResponse {
 export namespace HistoryResponse {
   export enum HistoryError {
     NONE = 'NONE',
-    INVALID_CURSOR = 'INVALID_CURSOR'
+    INVALID_CURSOR = 'INVALID_CURSOR',
+    TOO_MANY_RESULTS = 'TOO_MANY_RESULTS',
+    SERVICE_UNAVAILABLE = 'SERVICE_UNAVAILABLE'
   }
 
   enum __HistoryErrorValues {
     NONE = 0,
-    INVALID_CURSOR = 1
+    INVALID_CURSOR = 1,
+    TOO_MANY_RESULTS = 429,
+    SERVICE_UNAVAILABLE = 503
   }
 
   export namespace HistoryError {

--- a/packages/proto/src/lib/store.proto
+++ b/packages/proto/src/lib/store.proto
@@ -42,6 +42,8 @@ message HistoryResponse {
   enum HistoryError {
     NONE = 0;
     INVALID_CURSOR = 1;
+    TOO_MANY_RESULTS = 429;
+    SERVICE_UNAVAILABLE = 503;
   }
   HistoryError error = 4;
 }


### PR DESCRIPTION
## Problem

Find test failure in nwaku ci:

```
2024-04-09T09:49:52.0513572Z   8) Waku Store, general
2024-04-09T09:49:52.0513871Z        Query generator for 2000 messages:
2024-04-09T09:49:52.0514217Z      Error: Invalid enum value
2024-04-09T09:49:52.0514929Z       at findValue (file:///home/runner/work/nwaku/nwaku/node_modules/protons-runtime/src/codecs/enum.ts:9:13)
2024-04-09T09:49:52.0516150Z       at Object.enumDecode [as decode] (file:///home/runner/work/nwaku/nwaku/node_modules/protons-runtime/src/codecs/enum.ts:24:12)
2024-04-09T09:49:52.0517376Z       at Object.decode (file:///home/runner/work/nwaku/nwaku/packages/proto/src/generated/store.ts:451:64)
2024-04-09T09:49:52.0519087Z       at Object.decode (file:///home/runner/work/nwaku/nwaku/packages/proto/src/generated/store.ts:533:54)
2024-04-09T09:49:52.0521545Z       at decodeMessage (file:///home/runner/work/nwaku/nwaku/node_modules/protons-runtime/src/decode.ts:8:16)
2024-04-09T09:49:52.0522987Z       at Object.HistoryRpc.decode (file:///home/runner/work/nwaku/nwaku/packages/proto/src/generated/store.ts:557:12)
2024-04-09T09:49:52.0524260Z       at HistoryRpc.decode (file:///home/runner/work/nwaku/nwaku/packages/core/src/lib/store/history_rpc.ts:73:34)
2024-04-09T09:49:52.0525300Z       at StoreCore.queryPerPage (file:///home/runner/work/nwaku/nwaku/packages/core/src/lib/store/index.ts:110:37)
2024-04-09T09:49:52.0526135Z       at processTicksAndRejections (node:internal/process/task_queues:95:5)
2024-04-09T09:49:52.0526996Z       at async StoreSDK.queryGenerator (file:///home/runner/work/nwaku/nwaku/packages/sdk/src/protocols/store.ts:83:22)
2024-04-09T09:49:52.0527571Z 
```

Found missing enum values from HistoryError in protobuf definition.
Please help me elaborate this PR for me ;-)