### PR TITLE
feat: fix peer renewal, change Filter keep alive

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,6 @@ export { waitForRemotePeer } from "./lib/wait_for_remote_peer.js";
 export { ConnectionManager } from "./lib/connection_manager.js";
 
 export { KeepAliveManager } from "./lib/keep_alive_manager.js";
-export { StreamManager } from "./lib/stream_manager.js";
+export { StreamManager } from "./lib/stream_manager/index.js";
 
 export { MetadataCodec, wakuMetadata } from "./lib/metadata/index.js";

--- a/packages/core/src/lib/base_protocol.ts
+++ b/packages/core/src/lib/base_protocol.ts
@@ -14,7 +14,7 @@ import {
 } from "@waku/utils/libp2p";
 
 import { filterPeersByDiscovery } from "./filterPeers.js";
-import { StreamManager } from "./stream_manager.js";
+import { StreamManager } from "./stream_manager/index.js";
 
 /**
  * A class with predefined helpers, to be used as a base to implement Waku

--- a/packages/core/src/lib/base_protocol.ts
+++ b/packages/core/src/lib/base_protocol.ts
@@ -47,6 +47,7 @@ export class BaseProtocol implements IBaseProtocolCore {
       this.addLibp2pEventListener
     );
   }
+
   protected async getStream(peer: Peer): Promise<Stream> {
     return this.streamManager.getStream(peer);
   }

--- a/packages/core/src/lib/keep_alive_manager.ts
+++ b/packages/core/src/lib/keep_alive_manager.ts
@@ -27,8 +27,6 @@ export class KeepAliveManager {
     new Map();
 
   constructor({ options, relay, libp2p }: CreateKeepAliveManagerOptions) {
-    this.pingKeepAliveTimers = new Map();
-    this.relayKeepAliveTimers = new Map();
     this.options = options;
     this.relay = relay;
     this.libp2p = libp2p;

--- a/packages/core/src/lib/keep_alive_manager.ts
+++ b/packages/core/src/lib/keep_alive_manager.ts
@@ -1,6 +1,5 @@
-import type { PeerId, PeerStore } from "@libp2p/interface";
-import type { PingService } from "@libp2p/ping";
-import type { IRelay, PeerIdStr } from "@waku/interfaces";
+import type { PeerId } from "@libp2p/interface";
+import type { IRelay, Libp2p, PeerIdStr } from "@waku/interfaces";
 import type { KeepAliveOptions } from "@waku/interfaces";
 import { Logger, pubsubTopicToSingleShardInfo } from "@waku/utils";
 import { utf8ToBytes } from "@waku/utils/bytes";
@@ -10,24 +9,32 @@ import { createEncoder } from "./message/version_0.js";
 export const RelayPingContentTopic = "/relay-ping/1/ping/null";
 const log = new Logger("keep-alive");
 
-export class KeepAliveManager {
-  private pingKeepAliveTimers: Map<string, ReturnType<typeof setInterval>>;
-  private relayKeepAliveTimers: Map<PeerId, ReturnType<typeof setInterval>[]>;
-  private options: KeepAliveOptions;
-  private relay?: IRelay;
+type CreateKeepAliveManagerOptions = {
+  options: KeepAliveOptions;
+  libp2p: Libp2p;
+  relay?: IRelay;
+};
 
-  constructor(options: KeepAliveOptions, relay?: IRelay) {
+export class KeepAliveManager {
+  private readonly relay?: IRelay;
+  private readonly libp2p: Libp2p;
+
+  private readonly options: KeepAliveOptions;
+
+  private pingKeepAliveTimers: Map<string, ReturnType<typeof setInterval>> =
+    new Map();
+  private relayKeepAliveTimers: Map<PeerId, ReturnType<typeof setInterval>[]> =
+    new Map();
+
+  constructor({ options, relay, libp2p }: CreateKeepAliveManagerOptions) {
     this.pingKeepAliveTimers = new Map();
     this.relayKeepAliveTimers = new Map();
     this.options = options;
     this.relay = relay;
+    this.libp2p = libp2p;
   }
 
-  public start(
-    peerId: PeerId,
-    libp2pPing: PingService,
-    peerStore: PeerStore
-  ): void {
+  public start(peerId: PeerId): void {
     // Just in case a timer already exists for this peer
     this.stop(peerId);
 
@@ -46,7 +53,7 @@ export class KeepAliveManager {
             // ping the peer for keep alive
             // also update the peer store with the latency
             try {
-              ping = await libp2pPing.ping(peerId);
+              ping = await this.libp2p.services.ping.ping(peerId);
               log.info(`Ping succeeded (${peerIdStr})`, ping);
             } catch (error) {
               log.error(`Ping failed for peer (${peerIdStr}).
@@ -56,7 +63,7 @@ export class KeepAliveManager {
             }
 
             try {
-              await peerStore.merge(peerId, {
+              await this.libp2p.peerStore.merge(peerId, {
                 metadata: {
                   ping: utf8ToBytes(ping.toString())
                 }

--- a/packages/core/src/lib/stream_manager/index.ts
+++ b/packages/core/src/lib/stream_manager/index.ts
@@ -1,0 +1,1 @@
+export { StreamManager } from "./stream_manager.js";

--- a/packages/core/src/lib/stream_manager/stream_manager.ts
+++ b/packages/core/src/lib/stream_manager/stream_manager.ts
@@ -2,7 +2,8 @@ import type { PeerUpdate, Stream } from "@libp2p/interface";
 import type { Peer, PeerId } from "@libp2p/interface";
 import { Libp2p } from "@waku/interfaces";
 import { Logger } from "@waku/utils";
-import { selectConnection } from "@waku/utils/libp2p";
+
+import { selectConnection } from "./utils.js";
 
 const CONNECTION_TIMEOUT = 5_000;
 const RETRY_BACKOFF_BASE = 1_000;

--- a/packages/core/src/lib/stream_manager/utils.ts
+++ b/packages/core/src/lib/stream_manager/utils.ts
@@ -1,0 +1,22 @@
+import type { Connection } from "@libp2p/interface";
+
+export function selectConnection(
+  connections: Connection[]
+): Connection | undefined {
+  if (!connections.length) return;
+  if (connections.length === 1) return connections[0];
+
+  let latestConnection: Connection | undefined;
+
+  connections.forEach((connection) => {
+    if (connection.status === "open") {
+      if (!latestConnection) {
+        latestConnection = connection;
+      } else if (connection.timeline.open > latestConnection.timeline.open) {
+        latestConnection = connection;
+      }
+    }
+  });
+
+  return latestConnection;
+}

--- a/packages/sdk/src/protocols/filter.ts
+++ b/packages/sdk/src/protocols/filter.ts
@@ -41,11 +41,11 @@ type SubscriptionCallback<T extends IDecodedMessage> = {
 
 const log = new Logger("sdk:filter");
 
-const MINUTE = 60 * 1000;
 const DEFAULT_MAX_PINGS = 3;
+const DEFAULT_KEEP_ALIVE = 30 * 1000;
 
 const DEFAULT_SUBSCRIBE_OPTIONS = {
-  keepAlive: MINUTE
+  keepAlive: DEFAULT_KEEP_ALIVE
 };
 export class SubscriptionManager implements ISubscriptionSDK {
   private readonly pubsubTopic: PubsubTopic;

--- a/packages/utils/src/libp2p/index.ts
+++ b/packages/utils/src/libp2p/index.ts
@@ -105,24 +105,3 @@ export async function getConnectedPeersForProtocolAndShard(
   const peersWithNulls = await Promise.all(peerPromises);
   return peersWithNulls.filter((peer): peer is Peer => peer !== null);
 }
-
-export function selectConnection(
-  connections: Connection[]
-): Connection | undefined {
-  if (!connections.length) return;
-  if (connections.length === 1) return connections[0];
-
-  let latestConnection: Connection | undefined;
-
-  connections.forEach((connection) => {
-    if (connection.status === "open") {
-      if (!latestConnection) {
-        latestConnection = connection;
-      } else if (connection.timeline.open > latestConnection.timeline.open) {
-        latestConnection = connection;
-      }
-    }
-  });
-
-  return latestConnection;
-}


### PR DESCRIPTION
## Problem

Peer renewal doesn't work as intended.

Current behavior - it renews a peer to a one with which light node has a connection already.
Expected behavior - renews to a peer which we don't have a connection. 

This PR also adds decrease for Filter keep alive queries to 30 seconds as was proposed in one of the threads in https://github.com/waku-org/specs/pull/18, and some code improvements. 

## Solution

Fix the behavior and add some improvements.

## Notes

Tested in the dogfooding app - https://github.com/waku-org/lab.waku.org/pull/68