### PR TITLE
feat(filter)!: return error codes instead of throwing errors

### DIFF
--- a/packages/core/src/lib/filter/index.ts
+++ b/packages/core/src/lib/filter/index.ts
@@ -2,11 +2,11 @@ import type { Peer, Stream } from "@libp2p/interface";
 import type { IncomingStreamData } from "@libp2p/interface-internal";
 import {
   type ContentTopic,
+  CoreProtocolResult,
   type IBaseProtocolCore,
   type Libp2p,
   type ProtocolCreateOptions,
   ProtocolError,
-  type ProtocolRequestResult,
   type PubsubTopic
 } from "@waku/interfaces";
 import { WakuMessage } from "@waku/proto";
@@ -93,7 +93,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
     pubsubTopic: PubsubTopic,
     peer: Peer,
     contentTopics: ContentTopic[]
-  ): Promise<ProtocolRequestResult> {
+  ): Promise<CoreProtocolResult> {
     const stream = await this.getStream(peer);
 
     const request = FilterSubscribeRpc.createSubscribeRequest(
@@ -145,7 +145,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
     pubsubTopic: PubsubTopic,
     peer: Peer,
     contentTopics: ContentTopic[]
-  ): Promise<ProtocolRequestResult> {
+  ): Promise<CoreProtocolResult> {
     let stream: Stream | undefined;
     try {
       stream = await this.getStream(peer);
@@ -190,7 +190,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
   async unsubscribeAll(
     pubsubTopic: PubsubTopic,
     peer: Peer
-  ): Promise<ProtocolRequestResult> {
+  ): Promise<CoreProtocolResult> {
     const stream = await this.getStream(peer);
 
     const request = FilterSubscribeRpc.createUnsubscribeAllRequest(pubsubTopic);
@@ -235,7 +235,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
     };
   }
 
-  async ping(peer: Peer): Promise<ProtocolRequestResult> {
+  async ping(peer: Peer): Promise<CoreProtocolResult> {
     let stream: Stream | undefined;
     try {
       stream = await this.getStream(peer);

--- a/packages/core/src/lib/light_push/index.ts
+++ b/packages/core/src/lib/light_push/index.ts
@@ -1,13 +1,13 @@
-import type { Peer, PeerId, Stream } from "@libp2p/interface";
+import type { Peer, Stream } from "@libp2p/interface";
 import {
-  Failure,
-  IBaseProtocolCore,
-  IEncoder,
-  IMessage,
-  Libp2p,
-  ProtocolCreateOptions,
+  type IBaseProtocolCore,
+  type IEncoder,
+  type IMessage,
+  type Libp2p,
+  type ProtocolCreateOptions,
   ProtocolError,
-  ProtocolResult
+  ProtocolRequestResult,
+  type ResultWithError
 } from "@waku/interfaces";
 import { PushResponse } from "@waku/proto";
 import { isMessageSizeUnderCap } from "@waku/utils";
@@ -26,9 +26,7 @@ const log = new Logger("light-push");
 export const LightPushCodec = "/vac/waku/lightpush/2.0.0-beta1";
 export { PushResponse };
 
-type PreparePushMessageResult = ProtocolResult<"query", PushRpc>;
-
-type CoreSendResult = ProtocolResult<"success", PeerId, "failure", Failure>;
+type PreparePushMessageResult = ResultWithError<"query", PushRpc>;
 
 /**
  * Implements the [Waku v2 Light Push protocol](https://rfc.vac.dev/spec/19/).
@@ -84,7 +82,7 @@ export class LightPushCore extends BaseProtocol implements IBaseProtocolCore {
     encoder: IEncoder,
     message: IMessage,
     peer: Peer
-  ): Promise<CoreSendResult> {
+  ): Promise<ProtocolRequestResult> {
     const { query, error: preparationError } = await this.preparePushMessage(
       encoder,
       message

--- a/packages/core/src/lib/light_push/index.ts
+++ b/packages/core/src/lib/light_push/index.ts
@@ -1,13 +1,13 @@
 import type { Peer, Stream } from "@libp2p/interface";
 import {
+  type CoreProtocolResult,
   type IBaseProtocolCore,
   type IEncoder,
   type IMessage,
   type Libp2p,
   type ProtocolCreateOptions,
   ProtocolError,
-  ProtocolRequestResult,
-  type ResultWithError
+  type ThisOrThat
 } from "@waku/interfaces";
 import { PushResponse } from "@waku/proto";
 import { isMessageSizeUnderCap } from "@waku/utils";
@@ -26,7 +26,7 @@ const log = new Logger("light-push");
 export const LightPushCodec = "/vac/waku/lightpush/2.0.0-beta1";
 export { PushResponse };
 
-type PreparePushMessageResult = ResultWithError<"query", PushRpc>;
+type PreparePushMessageResult = ThisOrThat<"query", PushRpc>;
 
 /**
  * Implements the [Waku v2 Light Push protocol](https://rfc.vac.dev/spec/19/).
@@ -82,7 +82,7 @@ export class LightPushCore extends BaseProtocol implements IBaseProtocolCore {
     encoder: IEncoder,
     message: IMessage,
     peer: Peer
-  ): Promise<ProtocolRequestResult> {
+  ): Promise<CoreProtocolResult> {
     const { query, error: preparationError } = await this.preparePushMessage(
       encoder,
       message

--- a/packages/core/src/lib/metadata/index.ts
+++ b/packages/core/src/lib/metadata/index.ts
@@ -3,9 +3,9 @@ import { IncomingStreamData } from "@libp2p/interface";
 import {
   type IMetadata,
   type Libp2pComponents,
+  type MetadataQueryResult,
   type PeerIdStr,
   ProtocolError,
-  QueryResult,
   type ShardInfo
 } from "@waku/interfaces";
 import { proto_metadata } from "@waku/proto";
@@ -74,7 +74,7 @@ class Metadata extends BaseProtocol implements IMetadata {
   /**
    * Make a metadata query to a peer
    */
-  async query(peerId: PeerId): Promise<QueryResult> {
+  async query(peerId: PeerId): Promise<MetadataQueryResult> {
     const request = proto_metadata.WakuMetadataRequest.encode(this.shardInfo);
 
     const peer = await this.peerStore.get(peerId);
@@ -112,7 +112,9 @@ class Metadata extends BaseProtocol implements IMetadata {
     };
   }
 
-  public async confirmOrAttemptHandshake(peerId: PeerId): Promise<QueryResult> {
+  public async confirmOrAttemptHandshake(
+    peerId: PeerId
+  ): Promise<MetadataQueryResult> {
     const shardInfo = this.handshakesConfirmed.get(peerId.toString());
     if (shardInfo) {
       return {
@@ -126,7 +128,7 @@ class Metadata extends BaseProtocol implements IMetadata {
 
   private decodeMetadataResponse(
     encodedResponse: Uint8ArrayList[]
-  ): QueryResult {
+  ): MetadataQueryResult {
     const bytes = new Uint8ArrayList();
 
     encodedResponse.forEach((chunk) => {

--- a/packages/interfaces/src/filter.ts
+++ b/packages/interfaces/src/filter.ts
@@ -5,7 +5,8 @@ import type { ContentTopic, PubsubTopic } from "./misc.js";
 import type {
   Callback,
   IBaseProtocolCore,
-  IBaseProtocolSDK
+  IBaseProtocolSDK,
+  SDKProtocolResult
 } from "./protocols.js";
 import type { IReceiver } from "./receiver.js";
 
@@ -13,25 +14,25 @@ export type ContentFilter = {
   contentTopic: string;
 };
 
-export interface IFilterSubscription {
+export type IFilter = IReceiver & IBaseProtocolCore;
+
+export interface IFilterSubscriptionSDK {
   subscribe<T extends IDecodedMessage>(
     decoders: IDecoder<T> | IDecoder<T>[],
     callback: Callback<T>
-  ): Promise<void>;
+  ): Promise<SDKProtocolResult>;
 
-  unsubscribe(contentTopics: ContentTopic[]): Promise<void>;
+  unsubscribe(contentTopics: ContentTopic[]): Promise<SDKProtocolResult>;
 
-  ping(): Promise<void>;
+  ping(): Promise<SDKProtocolResult>;
 
-  unsubscribeAll(): Promise<void>;
+  unsubscribeAll(): Promise<SDKProtocolResult>;
 }
-
-export type IFilter = IReceiver & IBaseProtocolCore;
 
 export type IFilterSDK = IReceiver &
   IBaseProtocolSDK & { protocol: IBaseProtocolCore } & {
     createSubscription(
       pubsubTopicShardInfo?: SingleShardInfo | PubsubTopic,
       peerId?: PeerId
-    ): Promise<IFilterSubscription>;
+    ): Promise<IFilterSubscriptionSDK>;
   };

--- a/packages/interfaces/src/metadata.ts
+++ b/packages/interfaces/src/metadata.ts
@@ -3,15 +3,15 @@ import type { PeerId } from "@libp2p/interface";
 import { type ShardInfo } from "./enr.js";
 import type {
   IBaseProtocolCore,
-  ProtocolResult,
+  ResultWithError,
   ShardingParams
 } from "./protocols.js";
 
-export type QueryResult = ProtocolResult<"shardInfo", ShardInfo>;
+export type MetadataQueryResult = ResultWithError<"shardInfo", ShardInfo>;
 
 // IMetadata always has shardInfo defined while it is optionally undefined in IBaseProtocol
 export interface IMetadata extends Omit<IBaseProtocolCore, "shardInfo"> {
   shardInfo: ShardingParams;
-  confirmOrAttemptHandshake(peerId: PeerId): Promise<QueryResult>;
-  query(peerId: PeerId): Promise<QueryResult>;
+  confirmOrAttemptHandshake(peerId: PeerId): Promise<MetadataQueryResult>;
+  query(peerId: PeerId): Promise<MetadataQueryResult>;
 }

--- a/packages/interfaces/src/metadata.ts
+++ b/packages/interfaces/src/metadata.ts
@@ -1,13 +1,10 @@
 import type { PeerId } from "@libp2p/interface";
 
 import { type ShardInfo } from "./enr.js";
-import type {
-  IBaseProtocolCore,
-  ResultWithError,
-  ShardingParams
-} from "./protocols.js";
+import { ThisOrThat } from "./misc.js";
+import type { IBaseProtocolCore, ShardingParams } from "./protocols.js";
 
-export type MetadataQueryResult = ResultWithError<"shardInfo", ShardInfo>;
+export type MetadataQueryResult = ThisOrThat<"shardInfo", ShardInfo>;
 
 // IMetadata always has shardInfo defined while it is optionally undefined in IBaseProtocol
 export interface IMetadata extends Omit<IBaseProtocolCore, "shardInfo"> {

--- a/packages/interfaces/src/misc.ts
+++ b/packages/interfaces/src/misc.ts
@@ -1,4 +1,5 @@
 import type { IDecodedMessage } from "./message.js";
+import { ProtocolError } from "./protocols.js";
 
 export interface IAsyncIterator<T extends IDecodedMessage> {
   iterator: AsyncIterator<T>;
@@ -11,3 +12,23 @@ export type PubsubTopic = string;
 export type ContentTopic = string;
 
 export type PeerIdStr = string;
+
+// SK = success key name
+// SV = success value type
+// EK = error key name (default: "error")
+// EV = error value type (default: ProtocolError)
+export type ThisOrThat<
+  SK extends string,
+  SV,
+  EK extends string = "error",
+  EV = ProtocolError
+> =
+  | ({ [key in SK]: SV } & { [key in EK]: null })
+  | ({ [key in SK]: null } & { [key in EK]: EV });
+
+export type ThisAndThat<
+  SK extends string,
+  SV,
+  EK extends string = "error",
+  EV = ProtocolError
+> = { [key in SK]: SV } & { [key in EK]: EV };

--- a/packages/interfaces/src/peer_exchange.ts
+++ b/packages/interfaces/src/peer_exchange.ts
@@ -3,13 +3,14 @@ import type { PeerStore } from "@libp2p/interface";
 import type { ConnectionManager } from "@libp2p/interface-internal";
 
 import { IEnr } from "./enr.js";
-import { IBaseProtocolCore, ResultWithError } from "./protocols.js";
+import { ThisOrThat } from "./misc.js";
+import { IBaseProtocolCore } from "./protocols.js";
 
 export interface IPeerExchange extends IBaseProtocolCore {
   query(params: PeerExchangeQueryParams): Promise<PeerExchangeQueryResult>;
 }
 
-export type PeerExchangeQueryResult = ResultWithError<"peerInfos", PeerInfo[]>;
+export type PeerExchangeQueryResult = ThisOrThat<"peerInfos", PeerInfo[]>;
 
 export interface PeerExchangeQueryParams {
   numPeers: number;

--- a/packages/interfaces/src/peer_exchange.ts
+++ b/packages/interfaces/src/peer_exchange.ts
@@ -3,13 +3,13 @@ import type { PeerStore } from "@libp2p/interface";
 import type { ConnectionManager } from "@libp2p/interface-internal";
 
 import { IEnr } from "./enr.js";
-import { IBaseProtocolCore, ProtocolResult } from "./protocols.js";
+import { IBaseProtocolCore, ResultWithError } from "./protocols.js";
 
 export interface IPeerExchange extends IBaseProtocolCore {
-  query(params: PeerExchangeQueryParams): Promise<PeerExchangeResult>;
+  query(params: PeerExchangeQueryParams): Promise<PeerExchangeQueryResult>;
 }
 
-export type PeerExchangeResult = ProtocolResult<"peerInfos", PeerInfo[]>;
+export type PeerExchangeQueryResult = ResultWithError<"peerInfos", PeerInfo[]>;
 
 export interface PeerExchangeQueryParams {
   numPeers: number;

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -105,7 +105,7 @@ export type Callback<T extends IDecodedMessage> = (
 // SV = success value type
 // EK = error key name (default: "error")
 // EV = error value type (default: ProtocolError)
-export type ProtocolResult<
+export type ResultWithError<
   SK extends string,
   SV,
   EK extends string = "error",
@@ -184,3 +184,10 @@ export interface SendResult {
   failures?: Failure[];
   successes: PeerId[];
 }
+
+export type ProtocolRequestResult = ResultWithError<
+  "success",
+  PeerId,
+  "failure",
+  Failure
+>;

--- a/packages/interfaces/src/sender.ts
+++ b/packages/interfaces/src/sender.ts
@@ -1,6 +1,6 @@
 import type { IEncoder, IMessage } from "./message.js";
-import type { SendResult } from "./protocols.js";
+import { SDKProtocolResult } from "./protocols.js";
 
 export interface ISender {
-  send: (encoder: IEncoder, message: IMessage) => Promise<SendResult>;
+  send: (encoder: IEncoder, message: IMessage) => Promise<SDKProtocolResult>;
 }

--- a/packages/sdk/src/protocols/light_push.ts
+++ b/packages/sdk/src/protocols/light_push.ts
@@ -8,7 +8,7 @@ import {
   type Libp2p,
   type ProtocolCreateOptions,
   ProtocolError,
-  type SendResult
+  SDKProtocolResult
 } from "@waku/interfaces";
 import { ensurePubsubTopicIsConfigured, Logger } from "@waku/utils";
 
@@ -24,7 +24,7 @@ class LightPushSDK extends BaseProtocolSDK implements ILightPushSDK {
     this.protocol = new LightPushCore(libp2p, options);
   }
 
-  async send(encoder: IEncoder, message: IMessage): Promise<SendResult> {
+  async send(encoder: IEncoder, message: IMessage): Promise<SDKProtocolResult> {
     const successes: PeerId[] = [];
     const failures: Failure[] = [];
 

--- a/packages/sdk/src/utils/content_topic.ts
+++ b/packages/sdk/src/utils/content_topic.ts
@@ -3,7 +3,7 @@ import { createDecoder, DecodedMessage, waitForRemotePeer } from "@waku/core";
 import {
   Callback,
   IDecoder,
-  IFilterSubscription,
+  IFilterSubscriptionSDK,
   LightNode,
   Protocols
 } from "@waku/interfaces";
@@ -27,7 +27,7 @@ async function prepareSubscription(
   peer: Multiaddr
 ): Promise<{
   decoder: IDecoder<DecodedMessage>;
-  subscription: IFilterSubscription;
+  subscription: IFilterSubscriptionSDK;
 }> {
   // Validate that the Waku node matches assumptions
   if (!waku.filter) {
@@ -86,10 +86,11 @@ export async function streamContentTopic(
         controller.enqueue(message);
       });
     },
-    cancel() {
-      return subscription.unsubscribe([contentTopic]);
+    async cancel() {
+      await subscription.unsubscribe([contentTopic]);
     }
   });
+
   return [messageStream, opts.waku];
 }
 
@@ -105,7 +106,7 @@ export async function subscribeToContentTopic(
   contentTopic: string,
   callback: Callback<DecodedMessage>,
   opts: CreateTopicOptions
-): Promise<{ subscription: IFilterSubscription; waku: LightNode }> {
+): Promise<{ subscription: IFilterSubscriptionSDK; waku: LightNode }> {
   opts.waku =
     opts.waku ??
     (await createLightNode({

--- a/packages/sdk/src/waku.ts
+++ b/packages/sdk/src/waku.ts
@@ -5,7 +5,7 @@ import { ConnectionManager, DecodedMessage } from "@waku/core";
 import type {
   Callback,
   IFilterSDK,
-  IFilterSubscription,
+  IFilterSubscriptionSDK,
   ILightPushSDK,
   IRelay,
   IStoreSDK,
@@ -192,7 +192,7 @@ export class WakuNode implements Waku {
     contentTopic: string,
     peer: Multiaddr,
     callback: Callback<DecodedMessage>
-  ): Promise<IFilterSubscription> {
+  ): Promise<IFilterSubscriptionSDK> {
     return (
       await subscribeToContentTopic(contentTopic, callback, {
         waku: this as LightNode,


### PR DESCRIPTION
## Problem

The Filter implementation currently `throws` `Error` to handle non-success scenarios.
This needs a change to using error codes instead: #1694 

## Solution

Move all `throw`s to returning error codes

## Notes

- Related to #1694 

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
