### PR TITLE
chore: bump @waku peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36498,10 +36498,10 @@
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
-        "@waku/enr": "^0.0.21",
-        "@waku/interfaces": "0.0.22",
-        "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15",
+        "@waku/enr": "^0.0.24",
+        "@waku/interfaces": "0.0.25",
+        "@waku/proto": "0.0.7",
+        "@waku/utils": "0.0.18",
         "libp2p": "^1.1.2"
       },
       "peerDependenciesMeta": {
@@ -36552,11 +36552,11 @@
       },
       "peerDependencies": {
         "@libp2p/interface": "^1.1.2",
-        "@waku/core": "0.0.27",
-        "@waku/enr": "0.0.21",
-        "@waku/interfaces": "0.0.22",
-        "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15"
+        "@waku/core": "0.0.30",
+        "@waku/enr": "0.0.24",
+        "@waku/interfaces": "0.0.25",
+        "@waku/proto": "0.0.7",
+        "@waku/utils": "0.0.18"
       },
       "peerDependenciesMeta": {
         "@libp2p/interface": {
@@ -36604,8 +36604,8 @@
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
-        "@waku/interfaces": "0.0.22",
-        "@waku/utils": "0.0.15"
+        "@waku/interfaces": "0.0.25",
+        "@waku/utils": "0.0.18"
       },
       "peerDependenciesMeta": {
         "@multiformats/multiaddr": {
@@ -36667,10 +36667,10 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@waku/core": "0.0.27",
-        "@waku/interfaces": "0.0.22",
-        "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15"
+        "@waku/core": "0.0.30",
+        "@waku/interfaces": "0.0.25",
+        "@waku/proto": "0.0.7",
+        "@waku/utils": "0.0.18"
       },
       "peerDependenciesMeta": {
         "@waku/interfaces": {
@@ -36709,8 +36709,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@waku/interfaces": "0.0.22",
-        "@waku/utils": "0.0.15"
+        "@waku/interfaces": "0.0.25",
+        "@waku/utils": "0.0.18"
       },
       "peerDependenciesMeta": {
         "@waku/interfaces": {
@@ -36787,10 +36787,10 @@
       },
       "peerDependencies": {
         "@chainsafe/libp2p-gossipsub": "^12.0.0",
-        "@waku/core": "0.0.27",
-        "@waku/interfaces": "0.0.22",
-        "@waku/proto": "0.0.6",
-        "@waku/utils": "0.0.15"
+        "@waku/core": "0.0.30",
+        "@waku/interfaces": "0.0.25",
+        "@waku/proto": "0.0.7",
+        "@waku/utils": "0.0.18"
       },
       "peerDependenciesMeta": {
         "@chainsafe/libp2p-gossipsub": {
@@ -36838,11 +36838,11 @@
       },
       "peerDependencies": {
         "@libp2p/bootstrap": "^10",
-        "@waku/core": "0.0.28",
-        "@waku/interfaces": "0.0.23",
-        "@waku/message-hash": "^0.1.12",
-        "@waku/relay": "0.0.11",
-        "@waku/utils": "0.0.16"
+        "@waku/core": "0.0.30",
+        "@waku/interfaces": "0.0.25",
+        "@waku/message-hash": "^0.1.14",
+        "@waku/relay": "0.0.13",
+        "@waku/utils": "0.0.18"
       },
       "peerDependenciesMeta": {
         "@libp2p/bootstrap": {
@@ -36926,7 +36926,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@waku/interfaces": "0.0.22"
+        "@waku/interfaces": "0.0.25"
       },
       "peerDependenciesMeta": {
         "@waku/interfaces": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,10 +104,10 @@
   "peerDependencies": {
     "@multiformats/multiaddr": "^12.0.0",
     "libp2p": "^1.1.2",
-    "@waku/enr": "^0.0.21",
-    "@waku/interfaces": "0.0.22",
-    "@waku/proto": "0.0.6",
-    "@waku/utils": "0.0.15"
+    "@waku/enr": "^0.0.24",
+    "@waku/interfaces": "0.0.25",
+    "@waku/proto": "0.0.7",
+    "@waku/utils": "0.0.18"
   },
   "peerDependenciesMeta": {
     "@multiformats/multiaddr": {

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -81,11 +81,11 @@
     "sinon": "^18.0.0"
   },
   "peerDependencies": {
-    "@waku/core": "0.0.27",
-    "@waku/enr": "0.0.21",
-    "@waku/interfaces": "0.0.22",
-    "@waku/proto": "0.0.6",
-    "@waku/utils": "0.0.15",
+    "@waku/core": "0.0.30",
+    "@waku/enr": "0.0.24",
+    "@waku/interfaces": "0.0.25",
+    "@waku/proto": "0.0.7",
+    "@waku/utils": "0.0.18",
     "@libp2p/interface": "^1.1.2"
   },
   "peerDependenciesMeta": {

--- a/packages/enr/package.json
+++ b/packages/enr/package.json
@@ -79,8 +79,8 @@
     "uint8arrays": "^5.0.1"
   },
   "peerDependencies": {
-    "@waku/utils": "0.0.15",
-    "@waku/interfaces": "0.0.22",
+    "@waku/utils": "0.0.18",
+    "@waku/interfaces": "0.0.25",
     "@multiformats/multiaddr": "^12.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/message-encryption/package.json
+++ b/packages/message-encryption/package.json
@@ -100,10 +100,10 @@
     "rollup": "^4.12.0"
   },
   "peerDependencies": {
-    "@waku/core": "0.0.27",
-    "@waku/interfaces": "0.0.22",
-    "@waku/proto": "0.0.6",
-    "@waku/utils": "0.0.15"
+    "@waku/core": "0.0.30",
+    "@waku/interfaces": "0.0.25",
+    "@waku/proto": "0.0.7",
+    "@waku/utils": "0.0.18"
   },
   "peerDependenciesMeta": {
     "@waku/interfaces": {

--- a/packages/message-hash/package.json
+++ b/packages/message-hash/package.json
@@ -73,8 +73,8 @@
     "rollup": "^4.12.0"
   },
   "peerDependencies": {
-    "@waku/interfaces": "0.0.22",
-    "@waku/utils": "0.0.15"
+    "@waku/interfaces": "0.0.25",
+    "@waku/utils": "0.0.18"
   },
   "peerDependenciesMeta": {
     "@waku/interfaces": {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -67,10 +67,10 @@
     "rollup": "^4.12.0"
   },
   "peerDependencies": {
-    "@waku/core": "0.0.27",
-    "@waku/interfaces": "0.0.22",
-    "@waku/proto": "0.0.6",
-    "@waku/utils": "0.0.15",
+    "@waku/core": "0.0.30",
+    "@waku/interfaces": "0.0.25",
+    "@waku/proto": "0.0.7",
+    "@waku/utils": "0.0.18",
     "@chainsafe/libp2p-gossipsub": "^12.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -90,11 +90,11 @@
   },
   "peerDependencies": {
     "@libp2p/bootstrap": "^10",
-    "@waku/core": "0.0.28",
-    "@waku/interfaces": "0.0.23",
-    "@waku/message-hash": "^0.1.12",
-    "@waku/relay": "0.0.11",
-    "@waku/utils": "0.0.16"
+    "@waku/core": "0.0.30",
+    "@waku/interfaces": "0.0.25",
+    "@waku/message-hash": "^0.1.14",
+    "@waku/relay": "0.0.13",
+    "@waku/utils": "0.0.18"
   },
   "peerDependenciesMeta": {
     "@waku/interfaces": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -84,7 +84,7 @@
     "rollup": "^4.12.0"
   },
   "peerDependencies": {
-    "@waku/interfaces": "0.0.22"
+    "@waku/interfaces": "0.0.25"
   },
   "peerDependenciesMeta": {
     "@waku/interfaces": {


### PR DESCRIPTION
## Problem

In apps and libraries that consume `js-waku` might happen a problem with resolving packages.
Example - https://github.com/waku-org/waku-react/actions/runs/9923111221/job/27412913948?pr=46

## Solution

Manually bump.

## Notes

Related to - https://github.com/waku-org/js-waku/issues/2063