### PR TITLE
feat: only dial a peer if it has a wss multiaddr

### DIFF
--- a/packages/core/src/lib/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager.ts
@@ -456,6 +456,17 @@ export class ConnectionManager
       return false;
     }
 
+    const peer = await this.libp2p.peerStore.get(peerId);
+
+    if (
+      !peer.addresses.some((val) => val.multiaddr.toString().includes("/wss/"))
+    ) {
+      log.info(
+        `Peer ${peerId.toString()} does not have a multiaddr that supports wss, not dialing.`
+      );
+      return false;
+    }
+
     // if the peer is not part of any of the configured pubsub topics, don't dial
     if (!(await this.isPeerTopicConfigured(peerId))) {
       const shardInfo = await this.getPeerShardInfo(


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

Connection manager will attempt to dial a peer even if the peer doesn't have a wss multiaddr. This leads to a lot of failing dials with the error `"The dial request has no valid addresses"`


## Solution

<!-- describe the new behavior --> 

When checking if a peer should be dialed, get the peer info from the peer store and skip dialing if none of the multiaddrs use wss

## Notes

<!-- Remove items that are not relevant -->

- Related to #1966 

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
