### PR TITLE
fix: Handle local storage missing when saving peers

### DIFF
--- a/packages/discovery/src/local-peer-cache/index.ts
+++ b/packages/discovery/src/local-peer-cache/index.ts
@@ -136,7 +136,11 @@ export class LocalPeerCacheDiscovery
   }
 
   private savePeersToLocalStorage(): void {
-    localStorage.setItem("waku:peers", JSON.stringify(this.peers));
+    try {
+      localStorage.setItem("waku:peers", JSON.stringify(this.peers));
+    } catch (error) {
+      log.error("Error saving peers to local storage:", error);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
Trigger local storage missing error when calling `savePeersToLocalStorage` in `nodejs`


## Solution

Wrap the problematic block of code with a `try-catch` clause to handle any potential errors.

## Notes

<!-- Remove items that are not relevant -->

- Resolves https://github.com/waku-org/js-waku/issues/1953

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
