### PR TITLE
fix: use correct error message for store rate limit

### DIFF
--- a/packages/proto/src/generated/store.ts
+++ b/packages/proto/src/generated/store.ts
@@ -377,14 +377,14 @@ export namespace HistoryResponse {
   export enum HistoryError {
     NONE = 'NONE',
     INVALID_CURSOR = 'INVALID_CURSOR',
-    TOO_MANY_RESULTS = 'TOO_MANY_RESULTS',
+    TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS',
     SERVICE_UNAVAILABLE = 'SERVICE_UNAVAILABLE'
   }
 
   enum __HistoryErrorValues {
     NONE = 0,
     INVALID_CURSOR = 1,
-    TOO_MANY_RESULTS = 429,
+    TOO_MANY_REQUESTS = 429,
     SERVICE_UNAVAILABLE = 503
   }
 

--- a/packages/proto/src/lib/store.proto
+++ b/packages/proto/src/lib/store.proto
@@ -42,7 +42,7 @@ message HistoryResponse {
   enum HistoryError {
     NONE = 0;
     INVALID_CURSOR = 1;
-    TOO_MANY_RESULTS = 429;
+    TOO_MANY_REQUESTS = 429;
     SERVICE_UNAVAILABLE = 503;
   }
   HistoryError error = 4;


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

The error message for too many requests when querying store does not match what is set in nwaku

## Solution

<!-- describe the new behavior --> 

Update the error message in proto def to match nwaku

## Notes

<!-- Remove items that are not relevant -->

- Resolves <issue number>
- Related to <link to specs>

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
