### PR TITLE
fix(message-hash): account for `timestamp`

### DIFF
--- a/packages/message-hash/src/index.spec.ts
+++ b/packages/message-hash/src/index.spec.ts
@@ -5,64 +5,74 @@ import { expect } from "chai";
 import { messageHash } from "./index.js";
 
 // https://rfc.vac.dev/spec/14/#test-vectors
-describe("RFC Test Vectors", () => {
-  it("Waku message hash computation", () => {
+describe.only("RFC Test Vectors", () => {
+  it("Waku message hash computation (meta size of 12 bytes)", () => {
     const expectedHash =
-      "4fdde1099c9f77f6dae8147b6b3179aba1fc8e14a7bf35203fc253ee479f135f";
-
+      "64cce733fed134e83da02b02c6f689814872b1a0ac97ea56b76095c3c72bfe05";
     const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IProtoMessage = {
       payload: hexToBytes("0x010203045445535405060708"),
       contentTopic: "/waku/2/default-content/proto",
       meta: hexToBytes("0x73757065722d736563726574"),
+      timestamp: BigInt("0x175789bfa23f8400"),
       ephemeral: undefined,
       rateLimitProof: undefined,
-      timestamp: undefined,
       version: undefined
     };
-
     const hash = messageHash(pubsubTopic, message);
+    expect(bytesToHex(hash)).to.equal(expectedHash);
+  });
 
+  it("Waku message hash computation (meta size of 64 bytes)", () => {
+    const expectedHash =
+      "7158b6498753313368b9af8f6e0a0a05104f68f972981da42a43bc53fb0c1b27";
+    const pubsubTopic = "/waku/2/default-waku/proto";
+    const message: IProtoMessage = {
+      payload: hexToBytes("0x010203045445535405060708"),
+      contentTopic: "/waku/2/default-content/proto",
+      meta: hexToBytes(
+        "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+      ),
+      timestamp: BigInt("0x175789bfa23f8400"),
+      ephemeral: undefined,
+      rateLimitProof: undefined,
+      version: undefined
+    };
+    const hash = messageHash(pubsubTopic, message);
     expect(bytesToHex(hash)).to.equal(expectedHash);
   });
 
   it("Waku message hash computation (meta attribute not present)", () => {
     const expectedHash =
-      "87619d05e563521d9126749b45bd4cc2430df0607e77e23572d874ed9c1aaa62";
-
+      "a2554498b31f5bcdfcbf7fa58ad1c2d45f0254f3f8110a85588ec3cf10720fd8";
     const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IProtoMessage = {
       payload: hexToBytes("0x010203045445535405060708"),
       contentTopic: "/waku/2/default-content/proto",
       meta: undefined,
+      timestamp: BigInt("0x175789bfa23f8400"),
       ephemeral: undefined,
       rateLimitProof: undefined,
-      timestamp: undefined,
       version: undefined
     };
-
     const hash = messageHash(pubsubTopic, message);
-
     expect(bytesToHex(hash)).to.equal(expectedHash);
   });
 
   it("Waku message hash computation (payload length 0)", () => {
     const expectedHash =
-      "e1a9596237dbe2cc8aaf4b838c46a7052df6bc0d42ba214b998a8bfdbe8487d6";
-
+      "483ea950cb63f9b9d6926b262bb36194d3f40a0463ce8446228350bd44e96de4";
     const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IProtoMessage = {
       payload: new Uint8Array(),
       contentTopic: "/waku/2/default-content/proto",
       meta: hexToBytes("0x73757065722d736563726574"),
+      timestamp: BigInt("0x175789bfa23f8400"),
       ephemeral: undefined,
       rateLimitProof: undefined,
-      timestamp: undefined,
       version: undefined
     };
-
     const hash = messageHash(pubsubTopic, message);
-
     expect(bytesToHex(hash)).to.equal(expectedHash);
   });
 });

--- a/packages/message-hash/src/index.spec.ts
+++ b/packages/message-hash/src/index.spec.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import { messageHash } from "./index.js";
 
 // https://rfc.vac.dev/spec/14/#test-vectors
-describe.only("RFC Test Vectors", () => {
+describe("RFC Test Vectors", () => {
   it("Waku message hash computation (meta size of 12 bytes)", () => {
     const expectedHash =
       "64cce733fed134e83da02b02c6f689814872b1a0ac97ea56b76095c3c72bfe05";

--- a/packages/message-hash/src/index.ts
+++ b/packages/message-hash/src/index.ts
@@ -1,19 +1,11 @@
 import { sha256 } from "@noble/hashes/sha256";
 import type { IProtoMessage } from "@waku/interfaces";
-import { bytesToUtf8, concat, utf8ToBytes } from "@waku/utils/bytes";
-
-function numberToBytes(value: number | bigint): Uint8Array {
-  const buffer = new ArrayBuffer(8);
-  const view = new DataView(buffer);
-
-  if (typeof value === "number") {
-    view.setFloat64(0, value, false);
-  } else {
-    view.setBigInt64(0, value, false);
-  }
-
-  return new Uint8Array(buffer);
-}
+import {
+  bytesToUtf8,
+  concat,
+  numberToBytes,
+  utf8ToBytes
+} from "@waku/utils/bytes";
 
 /**
  * Deterministic Message Hashing as defined in

--- a/packages/message-hash/src/index.ts
+++ b/packages/message-hash/src/index.ts
@@ -1,5 +1,6 @@
 import { sha256 } from "@noble/hashes/sha256";
 import type { IProtoMessage } from "@waku/interfaces";
+import { isDefined } from "@waku/utils";
 import {
   bytesToUtf8,
   concat,
@@ -17,35 +18,20 @@ export function messageHash(
 ): Uint8Array {
   const pubsubTopicBytes = utf8ToBytes(pubsubTopic);
   const contentTopicBytes = utf8ToBytes(message.contentTopic);
+  const timestampBytes = message.timestamp
+    ? numberToBytes(message.timestamp)
+    : undefined;
 
-  let bytes;
-  if (message.meta && message.timestamp) {
-    const timestampBytes = numberToBytes(message.timestamp);
-    bytes = concat([
+  const bytes = concat(
+    [
       pubsubTopicBytes,
       message.payload,
       contentTopicBytes,
       message.meta,
       timestampBytes
-    ]);
-  } else if (message.meta) {
-    bytes = concat([
-      pubsubTopicBytes,
-      message.payload,
-      contentTopicBytes,
-      message.meta
-    ]);
-  } else if (message.timestamp) {
-    const timestampBytes = numberToBytes(message.timestamp);
-    bytes = concat([
-      pubsubTopicBytes,
-      message.payload,
-      contentTopicBytes,
-      timestampBytes
-    ]);
-  } else {
-    bytes = concat([pubsubTopicBytes, message.payload, contentTopicBytes]);
-  }
+    ].filter(isDefined)
+  );
+
   return sha256(bytes);
 }
 

--- a/packages/utils/src/bytes/index.ts
+++ b/packages/utils/src/bytes/index.ts
@@ -14,6 +14,19 @@ export function hexToBytes(hex: string | Uint8Array): Uint8Array {
   return hex;
 }
 
+export function numberToBytes(value: number | bigint): Uint8Array {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+
+  if (typeof value === "number") {
+    view.setFloat64(0, value, false);
+  } else {
+    view.setBigInt64(0, value, false);
+  }
+
+  return new Uint8Array(buffer);
+}
+
 /**
  * Convert byte array to hex string (no `0x` prefix).
  */


### PR DESCRIPTION
## Problem

Based on the specs: https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/14/message.md#deterministic-message-hashing, the current message-hash algorithm does not take into account the `timestamp`.

The test vectors mentioned in the spec also varied from the one in the implementation.

## Solution

- Update the algorithm to account for `timestamp`
- Update the test vectors

## Notes

- Resolves https://github.com/waku-org/js-waku/issues/1985

Contribution checklist:
- [x] covered by unit tests;
- [x] covered by e2e test;
- [x] add `!` in title if breaks public API;
