### PR TITLE
fix: adding delay between dials

### DIFF
--- a/packages/tests/tests/getPeers.spec.ts
+++ b/packages/tests/tests/getPeers.spec.ts
@@ -225,7 +225,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
 
     waku = await createLightNode({ shardInfo: shardInfo2 });
     await waku.libp2p.dialProtocol(serviceNodeMa1, LightPushCodec);
-    await delay(500); // Small delay between dials
+    await delay(500);
     await waku.libp2p.dialProtocol(serviceNodeMa2, LightPushCodec);
     await waku.start();
     await waitForRemotePeer(waku, [Protocols.LightPush]);

--- a/packages/tests/tests/getPeers.spec.ts
+++ b/packages/tests/tests/getPeers.spec.ts
@@ -20,6 +20,7 @@ import Sinon from "sinon";
 import {
   afterEachCustom,
   beforeEachCustom,
+  delay,
   isNwakuAtLeast,
   makeLogFileName,
   resolveAutoshardingCluster,
@@ -170,6 +171,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
 
     waku = await createLightNode({ shardInfo: shardInfo2 });
     await waku.libp2p.dialProtocol(serviceNode1Ma, LightPushCodec);
+    await delay(500);
     await waku.libp2p.dialProtocol(serviceNode2Ma, LightPushCodec);
 
     await waku.start();
@@ -223,6 +225,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
 
     waku = await createLightNode({ shardInfo: shardInfo2 });
     await waku.libp2p.dialProtocol(serviceNodeMa1, LightPushCodec);
+    await delay(500); // Small delay between dials
     await waku.libp2p.dialProtocol(serviceNodeMa2, LightPushCodec);
     await waku.start();
     await waitForRemotePeer(waku, [Protocols.LightPush]);
@@ -362,6 +365,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
 
     waku = await createLightNode({ shardInfo: shardInfo2 });
     await waku.libp2p.dialProtocol(serviceNode1Ma, LightPushCodec);
+    await delay(500);
     await waku.libp2p.dialProtocol(serviceNode2Ma, LightPushCodec);
 
     await waku.start();
@@ -416,6 +420,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
 
     waku = await createLightNode({ shardInfo: shardInfo2 });
     await waku.libp2p.dialProtocol(serviceNodeMa1, LightPushCodec);
+    await delay(500);
     await waku.libp2p.dialProtocol(serviceNodeMa2, LightPushCodec);
     await waku.start();
     await waitForRemotePeer(waku, [Protocols.LightPush]);


### PR DESCRIPTION
## Problem

In unit testing, after a node fails to connect to another node in a different cluster, the node fails to connect to a node in its same cluster and shard immediately after the failure.

Temporarily adding a small delay between dials until the root cause is found.


## Issue 
 https://github.com/waku-org/nwaku/issues/2621