### PR TITLE
fix: only override ping metadata in peer store

### DIFF
--- a/packages/core/src/lib/keep_alive_manager.ts
+++ b/packages/core/src/lib/keep_alive_manager.ts
@@ -56,7 +56,7 @@ export class KeepAliveManager {
             }
 
             try {
-              await peerStore.patch(peerId, {
+              await peerStore.merge(peerId, {
                 metadata: {
                   ping: utf8ToBytes(ping.toString())
                 }


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

After pinging a peer, the keep alive manager overwrites _all_ the metadata stored for that peer and replaces it with the latency of the ping. This causes the peer store to lose any other metadata that was stored, including the peer's shard info.

## Solution

<!-- describe the new behavior --> 

Use `peerStore.merge` instead of `peerStore.patch` to update the metadata, which will only overwrite the last value of `ping` and not wipe the rest of the metadata.

## Notes

<!-- Remove items that are not relevant -->

- Related to #1966 

Contribution checklist:
- [x] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
