### PR TITLE
feat: add libp2p option for max ping connections

### DIFF
--- a/packages/interfaces/src/libp2p.ts
+++ b/packages/interfaces/src/libp2p.ts
@@ -29,4 +29,5 @@ export type CreateLibp2pOptions = Libp2pOptions & {
    * @default false
    */
   hideWebSocketInfo?: boolean;
+  pingMaxInboundStreams?: number;
 };

--- a/packages/sdk/src/utils/libp2p.ts
+++ b/packages/sdk/src/utils/libp2p.ts
@@ -19,7 +19,11 @@ import { wakuGossipSub } from "@waku/relay";
 import { ensureShardingConfigured } from "@waku/utils";
 import { createLibp2p } from "libp2p";
 
-import { CreateWakuNodeOptions, DefaultUserAgent } from "../waku.js";
+import {
+  CreateWakuNodeOptions,
+  DefaultPingMaxInboundStreams,
+  DefaultUserAgent
+} from "../waku.js";
 
 import { defaultPeerDiscoveries } from "./discovery.js";
 
@@ -70,7 +74,10 @@ export async function defaultLibp2p(
       identify: identify({
         agentVersion: userAgent ?? DefaultUserAgent
       }),
-      ping: ping(),
+      ping: ping({
+        maxInboundStreams:
+          options?.pingMaxInboundStreams ?? DefaultPingMaxInboundStreams
+      }),
       ...metadataService,
       ...pubsubService,
       ...options?.services

--- a/packages/sdk/src/waku.ts
+++ b/packages/sdk/src/waku.ts
@@ -23,6 +23,7 @@ import { subscribeToContentTopic } from "./utils/content_topic.js";
 export const DefaultPingKeepAliveValueSecs = 5 * 60;
 export const DefaultRelayKeepAliveValueSecs = 5 * 60;
 export const DefaultUserAgent = "js-waku";
+export const DefaultPingMaxInboundStreams = 10;
 
 const log = new Logger("waku");
 


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

When a peer is connected to js-waku, it often exceeds the default number of incoming streams for libp2p's ping protocol. This causes the multiplexer to drop the entire connection, effectively losing the peer.

## Solution

<!-- describe the new behavior --> 

Add an option to overwrite the maximum number of inbound connections for the ping protocol when creating a waku node, and set the default to 10.

## Notes

<!-- Remove items that are not relevant -->
- Related to #1966 

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
