### PR TITLE
fix: add .js to base protocol import in filter sdk

### DIFF
--- a/packages/sdk/src/protocols/filter.ts
+++ b/packages/sdk/src/protocols/filter.ts
@@ -30,7 +30,7 @@ import {
   toAsyncIterator
 } from "@waku/utils";
 
-import { BaseProtocolSDK } from "./base_protocol";
+import { BaseProtocolSDK } from "./base_protocol.js";
 
 type SubscriptionCallback<T extends IDecodedMessage> = {
   decoders: IDecoder<T>[];


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

Using `@waku/sdk` fails in browser with this error:
```
ERROR in ../../../js-waku/packages/sdk/dist/protocols/filter.js 5:0-50
Module not found: Error: Can't resolve './base_protocol' in '/Users/arseniy/Waku/js-waku/packages/sdk/dist/protocols'
Did you mean 'base_protocol.js'?
BREAKING CHANGE: The request './base_protocol' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

## Solution

<!-- describe the new behavior --> 

Add `.js` to the failing import

## Notes

<!-- Remove items that are not relevant -->

- Resolves <issue number>
- Related to <link to specs>

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
