### PR TITLE
feat: make message hash compatible with decoded message

### DIFF
--- a/packages/message-hash/src/index.spec.ts
+++ b/packages/message-hash/src/index.spec.ts
@@ -102,7 +102,7 @@ describe("RFC Test Vectors", () => {
       pubsubTopic,
       contentTopic: "/waku/2/default-content/proto",
       meta: hexToBytes("0x73757065722d736563726574"),
-      timestamp: undefined,
+      timestamp: new Date(),
       ephemeral: undefined,
       rateLimitProof: undefined
     };

--- a/packages/message-hash/src/index.spec.ts
+++ b/packages/message-hash/src/index.spec.ts
@@ -78,7 +78,7 @@ describe("RFC Test Vectors", () => {
 
   it("Waku message hash computation (no timestamp)", () => {
     const expectedHash =
-      "483ea950cb63f9b9d6926b262bb36194d3f40a0463ce8446228350bd44e96de4";
+      "e1a9596237dbe2cc8aaf4b838c46a7052df6bc0d42ba214b998a8bfdbe8487d6";
     const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IProtoMessage = {
       payload: new Uint8Array(),
@@ -95,7 +95,7 @@ describe("RFC Test Vectors", () => {
 
   it("Waku message hash computation (message is IDecodedMessage)", () => {
     const expectedHash =
-      "483ea950cb63f9b9d6926b262bb36194d3f40a0463ce8446228350bd44e96de4";
+      "aa5c1c625e71e50a16a22925be8c8ac78cb91279c94e0d7479d4290693531191";
     const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IDecodedMessage = {
       payload: new Uint8Array(),

--- a/packages/message-hash/src/index.spec.ts
+++ b/packages/message-hash/src/index.spec.ts
@@ -1,4 +1,4 @@
-import type { IProtoMessage } from "@waku/interfaces";
+import type { IDecodedMessage, IProtoMessage } from "@waku/interfaces";
 import { bytesToHex, hexToBytes } from "@waku/utils/bytes";
 import { expect } from "chai";
 
@@ -71,6 +71,40 @@ describe("RFC Test Vectors", () => {
       ephemeral: undefined,
       rateLimitProof: undefined,
       version: undefined
+    };
+    const hash = messageHash(pubsubTopic, message);
+    expect(bytesToHex(hash)).to.equal(expectedHash);
+  });
+
+  it("Waku message hash computation (no timestamp)", () => {
+    const expectedHash =
+      "483ea950cb63f9b9d6926b262bb36194d3f40a0463ce8446228350bd44e96de4";
+    const pubsubTopic = "/waku/2/default-waku/proto";
+    const message: IProtoMessage = {
+      payload: new Uint8Array(),
+      contentTopic: "/waku/2/default-content/proto",
+      meta: hexToBytes("0x73757065722d736563726574"),
+      timestamp: undefined,
+      ephemeral: undefined,
+      rateLimitProof: undefined,
+      version: undefined
+    };
+    const hash = messageHash(pubsubTopic, message);
+    expect(bytesToHex(hash)).to.equal(expectedHash);
+  });
+
+  it("Waku message hash computation (message is IDecodedMessage)", () => {
+    const expectedHash =
+      "483ea950cb63f9b9d6926b262bb36194d3f40a0463ce8446228350bd44e96de4";
+    const pubsubTopic = "/waku/2/default-waku/proto";
+    const message: IDecodedMessage = {
+      payload: new Uint8Array(),
+      pubsubTopic,
+      contentTopic: "/waku/2/default-content/proto",
+      meta: hexToBytes("0x73757065722d736563726574"),
+      timestamp: undefined,
+      ephemeral: undefined,
+      rateLimitProof: undefined
     };
     const hash = messageHash(pubsubTopic, message);
     expect(bytesToHex(hash)).to.equal(expectedHash);

--- a/packages/message-hash/src/index.spec.ts
+++ b/packages/message-hash/src/index.spec.ts
@@ -95,14 +95,14 @@ describe("RFC Test Vectors", () => {
 
   it("Waku message hash computation (message is IDecodedMessage)", () => {
     const expectedHash =
-      "aa5c1c625e71e50a16a22925be8c8ac78cb91279c94e0d7479d4290693531191";
+      "bd81b27902ad51f49e8f73ff8db4a96994040c9421da88b7ee8ba07bd39070b2";
     const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IDecodedMessage = {
       payload: new Uint8Array(),
       pubsubTopic,
       contentTopic: "/waku/2/default-content/proto",
       meta: hexToBytes("0x73757065722d736563726574"),
-      timestamp: new Date(),
+      timestamp: new Date("2024-04-30T10:54:14.978Z"),
       ephemeral: undefined,
       rateLimitProof: undefined
     };

--- a/packages/message-hash/src/index.ts
+++ b/packages/message-hash/src/index.ts
@@ -18,9 +18,7 @@ export function messageHash(
 ): Uint8Array {
   const pubsubTopicBytes = utf8ToBytes(pubsubTopic);
   const contentTopicBytes = utf8ToBytes(message.contentTopic);
-  const timestampBytes = message.timestamp
-    ? numberToBytes(message.timestamp)
-    : undefined;
+  const timestampBytes = tryConvertTimestampToBytes(message.timestamp);
 
   const bytes = concat(
     [
@@ -33,6 +31,16 @@ export function messageHash(
   );
 
   return sha256(bytes);
+}
+
+function tryConvertTimestampToBytes(
+  timestamp: Date | number | bigint | undefined
+): undefined | Uint8Array {
+  if (!timestamp) {
+    return;
+  }
+
+  return numberToBytes(timestamp.valueOf());
 }
 
 export function messageHashStr(

--- a/packages/message-hash/src/index.ts
+++ b/packages/message-hash/src/index.ts
@@ -1,5 +1,5 @@
 import { sha256 } from "@noble/hashes/sha256";
-import type { IProtoMessage } from "@waku/interfaces";
+import type { IDecodedMessage, IProtoMessage } from "@waku/interfaces";
 import { isDefined } from "@waku/utils";
 import {
   bytesToUtf8,
@@ -14,7 +14,7 @@ import {
  */
 export function messageHash(
   pubsubTopic: string,
-  message: IProtoMessage
+  message: IProtoMessage | IDecodedMessage
 ): Uint8Array {
   const pubsubTopicBytes = utf8ToBytes(pubsubTopic);
   const contentTopicBytes = utf8ToBytes(message.contentTopic);
@@ -37,7 +37,7 @@ export function messageHash(
 
 export function messageHashStr(
   pubsubTopic: string,
-  message: IProtoMessage
+  message: IProtoMessage | IDecodedMessage
 ): string {
   const hash = messageHash(pubsubTopic, message);
   const hashStr = bytesToUtf8(hash);


### PR DESCRIPTION
## Problem

It is convenient to use `messageHash` for end users against `DecodedMessage` as it is the version they get from `Filter`.

## Solution

Make `messageHash` compatible with `IDecodedMessage` 
