### PR TITLE
chore: use nwaku:v0.27.0 and adjust tests for it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,14 @@ jobs:
     uses: ./.github/workflows/test-node.yml
     secrets: inherit
     with:
-      nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.26.0' }}
+      nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.27.0' }}
       test_type: node
       allure_reports: true
 
   node_optional:
     uses: ./.github/workflows/test-node.yml
     with:
-      nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.26.0' }}
+      nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.27.0' }}
       test_type: node-optional
 
   node_with_nwaku_master:

--- a/packages/tests/src/lib/service_node.ts
+++ b/packages/tests/src/lib/service_node.ts
@@ -27,7 +27,7 @@ const WAKU_SERVICE_NODE_PARAMS =
 const NODE_READY_LOG_LINE = "Node setup complete";
 
 export const DOCKER_IMAGE_NAME =
-  process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.26.0";
+  process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.27.0";
 
 const isGoWaku = DOCKER_IMAGE_NAME.includes("go-waku");
 

--- a/packages/tests/src/run-tests.js
+++ b/packages/tests/src/run-tests.js
@@ -3,7 +3,7 @@ import { promisify } from "util";
 
 const execAsync = promisify(exec);
 
-const WAKUNODE_IMAGE = process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.26.0";
+const WAKUNODE_IMAGE = process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.27.0";
 
 async function main() {
   try {

--- a/packages/tests/src/utils/waku_versions_utils.ts
+++ b/packages/tests/src/utils/waku_versions_utils.ts
@@ -1,8 +1,4 @@
-import { Logger } from "@waku/utils";
-
 import { DOCKER_IMAGE_NAME } from "../lib/service_node";
-
-const log = new Logger("test:utils");
 
 // Utility to add test conditions based on nwaku/go-waku versions
 export function isNwakuAtLeast(requiredVersion: string): boolean {
@@ -17,18 +13,5 @@ export function isNwakuAtLeast(requiredVersion: string): boolean {
   } else {
     // If there is no match we assume that it's a version close to master so we return True
     return true;
-  }
-}
-
-// Utility to resolve autosharding cluster ID
-export function resolveAutoshardingCluster(clusterId: number): number {
-  if (isNwakuAtLeast("0.27.0")) {
-    log.info(`Using clusterID ${clusterId} for autosharding`);
-    return clusterId;
-  } else {
-    // for versions older than 0.27.0 the autosharding cluster was hardcoded to 1
-    // https://github.com/waku-org/nwaku/pull/2505
-    log.warn("Falling back to clusterID 1 for autosharding");
-    return 1;
   }
 }

--- a/packages/tests/tests/filter/single_node/multiple_pubsub.node.spec.ts
+++ b/packages/tests/tests/filter/single_node/multiple_pubsub.node.spec.ts
@@ -19,10 +19,8 @@ import { expect } from "chai";
 import {
   afterEachCustom,
   beforeEachCustom,
-  isNwakuAtLeast,
   makeLogFileName,
   MessageCollector,
-  resolveAutoshardingCluster,
   ServiceNode,
   tearDownNodes
 } from "../../../src/index.js";
@@ -188,7 +186,7 @@ describe("Waku Filter V2: Multiple PubsubTopics", function () {
 describe("Waku Filter V2 (Autosharding): Multiple PubsubTopics", function () {
   // Set the timeout for all tests in this suite. Can be overwritten at test level
   this.timeout(30000);
-  const clusterId = resolveAutoshardingCluster(3);
+  const clusterId = 3;
   let waku: LightNode;
   let nwaku: ServiceNode;
   let nwaku2: ServiceNode;
@@ -230,12 +228,6 @@ describe("Waku Filter V2 (Autosharding): Multiple PubsubTopics", function () {
   const customDecoder2 = createDecoder(customContentTopic2, {
     clusterId: clusterId,
     shard: contentTopicToShardIndex(customContentTopic2)
-  });
-
-  before(async () => {
-    if (!isNwakuAtLeast("0.27.0")) {
-      this.ctx.skip();
-    }
   });
 
   beforeEachCustom(this, async () => {

--- a/packages/tests/tests/filter/single_node/subscribe.node.spec.ts
+++ b/packages/tests/tests/filter/single_node/subscribe.node.spec.ts
@@ -20,7 +20,6 @@ import {
   beforeEachCustom,
   delay,
   generateTestData,
-  isNwakuAtLeast,
   makeLogFileName,
   MessageCollector,
   ServiceNode,
@@ -223,53 +222,8 @@ describe("Waku Filter V2: Subscribe: Single Service Node", function () {
   });
 
   it("Subscribe to 100 topics (new limit) at once and receives messages", async function () {
-    let topicCount: number;
-    if (isNwakuAtLeast("0.25.0")) {
-      this.timeout(50000);
-      topicCount = 100;
-    } else {
-      // skipping for old versions where the limit is 30
-      this.skip();
-    }
-    const td = generateTestData(topicCount);
-
-    await subscription.subscribe(td.decoders, messageCollector.callback);
-
-    // Send a unique message on each topic.
-    for (let i = 0; i < topicCount; i++) {
-      await waku.lightPush.send(td.encoders[i], {
-        payload: utf8ToBytes(`Message for Topic ${i + 1}`)
-      });
-    }
-
-    // Open issue here: https://github.com/waku-org/js-waku/issues/1790
-    // That's why we use the try catch block
-    try {
-      // Verify that each message was received on the corresponding topic.
-      expect(await messageCollector.waitForMessages(topicCount)).to.eq(true);
-      td.contentTopics.forEach((topic, index) => {
-        messageCollector.verifyReceivedMessage(index, {
-          expectedContentTopic: topic,
-          expectedMessageText: `Message for Topic ${index + 1}`
-        });
-      });
-    } catch (error) {
-      console.warn(
-        "This test still fails because of https://github.com/waku-org/js-waku/issues/1790"
-      );
-    }
-  });
-
-  //TODO: remove test when WAKUNODE_IMAGE is 0.25.0
-  it("Subscribe to 30 topics (old limit) at once and receives messages", async function () {
-    let topicCount: number;
-    if (isNwakuAtLeast("0.25.0")) {
-      // skipping for new versions where the new limit is 100
-      this.skip();
-    } else {
-      topicCount = 30;
-    }
-
+    this.timeout(50000);
+    const topicCount = 100;
     const td = generateTestData(topicCount);
 
     await subscription.subscribe(td.decoders, messageCollector.callback);
@@ -300,43 +254,7 @@ describe("Waku Filter V2: Subscribe: Single Service Node", function () {
   });
 
   it("Error when try to subscribe to more than 101 topics (new limit)", async function () {
-    let topicCount: number;
-    if (isNwakuAtLeast("0.25.0")) {
-      topicCount = 101;
-    } else {
-      // skipping for old versions where the limit is 30
-      this.skip();
-    }
-    const td = generateTestData(topicCount);
-
-    try {
-      await subscription.subscribe(td.decoders, messageCollector.callback);
-      throw new Error(
-        `Subscribe to ${topicCount} topics was successful but was expected to fail with a specific error.`
-      );
-    } catch (err) {
-      if (
-        err instanceof Error &&
-        err.message.includes(
-          `exceeds maximum content topics: ${topicCount - 1}`
-        )
-      ) {
-        return;
-      } else {
-        throw err;
-      }
-    }
-  });
-
-  //TODO: remove test when WAKUNODE_IMAGE is 0.25.0
-  it("Error when try to subscribe to more than 31 topics (old limit)", async function () {
-    let topicCount: number;
-    if (isNwakuAtLeast("0.25.0")) {
-      // skipping for new versions where the new limit is 100
-      this.skip();
-    } else {
-      topicCount = 31;
-    }
+    const topicCount = 101;
     const td = generateTestData(topicCount);
 
     try {

--- a/packages/tests/tests/getPeers.spec.ts
+++ b/packages/tests/tests/getPeers.spec.ts
@@ -21,9 +21,7 @@ import {
   afterEachCustom,
   beforeEachCustom,
   delay,
-  isNwakuAtLeast,
   makeLogFileName,
-  resolveAutoshardingCluster,
   ServiceNode,
   tearDownNodes
 } from "../src/index.js";
@@ -33,13 +31,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
   let serviceNode1: ServiceNode;
   let serviceNode2: ServiceNode;
   const contentTopic = "/test/2/waku-light-push/utf8";
-  const autoshardingClusterId = resolveAutoshardingCluster(6);
-
-  before(async () => {
-    if (!isNwakuAtLeast("0.27.0")) {
-      this.ctx.skip();
-    }
-  });
+  const autoshardingClusterId = 6;
 
   beforeEachCustom(this, async () => {
     serviceNode1 = new ServiceNode(makeLogFileName(this.ctx) + "1");

--- a/packages/tests/tests/light-push/single_node/multiple_pubsub.node.spec.ts
+++ b/packages/tests/tests/light-push/single_node/multiple_pubsub.node.spec.ts
@@ -19,10 +19,8 @@ import { expect } from "chai";
 import {
   afterEachCustom,
   beforeEachCustom,
-  isNwakuAtLeast,
   makeLogFileName,
   MessageCollector,
-  resolveAutoshardingCluster,
   ServiceNode,
   tearDownNodes
 } from "../../../src/index.js";
@@ -179,7 +177,7 @@ describe("Waku Light Push (Autosharding): Multiple PubsubTopics", function () {
   let nwaku2: ServiceNode;
   let messageCollector: MessageCollector;
 
-  const clusterId = resolveAutoshardingCluster(4);
+  const clusterId = 4;
   const customContentTopic1 = "/waku/2/content/test.js";
   const customContentTopic2 = "/myapp/1/latest/proto";
   const autoshardingPubsubTopic1 = contentTopicToPubsubTopic(
@@ -204,12 +202,6 @@ describe("Waku Light Push (Autosharding): Multiple PubsubTopics", function () {
   });
 
   let nimPeerId: PeerId;
-
-  before(async () => {
-    if (!isNwakuAtLeast("0.27.0")) {
-      this.ctx.skip();
-    }
-  });
 
   beforeEachCustom(this, async () => {
     [nwaku, waku] = await runNodes(

--- a/packages/tests/tests/metadata.spec.ts
+++ b/packages/tests/tests/metadata.spec.ts
@@ -75,12 +75,12 @@ describe("Metadata Protocol", function () {
 
     it("same cluster, different shard: nodes connect", async function () {
       const shardInfo1: ShardInfo = {
-        clusterId: 0,
+        clusterId: 2,
         shards: [1]
       };
 
       const shardInfo2: ShardInfo = {
-        clusterId: 0,
+        clusterId: 2,
         shards: [2]
       };
 

--- a/packages/tests/tests/relay/multiple_pubsub.node.spec.ts
+++ b/packages/tests/tests/relay/multiple_pubsub.node.spec.ts
@@ -26,7 +26,6 @@ import {
   NOISE_KEY_1,
   NOISE_KEY_2,
   NOISE_KEY_3,
-  resolveAutoshardingCluster,
   tearDownNodes
 } from "../../src/index.js";
 import { TestDecoder } from "../filter/utils.js";
@@ -318,7 +317,7 @@ describe("Waku Relay, multiple pubsub topics", function () {
 
 describe("Waku Relay (Autosharding), multiple pubsub topics", function () {
   this.timeout(15000);
-  const clusterId = resolveAutoshardingCluster(7);
+  const clusterId = 7;
   let waku1: RelayNode;
   let waku2: RelayNode;
   let waku3: RelayNode;

--- a/packages/tests/tests/sdk/content_topic.spec.ts
+++ b/packages/tests/tests/sdk/content_topic.spec.ts
@@ -19,18 +19,13 @@ import {
 } from "@waku/utils";
 import { expect } from "chai";
 
-import {
-  makeLogFileName,
-  resolveAutoshardingCluster,
-  ServiceNode,
-  tearDownNodes
-} from "../../src";
+import { makeLogFileName, ServiceNode, tearDownNodes } from "../../src";
 
 // skipped: https://github.com/waku-org/js-waku/issues/1914
 describe.skip("SDK: Creating by Content Topic", function () {
   const ContentTopic = "/myapp/1/latest/proto";
   const testMessage = "Test123";
-  const clusterId = resolveAutoshardingCluster(2);
+  const clusterId = 2;
   let nwaku: ServiceNode;
   let waku: LightNode;
   let waku2: LightNode;

--- a/packages/tests/tests/sharding/auto_sharding.spec.ts
+++ b/packages/tests/tests/sharding/auto_sharding.spec.ts
@@ -40,6 +40,91 @@ describe("Autosharding: Running Nodes", function () {
   });
 
   describe("Different clusters and topics", function () {
+    // js-waku allows autosharding for cluster IDs different than 1
+    it("Cluster ID 0 - Default/Global Cluster", async function () {
+      const clusterId = 0;
+      const pubsubTopics = [contentTopicToPubsubTopic(ContentTopic, clusterId)];
+      await nwaku.start({
+        store: true,
+        lightpush: true,
+        relay: true,
+        clusterId: clusterId,
+        pubsubTopic: pubsubTopics
+      });
+
+      await nwaku.ensureSubscriptions(pubsubTopics);
+
+      waku = await createLightNode({
+        shardInfo: {
+          clusterId: clusterId,
+          contentTopics: [ContentTopic]
+        }
+      });
+      await waku.dial(await nwaku.getMultiaddrWithId());
+      await waitForRemotePeer(waku, [Protocols.LightPush]);
+
+      const encoder = createEncoder({
+        contentTopic: ContentTopic,
+        pubsubTopicShardInfo: {
+          clusterId: clusterId,
+          shard: contentTopicToShardIndex(ContentTopic)
+        }
+      });
+
+      const request = await waku.lightPush.send(encoder, {
+        payload: utf8ToBytes("Hello World")
+      });
+
+      expect(request.successes.length).to.eq(1);
+      expect(
+        await messageCollector.waitForMessagesAutosharding(1, {
+          contentTopic: ContentTopic
+        })
+      ).to.eq(true);
+    });
+
+    it("Non TWN Cluster", async function () {
+      const clusterId = 5;
+      const pubsubTopics = [contentTopicToPubsubTopic(ContentTopic, clusterId)];
+      await nwaku.start({
+        store: true,
+        lightpush: true,
+        relay: true,
+        clusterId: clusterId,
+        pubsubTopic: pubsubTopics
+      });
+
+      await nwaku.ensureSubscriptions(pubsubTopics);
+
+      waku = await createLightNode({
+        shardInfo: {
+          clusterId: clusterId,
+          contentTopics: [ContentTopic]
+        }
+      });
+      await waku.dial(await nwaku.getMultiaddrWithId());
+      await waitForRemotePeer(waku, [Protocols.LightPush]);
+
+      const encoder = createEncoder({
+        contentTopic: ContentTopic,
+        pubsubTopicShardInfo: {
+          clusterId: clusterId,
+          shard: contentTopicToShardIndex(ContentTopic)
+        }
+      });
+
+      const request = await waku.lightPush.send(encoder, {
+        payload: utf8ToBytes("Hello World")
+      });
+
+      expect(request.successes.length).to.eq(1);
+      expect(
+        await messageCollector.waitForMessagesAutosharding(1, {
+          contentTopic: ContentTopic
+        })
+      ).to.eq(true);
+    });
+
     const numTest = 10;
     for (let i = 0; i < numTest; i++) {
       // Random ContentTopic

--- a/packages/tests/tests/sharding/peer_management.spec.ts
+++ b/packages/tests/tests/sharding/peer_management.spec.ts
@@ -20,9 +20,7 @@ import {
   afterEachCustom,
   beforeEachCustom,
   delay,
-  isNwakuAtLeast,
   makeLogFileName,
-  resolveAutoshardingCluster,
   ServiceNode,
   tearDownNodes
 } from "../../src/index.js";
@@ -208,13 +206,7 @@ describe("Static Sharding: Peer Management", function () {
 
 describe("Autosharding: Peer Management", function () {
   const ContentTopic = "/myapp/1/latest/proto";
-  const clusterId = resolveAutoshardingCluster(8);
-
-  before(async () => {
-    if (!isNwakuAtLeast("0.27.0")) {
-      this.ctx.skip();
-    }
-  });
+  const clusterId = 8;
 
   describe("Peer Exchange", function () {
     let waku: LightNode;

--- a/packages/tests/tests/sharding/static_sharding.spec.ts
+++ b/packages/tests/tests/sharding/static_sharding.spec.ts
@@ -69,6 +69,8 @@ describe("Static Sharding: Running Nodes", function () {
         pubsubTopic: shardInfoToPubsubTopics(shardInfo)
       });
 
+      await nwaku.ensureSubscriptions(shardInfoToPubsubTopics(shardInfo));
+
       waku = await createLightNode({
         shardInfo: shardInfo
       });

--- a/packages/tests/tests/store/multiple_pubsub.spec.ts
+++ b/packages/tests/tests/store/multiple_pubsub.spec.ts
@@ -11,10 +11,8 @@ import { expect } from "chai";
 import {
   afterEachCustom,
   beforeEachCustom,
-  isNwakuAtLeast,
   makeLogFileName,
   NOISE_KEY_1,
-  resolveAutoshardingCluster,
   ServiceNode,
   tearDownNodes
 } from "../../src/index.js";
@@ -190,7 +188,7 @@ describe("Waku Store (Autosharding), custom pubsub topic", function () {
 
   const customContentTopic1 = "/waku/2/content/utf8";
   const customContentTopic2 = "/myapp/1/latest/proto";
-  const clusterId = resolveAutoshardingCluster(5);
+  const clusterId = 5;
   const autoshardingPubsubTopic1 = contentTopicToPubsubTopic(
     customContentTopic1,
     clusterId
@@ -215,12 +213,6 @@ describe("Waku Store (Autosharding), custom pubsub topic", function () {
     clusterId,
     contentTopics: [customContentTopic1, customContentTopic2]
   };
-
-  before(async () => {
-    if (!isNwakuAtLeast("0.27.0")) {
-      this.ctx.skip();
-    }
-  });
 
   beforeEachCustom(this, async () => {
     nwaku = new ServiceNode(makeLogFileName(this.ctx));


### PR DESCRIPTION
## Problem

Upgrade nwaku to v0.27.0 and adjust the tests to work with this version

## Solution

<!-- describe the new behavior --> 

## Notes

<!-- Remove items that are not relevant -->

- Resolves <issue number>
- Related to <link to specs>

Contribution checklist:
- [x] covered by unit tests;
- [x] covered by e2e test;
- [ ] add `!` in title if breaks public API;
