### PR TITLE
fix: filter for wss in libp2p websocket transport

### DIFF
--- a/packages/sdk/src/utils/libp2p.ts
+++ b/packages/sdk/src/utils/libp2p.ts
@@ -5,7 +5,7 @@ import { identify } from "@libp2p/identify";
 import { mplex } from "@libp2p/mplex";
 import { ping } from "@libp2p/ping";
 import { webSockets } from "@libp2p/websockets";
-import { all as filterAll } from "@libp2p/websockets/filters";
+import { all as filterAll, wss } from "@libp2p/websockets/filters";
 import { wakuMetadata } from "@waku/core";
 import {
   type CreateLibp2pOptions,
@@ -64,11 +64,13 @@ export async function defaultLibp2p(
     ? { metadata: wakuMetadata(shardInfo) }
     : {};
 
+  const filter = process?.env?.NODE_ENV === "test" ? filterAll : wss;
+
   return createLibp2p({
     connectionManager: {
       minConnections: 1
     },
-    transports: [webSockets({ filter: filterAll })],
+    transports: [webSockets({ filter })],
     streamMuxers: [mplex()],
     connectionEncryption: [noise()],
     ...options,


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

Current libp2p transport filter allows all connections. This is fine for testing, but in production we want to limit transports to secure WebSockets (wss or tls/ws).

## Solution

<!-- describe the new behavior --> 

Allow all transport types when running tests by setting `process.env.NODE_ENV=test` but otherwise use the libp2p filter for secure websockets peers

## Notes

<!-- Remove items that are not relevant -->

- Resolves #1547 
- Related to #1966 

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
