### PR TITLE
fix: add shard arg to nwaku in peer management tests

### DIFF
--- a/packages/tests/src/run-tests.js
+++ b/packages/tests/src/run-tests.js
@@ -26,7 +26,11 @@ async function main() {
 
   // Run mocha tests
   const mocha = spawn("npx", mochaArgs, {
-    stdio: "inherit"
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      NODE_ENV: "test"
+    }
   });
 
   mocha.on("error", (error) => {

--- a/packages/tests/src/types.ts
+++ b/packages/tests/src/types.ts
@@ -25,6 +25,7 @@ export interface Args {
   // `legacyFilter` is required to enable filter v1 with go-waku
   legacyFilter?: boolean;
   clusterId?: number;
+  shard?: Array<number>;
 }
 
 export interface Ports {

--- a/packages/tests/tests/sharding/peer_management.spec.ts
+++ b/packages/tests/tests/sharding/peer_management.spec.ts
@@ -61,7 +61,8 @@ describe("Static Sharding: Peer Management", function () {
         discv5Discovery: true,
         peerExchange: true,
         relay: true,
-        clusterId: clusterId
+        clusterId: clusterId,
+        shard: [2]
       });
 
       const enr1 = (await nwaku1.info()).enrUri;
@@ -72,7 +73,8 @@ describe("Static Sharding: Peer Management", function () {
         peerExchange: true,
         discv5BootstrapNode: enr1,
         relay: true,
-        clusterId: clusterId
+        clusterId: clusterId,
+        shard: [2]
       });
 
       const enr2 = (await nwaku2.info()).enrUri;
@@ -83,7 +85,8 @@ describe("Static Sharding: Peer Management", function () {
         peerExchange: true,
         discv5BootstrapNode: enr2,
         relay: true,
-        clusterId: clusterId
+        clusterId: clusterId,
+        shard: [2]
       });
       const nwaku3Ma = await nwaku3.getMultiaddrWithId();
 
@@ -140,7 +143,8 @@ describe("Static Sharding: Peer Management", function () {
         relay: true,
         discv5Discovery: true,
         peerExchange: true,
-        clusterId: clusterId
+        clusterId: clusterId,
+        shard: [1]
       });
 
       const enr1 = (await nwaku1.info()).enrUri;
@@ -151,7 +155,8 @@ describe("Static Sharding: Peer Management", function () {
         discv5Discovery: true,
         peerExchange: true,
         discv5BootstrapNode: enr1,
-        clusterId: clusterId
+        clusterId: clusterId,
+        shard: [2]
       });
 
       const enr2 = (await nwaku2.info()).enrUri;
@@ -162,7 +167,8 @@ describe("Static Sharding: Peer Management", function () {
         discv5Discovery: true,
         peerExchange: true,
         discv5BootstrapNode: enr2,
-        clusterId: clusterId
+        clusterId: clusterId,
+        shard: [2]
       });
       const nwaku3Ma = await nwaku3.getMultiaddrWithId();
 


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

Tests for checking that connection manager dials the correct peers based on sharding params were failing against nwaku

## Solution

<!-- describe the new behavior --> 

1. Add `NODE_ENV=test` to env vars when running tests
2. Add `shard` argument when starting nwaku
3. Use correct `shard` arguments when running tests in `peer_management.spec.ts`

## Notes

<!-- Remove items that are not relevant -->

- Resolves <issue number>
- Related to <link to specs>

Contribution checklist:
- [ ] covered by unit tests;
- [x] covered by e2e test;
- [ ] add `!` in title if breaks public API;
