### PR TITLE
feat: add rpc url to nwaku, persist rln tree in docker and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,53 @@ jobs:
       - run: npm run build:esm
       - run: npm run test:browser
 
+  build_rln_tree:
+    if: false # This condition disables the job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: waku-org/js-waku
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_JS }}
+      - name: Check for existing RLN tree artifact
+        id: check-artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const artifact = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            console.log(artifact);
+            const foundArtifact = artifact.data.artifacts.find(art => art.name === 'rln_tree.tar.gz');
+            if (foundArtifact) {
+              core.setOutput('artifact_id', foundArtifact.id);
+              core.setOutput('artifact_found', 'true');
+            } else {
+              core.setOutput('artifact_found', 'false');
+            }
+      - name: Download RLN tree artifact
+        if: steps.check-artifact.outputs.artifact_found == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: rln_tree.tar.gz
+          path: /tmp
+      - uses: ./.github/actions/npm
+      - name: Sync rln tree and save artifact
+        run: |
+          mkdir -p /tmp/rln_tree.db
+          npm run build:esm
+          npm run sync-rln-tree
+          tar -czf rln_tree.tar.gz -C /tmp/rln_tree.db .
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rln_tree.tar.gz
+          path: rln_tree.tar.gz
+
   node:
     uses: ./.github/workflows/test-node.yml
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "doc": "run-s doc:*",
     "doc:html": "typedoc --options typedoc.cjs",
     "doc:cname": "echo 'js.waku.org' > docs/CNAME",
-    "publish": "node ./ci/publish.js"
+    "publish": "node ./ci/publish.js",
+    "sync-rln-tree": "node ./packages/tests/src/sync-rln-tree.js"
   },
   "devDependencies": {
     "@size-limit/preset-big-lib": "^11.0.2",

--- a/packages/tests/src/constants.ts
+++ b/packages/tests/src/constants.ts
@@ -62,3 +62,6 @@ export const TEST_TIMESTAMPS = [
 ];
 
 export const MOCHA_HOOK_MAX_TIMEOUT = 50_000;
+
+export const SEPOLIA_RPC_URL =
+  process.env.SEPOLIA_RPC_URL || "https://sepolia.gateway.tenderly.co";

--- a/packages/tests/src/lib/dockerode.ts
+++ b/packages/tests/src/lib/dockerode.ts
@@ -115,7 +115,17 @@ export default class Dockerode {
           ...(args?.peerExchange && {
             [`${discv5UdpPort}/udp`]: [{ HostPort: discv5UdpPort.toString() }]
           })
-        }
+        },
+        Mounts: args.rlnRelayEthClientAddress
+          ? [
+              {
+                Type: "bind",
+                ReadOnly: false,
+                Source: "/tmp/rln_tree.db",
+                Target: "/rln_tree.db"
+              }
+            ]
+          : []
       },
       ExposedPorts: {
         [`${restPort}/tcp`]: {},

--- a/packages/tests/src/lib/service_node.ts
+++ b/packages/tests/src/lib/service_node.ts
@@ -87,6 +87,10 @@ export class ServiceNode {
     return isGoWaku ? "go-waku" : "nwaku";
   }
 
+  get containerName(): string | undefined {
+    return this.docker?.container?.id;
+  }
+
   async start(
     args: Args = {},
     options: {
@@ -226,6 +230,17 @@ export class ServiceNode {
       "GET",
       undefined,
       async (response) => await response.json()
+    );
+  }
+
+  async healthy(): Promise<boolean> {
+    this.checkProcess();
+
+    return this.restCall<boolean>(
+      "/health",
+      "GET",
+      undefined,
+      async (response) => response.status === 200
     );
   }
 

--- a/packages/tests/src/sync-rln-tree.js
+++ b/packages/tests/src/sync-rln-tree.js
@@ -1,0 +1,56 @@
+import { exec } from "child_process";
+import { setTimeout } from "timers";
+import { promisify } from "util";
+
+import { SEPOLIA_RPC_URL } from "../dist/constants.js";
+import { ServiceNode } from "../dist/lib/service_node.js";
+
+const execAsync = promisify(exec);
+
+const WAKUNODE_IMAGE = process.env.WAKUNODE_IMAGE || "wakuorg/nwaku:v0.27.0";
+const containerName = "rln_tree";
+
+async function syncRlnTree() {
+  try {
+    await execAsync(`docker inspect ${WAKUNODE_IMAGE}`);
+    console.log(`Using local image ${WAKUNODE_IMAGE}`);
+  } catch (error) {
+    console.log(`Pulling image ${WAKUNODE_IMAGE}`);
+    await execAsync(`docker pull ${WAKUNODE_IMAGE}`);
+    console.log("Image pulled");
+  }
+
+  const nwaku = new ServiceNode(containerName);
+  await nwaku.start(
+    {
+      store: false,
+      lightpush: false,
+      relay: true,
+      filter: false,
+      rest: true,
+      clusterId: 1,
+      rlnRelayEthClientAddress: SEPOLIA_RPC_URL
+    },
+    { retries: 3 }
+  );
+  let healthy = false;
+  while (!healthy) {
+    healthy = await nwaku.healthy();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  await execAsync(
+    `docker cp ${nwaku.containerName}:/rln_tree.db /tmp/rln_tree.db`
+  );
+  await nwaku.stop();
+}
+
+syncRlnTree()
+  .then(() => {
+    console.log("Synced RLN tree");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(`Error syncing RLN tree: ${err}`);
+    process.exit(1);
+  });

--- a/packages/tests/src/types.ts
+++ b/packages/tests/src/types.ts
@@ -26,6 +26,7 @@ export interface Args {
   legacyFilter?: boolean;
   clusterId?: number;
   shard?: Array<number>;
+  rlnRelayEthClientAddress?: string;
 }
 
 export interface Ports {


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

Tests that run against cluster id 1 (The Waku Network) require running an nwaku node with a sepolia RPC url.
When adding this parameter, the nwaku node will not be "ready" (`/health` returns status 200) until the RLN tree is synced. If starting from scratch, this process takes a long time (up to 5 minutes, and will only take longer as more blocks are mined on Sepolia).

## Solution

<!-- describe the new behavior --> 

Add a step to the CI that:
- checks if the `rln_tree.db` is stored as an artifact. If so, pull it.
- run an nwaku node in docker that mounts the `rln_tree.db` until the `/health` endpoint returns 200 (basically syncs the rln_tree to latest block on sepolia)
- store the synced `rln_tree.db` as an artifact

For now, the step is disabled. When we have tests that run against TWN, we will enable this job and have it be a prereq for running those tests.

## Notes

<!-- Remove items that are not relevant -->

- Related to #1914 

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
