### PR TITLE
chore: changing default pubsub topic to its static sharding version

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1083,7 +1083,7 @@ Nothing. Was published by mistake and does not contain valid code. Same as 0.0.1
 - Doc: Link to [Waku v2 Toy Chat specs](https://rfc.vac.dev/spec/22/) in README.
 - Examples (web chat): Persist nick.
 - Support for custom PubSub Topics to `Waku`, `WakuRelay`, `WakuStore` and `WakuLightPush`;
-  Passing a PubSub Topic is optional and still defaults to `/waku/2/default-waku/proto`;
+  Passing a PubSub Topic is optional and still defaults to `/waku/2/rs/0/0`;
   JS-Waku currently supports one, and only, PubSub topic per instance.
 
 ## [0.5.0] - 2021-05-21

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1083,7 +1083,7 @@ Nothing. Was published by mistake and does not contain valid code. Same as 0.0.1
 - Doc: Link to [Waku v2 Toy Chat specs](https://rfc.vac.dev/spec/22/) in README.
 - Examples (web chat): Persist nick.
 - Support for custom PubSub Topics to `Waku`, `WakuRelay`, `WakuStore` and `WakuLightPush`;
-  Passing a PubSub Topic is optional and still defaults to `/waku/2/rs/0/0`;
+  Passing a PubSub Topic is optional and still defaults to `/waku/2/default-waku/proto`;
   JS-Waku currently supports one, and only, PubSub topic per instance.
 
 ## [0.5.0] - 2021-05-21

--- a/packages/discovery/src/dns/constants.ts
+++ b/packages/discovery/src/dns/constants.ts
@@ -3,14 +3,11 @@ import type { NodeCapabilityCount } from "@waku/interfaces";
 /**
  * The ENR tree for the different fleets.
  * SANDBOX and TEST fleets are for The Waku Network.
- * DEPRECATED_DEFAULT_PUBSUB is the fleet of nodes supporting the now deprecated DefaultPubsubTopic.
  */
 export const enrTree = {
   SANDBOX:
     "enrtree://AIRVQ5DDA4FFWLRBCHJWUWOO6X6S4ZTZ5B667LQ6AJU6PEYDLRD5O@sandbox.waku.nodes.status.im",
-  TEST: "enrtree://AOGYWMBYOUIMOENHXCHILPKY3ZRFEULMFI4DOM442QSZ73TT2A7VI@test.waku.nodes.status.im",
-  DEPRECATED_DEFAULT_PUBSUB:
-    "enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im"
+  TEST: "enrtree://AOGYWMBYOUIMOENHXCHILPKY3ZRFEULMFI4DOM442QSZ73TT2A7VI@test.waku.nodes.status.im"
 };
 
 export const DEFAULT_BOOTSTRAP_TAG_NAME = "bootstrap";

--- a/packages/interfaces/src/constants.ts
+++ b/packages/interfaces/src/constants.ts
@@ -1,7 +1,7 @@
 /**
  * DefaultPubsubTopic is the default gossipsub topic to use for Waku.
  */
-export const DefaultPubsubTopic = "/waku/2/default-waku/proto";
+export const DefaultPubsubTopic = "/waku/2/rs/0/0";
 
 /**
  * The default cluster ID for The Waku Network

--- a/packages/interfaces/src/constants.ts
+++ b/packages/interfaces/src/constants.ts
@@ -1,9 +1,14 @@
-/**
- * DefaultPubsubTopic is the default gossipsub topic to use for Waku.
- */
-export const DefaultPubsubTopic = "/waku/2/rs/0/0";
+import { ShardInfo } from "./enr";
 
 /**
  * The default cluster ID for The Waku Network
  */
 export const DEFAULT_CLUSTER_ID = 1;
+
+/**
+ * DefaultShardInfo is default configuration for The Waku Network.
+ */
+export const DefaultShardInfo: ShardInfo = {
+  clusterId: DEFAULT_CLUSTER_ID,
+  shards: [0, 1, 2, 3, 4, 5, 6, 7, 8]
+};

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -73,31 +73,35 @@ export type ProtocolUseOptions = {
 export type ProtocolCreateOptions = {
   /**
    * @deprecated
-   * Waku will stop supporting named sharding. Only static sharding and autosharding will be supported moving forward.
-   */
-  pubsubTopics?: PubsubTopic[];
-  /**
-   * Waku supports usage of multiple pubsub topics. This is achieved through static sharding for now, and auto-sharding in the future.
-   * The format to specify a shard is:
-   * clusterId: number, shards: number[]
-   * To learn more about the sharding specifications implemented, see [Relay Sharding](https://rfc.vac.dev/spec/51/).
-   * The Pubsub Topic to use. Defaults to {@link @waku/core!DefaultPubsubTopic }.
+   * Should be used ONLY if some other than The Waku Network is in use.
    *
-   * If no pubsub topic is specified, the default pubsub topic is used.
-   * The set of pubsub topics that are used to initialize the Waku node, will need to be used by the protocols as well
-   * You cannot currently add or remove pubsub topics after initialization.
+   * See [Waku v2 Topic Usage Recommendations](https://github.com/vacp2p/rfc-index/blob/main/waku/informational/23/topics.md#pubsub-topics) for details.
+   *
    * This is used by:
    * - WakuRelay to receive, route and send messages,
    * - WakuLightPush to send messages,
    * - WakuStore to retrieve messages.
-   * See [Waku v2 Topic Usage Recommendations](https://github.com/vacp2p/rfc-index/blob/main/waku/informational/23/topics.md) for details.
    *
+   * If no pubsub topic is specified, the default pubsub topic will be determined from DefaultShardInfo.
+   *
+   * You cannot add or remove pubsub topics after initialization of the node.
+   */
+  pubsubTopics?: PubsubTopic[];
+  /**
+   * ShardInfo is used to determine which network is in use.
+   * Defaults to {@link @waku/interfaces!DefaultShardInfo}.
+   * Default value is configured for The Waku Network
+   *
+   * The format to specify a shard is:
+   * clusterId: number, shards: number[]
+   * To learn more about the sharding specification, see [Relay Sharding](https://rfc.vac.dev/spec/51/).
    */
   shardInfo?: Partial<ShardingParams>;
   /**
-   * Content topics are used to determine pubsubTopics
-   * If not provided pubsubTopics will be determined based on shardInfo
-   * See [Waku v2 Topic Usage Recommendations](https://github.com/vacp2p/rfc-index/blob/main/waku/informational/23/topics.md) for details.
+   * Content topics are used to determine network in use.
+   * See [Waku v2 Topic Usage Recommendations](https://github.com/vacp2p/rfc-index/blob/main/waku/informational/23/topics.md#content-topics) for details.
+   *
+   * You cannot add or remove content topics after initialization of the node.
    */
   contentTopics?: string[];
   /**

--- a/packages/message-encryption/src/symmetric.ts
+++ b/packages/message-encryption/src/symmetric.ts
@@ -1,7 +1,6 @@
 import { Decoder as DecoderV0 } from "@waku/core/lib/message/version_0";
 import {
   type EncoderOptions as BaseEncoderOptions,
-  DefaultPubsubTopic,
   type IDecoder,
   type IEncoder,
   type IMessage,
@@ -101,7 +100,7 @@ export interface EncoderOptions extends BaseEncoderOptions {
  * in [26/WAKU2-PAYLOAD](https://rfc.vac.dev/spec/26/).
  */
 export function createEncoder({
-  pubsubTopic = DefaultPubsubTopic,
+  pubsubTopic,
   pubsubTopicShardInfo,
   contentTopic,
   symKey,
@@ -198,7 +197,7 @@ class Decoder extends DecoderV0 implements IDecoder<DecodedMessage> {
 export function createDecoder(
   contentTopic: string,
   symKey: Uint8Array,
-  pubsubTopicShardInfo: SingleShardInfo | PubsubTopic = DefaultPubsubTopic
+  pubsubTopicShardInfo?: SingleShardInfo | PubsubTopic
 ): Decoder {
   return new Decoder(
     determinePubsubTopic(contentTopic, pubsubTopicShardInfo),

--- a/packages/message-hash/src/index.spec.ts
+++ b/packages/message-hash/src/index.spec.ts
@@ -9,7 +9,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (meta size of 12 bytes)", () => {
     const expectedHash =
       "64cce733fed134e83da02b02c6f689814872b1a0ac97ea56b76095c3c72bfe05";
-    const pubsubTopic = "/waku/2/default-waku/proto";
+    const pubsubTopic = "/waku/2/rs/0/0";
     const message: IProtoMessage = {
       payload: hexToBytes("0x010203045445535405060708"),
       contentTopic: "/waku/2/default-content/proto",
@@ -26,7 +26,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (meta size of 64 bytes)", () => {
     const expectedHash =
       "7158b6498753313368b9af8f6e0a0a05104f68f972981da42a43bc53fb0c1b27";
-    const pubsubTopic = "/waku/2/default-waku/proto";
+    const pubsubTopic = "/waku/2/rs/0/0";
     const message: IProtoMessage = {
       payload: hexToBytes("0x010203045445535405060708"),
       contentTopic: "/waku/2/default-content/proto",
@@ -45,7 +45,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (meta attribute not present)", () => {
     const expectedHash =
       "a2554498b31f5bcdfcbf7fa58ad1c2d45f0254f3f8110a85588ec3cf10720fd8";
-    const pubsubTopic = "/waku/2/default-waku/proto";
+    const pubsubTopic = "/waku/2/rs/0/0";
     const message: IProtoMessage = {
       payload: hexToBytes("0x010203045445535405060708"),
       contentTopic: "/waku/2/default-content/proto",
@@ -62,7 +62,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (payload length 0)", () => {
     const expectedHash =
       "483ea950cb63f9b9d6926b262bb36194d3f40a0463ce8446228350bd44e96de4";
-    const pubsubTopic = "/waku/2/default-waku/proto";
+    const pubsubTopic = "/waku/2/rs/0/0";
     const message: IProtoMessage = {
       payload: new Uint8Array(),
       contentTopic: "/waku/2/default-content/proto",
@@ -79,7 +79,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (no timestamp)", () => {
     const expectedHash =
       "e1a9596237dbe2cc8aaf4b838c46a7052df6bc0d42ba214b998a8bfdbe8487d6";
-    const pubsubTopic = "/waku/2/default-waku/proto";
+    const pubsubTopic = "/waku/2/rs/0/0";
     const message: IProtoMessage = {
       payload: new Uint8Array(),
       contentTopic: "/waku/2/default-content/proto",
@@ -96,7 +96,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (message is IDecodedMessage)", () => {
     const expectedHash =
       "bd81b27902ad51f49e8f73ff8db4a96994040c9421da88b7ee8ba07bd39070b2";
-    const pubsubTopic = "/waku/2/default-waku/proto";
+    const pubsubTopic = "/waku/2/rs/0/0";
     const message: IDecodedMessage = {
       payload: new Uint8Array(),
       pubsubTopic,

--- a/packages/message-hash/src/index.spec.ts
+++ b/packages/message-hash/src/index.spec.ts
@@ -9,7 +9,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (meta size of 12 bytes)", () => {
     const expectedHash =
       "64cce733fed134e83da02b02c6f689814872b1a0ac97ea56b76095c3c72bfe05";
-    const pubsubTopic = "/waku/2/rs/0/0";
+    const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IProtoMessage = {
       payload: hexToBytes("0x010203045445535405060708"),
       contentTopic: "/waku/2/default-content/proto",
@@ -26,7 +26,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (meta size of 64 bytes)", () => {
     const expectedHash =
       "7158b6498753313368b9af8f6e0a0a05104f68f972981da42a43bc53fb0c1b27";
-    const pubsubTopic = "/waku/2/rs/0/0";
+    const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IProtoMessage = {
       payload: hexToBytes("0x010203045445535405060708"),
       contentTopic: "/waku/2/default-content/proto",
@@ -45,7 +45,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (meta attribute not present)", () => {
     const expectedHash =
       "a2554498b31f5bcdfcbf7fa58ad1c2d45f0254f3f8110a85588ec3cf10720fd8";
-    const pubsubTopic = "/waku/2/rs/0/0";
+    const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IProtoMessage = {
       payload: hexToBytes("0x010203045445535405060708"),
       contentTopic: "/waku/2/default-content/proto",
@@ -62,7 +62,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (payload length 0)", () => {
     const expectedHash =
       "483ea950cb63f9b9d6926b262bb36194d3f40a0463ce8446228350bd44e96de4";
-    const pubsubTopic = "/waku/2/rs/0/0";
+    const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IProtoMessage = {
       payload: new Uint8Array(),
       contentTopic: "/waku/2/default-content/proto",
@@ -79,7 +79,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (no timestamp)", () => {
     const expectedHash =
       "e1a9596237dbe2cc8aaf4b838c46a7052df6bc0d42ba214b998a8bfdbe8487d6";
-    const pubsubTopic = "/waku/2/rs/0/0";
+    const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IProtoMessage = {
       payload: new Uint8Array(),
       contentTopic: "/waku/2/default-content/proto",
@@ -96,7 +96,7 @@ describe("RFC Test Vectors", () => {
   it("Waku message hash computation (message is IDecodedMessage)", () => {
     const expectedHash =
       "bd81b27902ad51f49e8f73ff8db4a96994040c9421da88b7ee8ba07bd39070b2";
-    const pubsubTopic = "/waku/2/rs/0/0";
+    const pubsubTopic = "/waku/2/default-waku/proto";
     const message: IDecodedMessage = {
       payload: new Uint8Array(),
       pubsubTopic,

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -11,7 +11,6 @@ import { sha256 } from "@noble/hashes/sha256";
 import {
   ActiveSubscriptions,
   Callback,
-  DefaultPubsubTopic,
   IAsyncIterator,
   IDecodedMessage,
   IDecoder,
@@ -75,9 +74,8 @@ class Relay implements IRelay {
 
     this.observers = new Map();
 
-    // Default PubsubTopic decoder
     // TODO: User might want to decide what decoder should be used (e.g. for RLN)
-    this.defaultDecoder = new TopicOnlyDecoder();
+    this.defaultDecoder = new TopicOnlyDecoder(pubsubTopics[0]);
   }
 
   /**
@@ -204,8 +202,9 @@ class Relay implements IRelay {
     return map;
   }
 
-  public getMeshPeers(topic: TopicStr = DefaultPubsubTopic): PeerIdStr[] {
-    return this.gossipSub.getMeshPeers(topic);
+  public getMeshPeers(topic?: TopicStr): PeerIdStr[] {
+    // if no TopicStr is provided - returns empty array
+    return this.gossipSub.getMeshPeers(topic || "");
   }
 
   private subscribeToAllTopics(): void {

--- a/packages/relay/src/topic_only_message.ts
+++ b/packages/relay/src/topic_only_message.ts
@@ -1,8 +1,8 @@
-import { DefaultPubsubTopic } from "@waku/interfaces";
 import type {
   IDecodedMessage,
   IDecoder,
-  IProtoMessage
+  IProtoMessage,
+  PubsubTopic
 } from "@waku/interfaces";
 import { TopicOnlyMessage as ProtoTopicOnlyMessage } from "@waku/proto";
 
@@ -23,9 +23,12 @@ export class TopicOnlyMessage implements IDecodedMessage {
   }
 }
 
+// This decoder is used only for reading `contentTopic` from the WakuMessage
 export class TopicOnlyDecoder implements IDecoder<TopicOnlyMessage> {
-  public pubsubTopic = DefaultPubsubTopic;
   public contentTopic = "";
+
+  // pubsubTopic is ignored
+  public constructor(public pubsubTopic: PubsubTopic) {}
 
   public fromWireToProtoObj(
     bytes: Uint8Array

--- a/packages/sdk/src/create/discovery.ts
+++ b/packages/sdk/src/create/discovery.ts
@@ -5,11 +5,7 @@ import {
   wakuLocalPeerCacheDiscovery,
   wakuPeerExchangeDiscovery
 } from "@waku/discovery";
-import {
-  DefaultPubsubTopic,
-  type Libp2pComponents,
-  PubsubTopic
-} from "@waku/interfaces";
+import { type Libp2pComponents, PubsubTopic } from "@waku/interfaces";
 
 const DEFAULT_NODE_REQUIREMENTS = {
   lightPush: 1,
@@ -20,10 +16,7 @@ const DEFAULT_NODE_REQUIREMENTS = {
 export function defaultPeerDiscoveries(
   pubsubTopics: PubsubTopic[]
 ): ((components: Libp2pComponents) => PeerDiscovery)[] {
-  const isDefaultPubsubTopic = pubsubTopics.includes(DefaultPubsubTopic);
-  const dnsEnrTrees = isDefaultPubsubTopic
-    ? [enrTree["DEPRECATED_DEFAULT_PUBSUB"]]
-    : [enrTree["SANDBOX"], enrTree["TEST"]];
+  const dnsEnrTrees = [enrTree["SANDBOX"], enrTree["TEST"]];
 
   const discoveries = [
     wakuDnsDiscovery(dnsEnrTrees, DEFAULT_NODE_REQUIREMENTS),

--- a/packages/sdk/src/create/libp2p.ts
+++ b/packages/sdk/src/create/libp2p.ts
@@ -9,7 +9,7 @@ import { all as filterAll, wss } from "@libp2p/websockets/filters";
 import { wakuMetadata } from "@waku/core";
 import {
   type CreateLibp2pOptions,
-  DefaultPubsubTopic,
+  DefaultShardInfo,
   type IMetadata,
   type Libp2p,
   type Libp2pComponents,
@@ -138,12 +138,15 @@ function configureNetworkOptions(
     options.shardInfo = { contentTopics: options.contentTopics };
   }
 
+  if (!options.shardInfo) {
+    options.shardInfo = DefaultShardInfo;
+  }
+
   const shardInfo = options.shardInfo
     ? ensureShardingConfigured(options.shardInfo)
     : undefined;
 
-  options.pubsubTopics = shardInfo?.pubsubTopics ??
-    options.pubsubTopics ?? [DefaultPubsubTopic];
+  options.pubsubTopics = options.pubsubTopics ?? shardInfo?.pubsubTopics;
 
   return shardInfo?.shardInfo;
 }

--- a/packages/tests/src/constants.ts
+++ b/packages/tests/src/constants.ts
@@ -5,6 +5,8 @@
  * @module
  */
 
+import { PubsubTopic, ShardInfo, SingleShardInfo } from "@waku/interfaces";
+
 export const NOISE_KEY_1 = new Uint8Array(
   ((): number[] => {
     const b = [];
@@ -65,3 +67,13 @@ export const MOCHA_HOOK_MAX_TIMEOUT = 50_000;
 
 export const SEPOLIA_RPC_URL =
   process.env.SEPOLIA_RPC_URL || "https://sepolia.gateway.tenderly.co";
+
+export const DefaultTestPubsubTopic: PubsubTopic = "/waku/2/rs/0/0";
+export const DefaultTestShardInfo: ShardInfo = {
+  clusterId: 0,
+  shards: [0]
+};
+export const DefaultTestSingleShardInfo: SingleShardInfo = {
+  clusterId: 0,
+  shard: 0
+};

--- a/packages/tests/src/lib/index.ts
+++ b/packages/tests/src/lib/index.ts
@@ -1,12 +1,9 @@
 import { DecodedMessage } from "@waku/core";
-import {
-  DefaultPubsubTopic,
-  PubsubTopic,
-  ShardingParams
-} from "@waku/interfaces";
+import { PubsubTopic, ShardingParams } from "@waku/interfaces";
 import { ensureShardingConfigured, Logger } from "@waku/utils";
 import { expect } from "chai";
 
+import { DefaultTestPubsubTopic } from "../constants";
 import { Args, MessageRpcQuery, MessageRpcResponse } from "../types";
 import { delay, makeLogFileName } from "../utils/index.js";
 
@@ -105,7 +102,7 @@ export class ServiceNodesFleet {
 
   public async sendRelayMessage(
     message: MessageRpcQuery,
-    pubsubTopic: string = DefaultPubsubTopic
+    pubsubTopic: string = DefaultTestPubsubTopic
   ): Promise<boolean> {
     const relayMessagePromises: Promise<boolean>[] = this.nodes.map((node) =>
       node.sendMessage(message, pubsubTopic)
@@ -221,7 +218,7 @@ class MultipleNodesMessageCollector {
     }
   ): Promise<boolean> {
     const startTime = Date.now();
-    const pubsubTopic = options?.pubsubTopic || DefaultPubsubTopic;
+    const pubsubTopic = options?.pubsubTopic || DefaultTestPubsubTopic;
     const timeoutDuration = options?.timeoutDuration || 400;
     const exact = options?.exact || false;
 

--- a/packages/tests/src/lib/message_collector.ts
+++ b/packages/tests/src/lib/message_collector.ts
@@ -1,10 +1,10 @@
 import { DecodedMessage } from "@waku/core";
-import { DefaultPubsubTopic } from "@waku/interfaces";
 import { Logger } from "@waku/utils";
 import { bytesToUtf8, utf8ToBytes } from "@waku/utils/bytes";
 import { AssertionError, expect } from "chai";
 import { equals } from "uint8arrays/equals";
 
+import { DefaultTestPubsubTopic } from "../constants.js";
 import { MessageRpcResponse } from "../types.js";
 import { base64ToUtf8 } from "../utils/base64_utf8.js";
 import { delay } from "../utils/delay.js";
@@ -269,6 +269,8 @@ export class MessageCollector {
   }
 
   private getPubsubTopicToUse(pubsubTopic: string | undefined): string {
-    return pubsubTopic || this.nwaku?.pubsubTopics?.[0] || DefaultPubsubTopic;
+    return (
+      pubsubTopic || this.nwaku?.pubsubTopics?.[0] || DefaultTestPubsubTopic
+    );
   }
 }

--- a/packages/tests/src/lib/service_node.ts
+++ b/packages/tests/src/lib/service_node.ts
@@ -1,12 +1,12 @@
 import type { PeerId } from "@libp2p/interface";
 import { peerIdFromString } from "@libp2p/peer-id";
 import { Multiaddr, multiaddr } from "@multiformats/multiaddr";
-import { DefaultPubsubTopic } from "@waku/interfaces";
 import { isDefined } from "@waku/utils";
 import { Logger } from "@waku/utils";
 import pRetry from "p-retry";
 import portfinder from "portfinder";
 
+import { DefaultTestPubsubTopic } from "../constants.js";
 import {
   Args,
   LogLevel,
@@ -245,7 +245,7 @@ export class ServiceNode {
   }
 
   public async ensureSubscriptions(
-    pubsubTopics: string[] = [DefaultPubsubTopic]
+    pubsubTopics: string[] = [DefaultTestPubsubTopic]
   ): Promise<boolean> {
     return this.restCall<boolean>(
       "/relay/v1/subscriptions",
@@ -257,7 +257,7 @@ export class ServiceNode {
 
   public async messages(pubsubTopic?: string): Promise<MessageRpcResponse[]> {
     return this.restCall<MessageRpcResponse[]>(
-      `/relay/v1/messages/${encodeURIComponent(pubsubTopic || this?.args?.pubsubTopic?.[0] || DefaultPubsubTopic)}`,
+      `/relay/v1/messages/${encodeURIComponent(pubsubTopic || this?.args?.pubsubTopic?.[0] || DefaultTestPubsubTopic)}`,
       "GET",
       null,
       async (response) => {
@@ -291,7 +291,7 @@ export class ServiceNode {
     }
 
     return this.restCall<boolean>(
-      `/relay/v1/messages/${encodeURIComponent(pubsubTopic || this.args?.pubsubTopic?.[0] || DefaultPubsubTopic)}`,
+      `/relay/v1/messages/${encodeURIComponent(pubsubTopic || this.args?.pubsubTopic?.[0] || DefaultTestPubsubTopic)}`,
       "POST",
       message,
       async (response) => response.status === 200
@@ -411,7 +411,8 @@ export function defaultArgs(): Args {
     rest: true,
     restAdmin: true,
     websocketSupport: true,
-    logLevel: LogLevel.Trace
+    logLevel: LogLevel.Trace,
+    pubsubTopic: ["/waku/2/rs/0/0"]
   };
 }
 

--- a/packages/tests/tests/connection-mananger/connection_state.spec.ts
+++ b/packages/tests/tests/connection-mananger/connection_state.spec.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestShardInfo,
   delay,
   NOISE_KEY_1
 } from "../../src/index.js";
@@ -28,7 +29,7 @@ describe("Connection state", function () {
   let nwaku2PeerId: Multiaddr;
 
   beforeEachCustom(this, async () => {
-    waku = await createLightNode({ shardInfo: { clusterId: 0, shards: [0] } });
+    waku = await createLightNode({ shardInfo: DefaultTestShardInfo });
     nwaku1 = new ServiceNode(makeLogFileName(this.ctx) + "1");
     nwaku2 = new ServiceNode(makeLogFileName(this.ctx) + "2");
     await nwaku1.start({ filter: true });

--- a/packages/tests/tests/connection-mananger/connection_state.spec.ts
+++ b/packages/tests/tests/connection-mananger/connection_state.spec.ts
@@ -28,7 +28,7 @@ describe("Connection state", function () {
   let nwaku2PeerId: Multiaddr;
 
   beforeEachCustom(this, async () => {
-    waku = await createLightNode({ shardInfo: { shards: [0] } });
+    waku = await createLightNode({ shardInfo: { clusterId: 0, shards: [0] } });
     nwaku1 = new ServiceNode(makeLogFileName(this.ctx) + "1");
     nwaku2 = new ServiceNode(makeLogFileName(this.ctx) + "2");
     await nwaku1.start({ filter: true });

--- a/packages/tests/tests/connection-mananger/connection_state.spec.ts
+++ b/packages/tests/tests/connection-mananger/connection_state.spec.ts
@@ -90,10 +90,12 @@ describe("Connection state", function () {
 
   it("`waku:online` between 2 js-waku relay nodes", async function () {
     const waku1 = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     const waku2 = await createRelayNode({
-      libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } }
+      libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } },
+      shardInfo: DefaultTestShardInfo
     });
 
     let eventCount1 = 0;

--- a/packages/tests/tests/enr.node.spec.ts
+++ b/packages/tests/tests/enr.node.spec.ts
@@ -13,6 +13,7 @@ import {
   ServiceNode,
   tearDownNodes
 } from "../src/index.js";
+import { DefaultTestShardInfo } from "../src/index.js";
 
 describe("ENR Interop: ServiceNode", function () {
   let waku: RelayNode;
@@ -35,7 +36,8 @@ describe("ENR Interop: ServiceNode", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku.start();
     await waku.dial(multiAddrWithId);
@@ -68,7 +70,8 @@ describe("ENR Interop: ServiceNode", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku.start();
     await waku.dial(multiAddrWithId);
@@ -102,7 +105,8 @@ describe("ENR Interop: ServiceNode", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku.start();
     await waku.dial(multiAddrWithId);

--- a/packages/tests/tests/enr.node.spec.ts
+++ b/packages/tests/tests/enr.node.spec.ts
@@ -1,7 +1,7 @@
 import { waitForRemotePeer } from "@waku/core";
 import { EnrDecoder } from "@waku/enr";
 import type { RelayNode } from "@waku/interfaces";
-import { Protocols } from "@waku/interfaces";
+import { DefaultPubsubTopic, Protocols } from "@waku/interfaces";
 import { createRelayNode } from "@waku/sdk/relay";
 import { expect } from "chai";
 
@@ -28,7 +28,8 @@ describe("ENR Interop: ServiceNode", function () {
       relay: true,
       store: false,
       filter: false,
-      lightpush: false
+      lightpush: false,
+      pubsubTopic: [DefaultPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
@@ -60,7 +61,8 @@ describe("ENR Interop: ServiceNode", function () {
       relay: true,
       store: true,
       filter: false,
-      lightpush: false
+      lightpush: false,
+      pubsubTopic: [DefaultPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
@@ -93,7 +95,8 @@ describe("ENR Interop: ServiceNode", function () {
       store: true,
       filter: true,
       lightpush: true,
-      legacyFilter: true
+      legacyFilter: true,
+      pubsubTopic: [DefaultPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 

--- a/packages/tests/tests/enr.node.spec.ts
+++ b/packages/tests/tests/enr.node.spec.ts
@@ -1,12 +1,13 @@
 import { waitForRemotePeer } from "@waku/core";
 import { EnrDecoder } from "@waku/enr";
 import type { RelayNode } from "@waku/interfaces";
-import { DefaultPubsubTopic, Protocols } from "@waku/interfaces";
+import { Protocols } from "@waku/interfaces";
 import { createRelayNode } from "@waku/sdk/relay";
 import { expect } from "chai";
 
 import {
   afterEachCustom,
+  DefaultTestPubsubTopic,
   makeLogFileName,
   NOISE_KEY_1,
   ServiceNode,
@@ -29,7 +30,7 @@ describe("ENR Interop: ServiceNode", function () {
       store: false,
       filter: false,
       lightpush: false,
-      pubsubTopic: [DefaultPubsubTopic]
+      pubsubTopic: [DefaultTestPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
@@ -62,7 +63,7 @@ describe("ENR Interop: ServiceNode", function () {
       store: true,
       filter: false,
       lightpush: false,
-      pubsubTopic: [DefaultPubsubTopic]
+      pubsubTopic: [DefaultTestPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
@@ -96,7 +97,7 @@ describe("ENR Interop: ServiceNode", function () {
       filter: true,
       lightpush: true,
       legacyFilter: true,
-      pubsubTopic: [DefaultPubsubTopic]
+      pubsubTopic: [DefaultTestPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 

--- a/packages/tests/tests/filter/peer_management.spec.ts
+++ b/packages/tests/tests/filter/peer_management.spec.ts
@@ -1,9 +1,7 @@
 import {
-  DefaultPubsubTopic,
   ISubscriptionSDK,
   LightNode,
-  SDKProtocolResult,
-  ShardInfo
+  SDKProtocolResult
 } from "@waku/interfaces";
 import {
   createDecoder,
@@ -18,6 +16,8 @@ import { describe } from "mocha";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestPubsubTopic,
+  DefaultTestShardInfo,
   ServiceNode,
   ServiceNodesFleet
 } from "../../src/index.js";
@@ -32,7 +32,7 @@ describe("Waku Filter: Peer Management: E2E", function () {
   let serviceNodes: ServiceNodesFleet;
   let subscription: ISubscriptionSDK;
 
-  const pubsubTopic = DefaultPubsubTopic;
+  const pubsubTopic = DefaultTestPubsubTopic;
   const contentTopic = "/test";
 
   const encoder = createEncoder({
@@ -42,12 +42,10 @@ describe("Waku Filter: Peer Management: E2E", function () {
 
   const decoder = createDecoder(contentTopic, pubsubTopic);
 
-  const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
-
   beforeEachCustom(this, async () => {
     [serviceNodes, waku] = await runMultipleNodes(
       this.ctx,
-      shardInfo,
+      DefaultTestShardInfo,
       undefined,
       5
     );
@@ -186,7 +184,7 @@ describe("Waku Filter: Peer Management: E2E", function () {
   it("Renews peer on consistent missed messages", async function () {
     const [serviceNodes, waku] = await runMultipleNodes(
       this.ctx,
-      shardInfo,
+      DefaultTestShardInfo,
       undefined,
       2
     );

--- a/packages/tests/tests/filter/peer_management.spec.ts
+++ b/packages/tests/tests/filter/peer_management.spec.ts
@@ -32,15 +32,14 @@ describe("Waku Filter: Peer Management: E2E", function () {
   let serviceNodes: ServiceNodesFleet;
   let subscription: ISubscriptionSDK;
 
-  const pubsubTopic = DefaultTestPubsubTopic;
   const contentTopic = "/test";
 
   const encoder = createEncoder({
-    pubsubTopic,
+    pubsubTopic: DefaultTestPubsubTopic,
     contentTopic
   });
 
-  const decoder = createDecoder(contentTopic, pubsubTopic);
+  const decoder = createDecoder(contentTopic, DefaultTestPubsubTopic);
 
   beforeEachCustom(this, async () => {
     [serviceNodes, waku] = await runMultipleNodes(
@@ -49,8 +48,9 @@ describe("Waku Filter: Peer Management: E2E", function () {
       undefined,
       5
     );
-    const { error, subscription: sub } =
-      await waku.filter.createSubscription(pubsubTopic);
+    const { error, subscription: sub } = await waku.filter.createSubscription(
+      DefaultTestPubsubTopic
+    );
     if (!sub || error) {
       throw new Error("Could not create subscription");
     }
@@ -200,8 +200,9 @@ describe("Waku Filter: Peer Management: E2E", function () {
     ).toString();
     await waku.dial(await nodeWithoutDiscovery.getMultiaddrWithId());
 
-    const { error, subscription: sub } =
-      await waku.filter.createSubscription(pubsubTopic);
+    const { error, subscription: sub } = await waku.filter.createSubscription(
+      DefaultTestPubsubTopic
+    );
     if (!sub || error) {
       throw new Error("Could not create subscription");
     }

--- a/packages/tests/tests/filter/peer_management.spec.ts
+++ b/packages/tests/tests/filter/peer_management.spec.ts
@@ -2,7 +2,8 @@ import {
   DefaultPubsubTopic,
   ISubscriptionSDK,
   LightNode,
-  SDKProtocolResult
+  SDKProtocolResult,
+  ShardInfo
 } from "@waku/interfaces";
 import {
   createDecoder,
@@ -41,10 +42,12 @@ describe("Waku Filter: Peer Management: E2E", function () {
 
   const decoder = createDecoder(contentTopic, pubsubTopic);
 
+  const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
+
   beforeEachCustom(this, async () => {
     [serviceNodes, waku] = await runMultipleNodes(
       this.ctx,
-      undefined,
+      shardInfo,
       undefined,
       5
     );

--- a/packages/tests/tests/filter/peer_management.spec.ts
+++ b/packages/tests/tests/filter/peer_management.spec.ts
@@ -186,7 +186,7 @@ describe("Waku Filter: Peer Management: E2E", function () {
   it("Renews peer on consistent missed messages", async function () {
     const [serviceNodes, waku] = await runMultipleNodes(
       this.ctx,
-      undefined,
+      shardInfo,
       undefined,
       2
     );

--- a/packages/tests/tests/filter/utils.ts
+++ b/packages/tests/tests/filter/utils.ts
@@ -1,6 +1,5 @@
 import { createDecoder, createEncoder, waitForRemotePeer } from "@waku/core";
 import {
-  DefaultPubsubTopic,
   ISubscriptionSDK,
   LightNode,
   ProtocolCreateOptions,
@@ -19,6 +18,7 @@ import { Context } from "mocha";
 import pRetry from "p-retry";
 
 import {
+  DefaultTestPubsubTopic,
   NOISE_KEY_1,
   ServiceNodesFleet,
   waitForConnections
@@ -76,7 +76,7 @@ export async function runMultipleNodes(
 ): Promise<[ServiceNodesFleet, LightNode]> {
   const pubsubTopics = shardInfo
     ? shardInfoToPubsubTopics(shardInfo)
-    : [DefaultPubsubTopic];
+    : [DefaultTestPubsubTopic];
   // create numServiceNodes nodes
   const serviceNodes = await ServiceNodesFleet.createAndRun(
     context,

--- a/packages/tests/tests/getPeers.spec.ts
+++ b/packages/tests/tests/getPeers.spec.ts
@@ -11,7 +11,11 @@ import {
   Tags,
   utf8ToBytes
 } from "@waku/sdk";
-import { ensureShardingConfigured, shardInfoToPubsubTopics } from "@waku/utils";
+import {
+  encodeRelayShard,
+  ensureShardingConfigured,
+  shardInfoToPubsubTopics
+} from "@waku/utils";
 import { getConnectedPeersForProtocolAndShard } from "@waku/utils/libp2p";
 import { expect } from "chai";
 import fc from "fast-check";
@@ -20,6 +24,7 @@ import Sinon from "sinon";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestShardInfo,
   delay,
   makeLogFileName,
   ServiceNode,
@@ -426,6 +431,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
     expect(peers.length).to.be.equal(1);
   });
 });
+
 describe("getPeers", function () {
   let peerStore: PeerStore;
   let connectionManager: Libp2pComponents["connectionManager"];
@@ -448,7 +454,7 @@ describe("getPeers", function () {
   let allPeers: Peer[];
 
   beforeEachCustom(this, async () => {
-    waku = await createLightNode();
+    waku = await createLightNode({ shardInfo: DefaultTestShardInfo });
     peerStore = waku.libp2p.peerStore;
     connectionManager = waku.libp2p.components.connectionManager;
 
@@ -539,6 +545,10 @@ describe("getPeers", function () {
       differentCodecPeer,
       anotherDifferentCodecPeer
     ];
+
+    allPeers.forEach((peer) => {
+      peer.metadata.set("shardInfo", encodeRelayShard(DefaultTestShardInfo));
+    });
 
     Sinon.stub(peerStore, "get").callsFake(async (peerId) => {
       return allPeers.find((peer) => peer.id.equals(peerId))!;

--- a/packages/tests/tests/light-push/peer_management.spec.ts
+++ b/packages/tests/tests/light-push/peer_management.spec.ts
@@ -38,7 +38,7 @@ describe("Waku Light Push: Peer Management: E2E", function () {
     contentTopic: "/test"
   });
 
-  it.only("Number of peers are maintained correctly", async function () {
+  it("Number of peers are maintained correctly", async function () {
     const { successes, failures } = await waku.lightPush.send(encoder, {
       payload: utf8ToBytes("Hello_World")
     });

--- a/packages/tests/tests/light-push/peer_management.spec.ts
+++ b/packages/tests/tests/light-push/peer_management.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultPubsubTopic, LightNode } from "@waku/interfaces";
+import { DefaultPubsubTopic, LightNode, ShardInfo } from "@waku/interfaces";
 import { createEncoder, utf8ToBytes } from "@waku/sdk";
 import { expect } from "chai";
 import { describe } from "mocha";
@@ -18,10 +18,12 @@ describe("Waku Light Push: Peer Management: E2E", function () {
   let waku: LightNode;
   let serviceNodes: ServiceNodesFleet;
 
+  const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
+
   beforeEachCustom(this, async () => {
     [serviceNodes, waku] = await runMultipleNodes(
       this.ctx,
-      undefined,
+      shardInfo,
       undefined,
       5
     );
@@ -36,7 +38,7 @@ describe("Waku Light Push: Peer Management: E2E", function () {
     contentTopic: "/test"
   });
 
-  it("Number of peers are maintained correctly", async function () {
+  it.only("Number of peers are maintained correctly", async function () {
     const { successes, failures } = await waku.lightPush.send(encoder, {
       payload: utf8ToBytes("Hello_World")
     });

--- a/packages/tests/tests/light-push/peer_management.spec.ts
+++ b/packages/tests/tests/light-push/peer_management.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultPubsubTopic, LightNode } from "@waku/interfaces";
+import { LightNode } from "@waku/interfaces";
 import { createEncoder, utf8ToBytes } from "@waku/sdk";
 import { expect } from "chai";
 import { describe } from "mocha";
@@ -7,11 +7,13 @@ import {
   afterEachCustom,
   beforeEachCustom,
   DefaultTestShardInfo,
+  DefaultTestSingleShardInfo,
   ServiceNodesFleet
 } from "../../src/index.js";
 import {
   runMultipleNodes,
-  teardownNodesWithRedundancy
+  teardownNodesWithRedundancy,
+  TestContentTopic
 } from "../filter/utils.js";
 
 describe("Waku Light Push: Peer Management: E2E", function () {
@@ -33,8 +35,8 @@ describe("Waku Light Push: Peer Management: E2E", function () {
   });
 
   const encoder = createEncoder({
-    pubsubTopic: DefaultPubsubTopic,
-    contentTopic: "/test"
+    pubsubTopicShardInfo: DefaultTestSingleShardInfo,
+    contentTopic: TestContentTopic
   });
 
   it("Number of peers are maintained correctly", async function () {

--- a/packages/tests/tests/light-push/peer_management.spec.ts
+++ b/packages/tests/tests/light-push/peer_management.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultPubsubTopic, LightNode, ShardInfo } from "@waku/interfaces";
+import { DefaultPubsubTopic, LightNode } from "@waku/interfaces";
 import { createEncoder, utf8ToBytes } from "@waku/sdk";
 import { expect } from "chai";
 import { describe } from "mocha";
@@ -6,6 +6,7 @@ import { describe } from "mocha";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestShardInfo,
   ServiceNodesFleet
 } from "../../src/index.js";
 import {
@@ -18,12 +19,10 @@ describe("Waku Light Push: Peer Management: E2E", function () {
   let waku: LightNode;
   let serviceNodes: ServiceNodesFleet;
 
-  const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
-
   beforeEachCustom(this, async () => {
     [serviceNodes, waku] = await runMultipleNodes(
       this.ctx,
-      shardInfo,
+      DefaultTestShardInfo,
       undefined,
       5
     );

--- a/packages/tests/tests/nwaku.node.spec.ts
+++ b/packages/tests/tests/nwaku.node.spec.ts
@@ -17,6 +17,7 @@ describe("nwaku", () => {
       "--rest-admin=true",
       "--websocket-support=true",
       "--log-level=TRACE",
+      "--pubsub-topic=/waku/2/rs/0/0",
       "--ports-shift=42"
     ];
 

--- a/packages/tests/tests/peer-exchange/compliance.spec.ts
+++ b/packages/tests/tests/peer-exchange/compliance.spec.ts
@@ -1,18 +1,16 @@
 import tests from "@libp2p/interface-compliance-tests/peer-discovery";
 import { PeerExchangeCodec, PeerExchangeDiscovery } from "@waku/discovery";
-import type { LightNode, ShardInfo } from "@waku/interfaces";
+import type { LightNode } from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
-import { singleShardInfoToPubsubTopic } from "@waku/utils";
 
 import {
   beforeEachCustom,
+  DefaultTestPubsubTopic,
+  DefaultTestShardInfo,
   makeLogFileName,
   ServiceNode,
   tearDownNodes
 } from "../../src/index.js";
-
-const pubsubTopic = [singleShardInfoToPubsubTopic({ clusterId: 0, shard: 0 })];
-const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
 
 describe("Peer Exchange", function () {
   describe("Compliance Test", function () {
@@ -43,15 +41,14 @@ describe("Peer Exchange", function () {
 
     tests({
       async setup() {
-        waku = await createLightNode({ shardInfo });
+        waku = await createLightNode({ shardInfo: DefaultTestShardInfo });
         await waku.start();
 
         const nwaku2Ma = await nwaku2.getMultiaddrWithId();
 
-        const peerExchange = new PeerExchangeDiscovery(
-          waku.libp2p.components,
-          pubsubTopic
-        );
+        const peerExchange = new PeerExchangeDiscovery(waku.libp2p.components, [
+          DefaultTestPubsubTopic
+        ]);
 
         peerExchange.addEventListener("waku:peer-exchange:started", (event) => {
           if (event.detail === true) {

--- a/packages/tests/tests/peer-exchange/compliance.spec.ts
+++ b/packages/tests/tests/peer-exchange/compliance.spec.ts
@@ -1,6 +1,7 @@
 import tests from "@libp2p/interface-compliance-tests/peer-discovery";
 import { PeerExchangeCodec, PeerExchangeDiscovery } from "@waku/discovery";
-import type { LightNode } from "@waku/interfaces";
+import type { LightNode, ShardInfo } from "@waku/interfaces";
+import { DefaultPubsubTopic } from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
 import { singleShardInfoToPubsubTopic } from "@waku/utils";
 
@@ -11,7 +12,8 @@ import {
   tearDownNodes
 } from "../../src/index.js";
 
-const pubsubTopic = [singleShardInfoToPubsubTopic({ clusterId: 0, shard: 2 })];
+const pubsubTopic = [singleShardInfoToPubsubTopic({ clusterId: 0, shard: 0 })];
+const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
 
 describe("Peer Exchange", function () {
   describe("Compliance Test", function () {
@@ -28,7 +30,8 @@ describe("Peer Exchange", function () {
       await nwaku1.start({
         relay: true,
         discv5Discovery: true,
-        peerExchange: true
+        peerExchange: true,
+        pubsubTopic: [DefaultPubsubTopic]
       });
       const enr = (await nwaku1.info()).enrUri;
 
@@ -36,13 +39,14 @@ describe("Peer Exchange", function () {
         relay: true,
         discv5Discovery: true,
         peerExchange: true,
-        discv5BootstrapNode: enr
+        discv5BootstrapNode: enr,
+        pubsubTopic: [DefaultPubsubTopic]
       });
     });
 
     tests({
       async setup() {
-        waku = await createLightNode();
+        waku = await createLightNode({ shardInfo });
         await waku.start();
 
         const nwaku2Ma = await nwaku2.getMultiaddrWithId();

--- a/packages/tests/tests/peer-exchange/compliance.spec.ts
+++ b/packages/tests/tests/peer-exchange/compliance.spec.ts
@@ -1,7 +1,6 @@
 import tests from "@libp2p/interface-compliance-tests/peer-discovery";
 import { PeerExchangeCodec, PeerExchangeDiscovery } from "@waku/discovery";
 import type { LightNode, ShardInfo } from "@waku/interfaces";
-import { DefaultPubsubTopic } from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
 import { singleShardInfoToPubsubTopic } from "@waku/utils";
 
@@ -30,8 +29,7 @@ describe("Peer Exchange", function () {
       await nwaku1.start({
         relay: true,
         discv5Discovery: true,
-        peerExchange: true,
-        pubsubTopic: [DefaultPubsubTopic]
+        peerExchange: true
       });
       const enr = (await nwaku1.info()).enrUri;
 
@@ -39,8 +37,7 @@ describe("Peer Exchange", function () {
         relay: true,
         discv5Discovery: true,
         peerExchange: true,
-        discv5BootstrapNode: enr,
-        pubsubTopic: [DefaultPubsubTopic]
+        discv5BootstrapNode: enr
       });
     });
 

--- a/packages/tests/tests/peer-exchange/index.spec.ts
+++ b/packages/tests/tests/peer-exchange/index.spec.ts
@@ -1,7 +1,11 @@
 import { bootstrap } from "@libp2p/bootstrap";
 import type { PeerId } from "@libp2p/interface";
 import { wakuPeerExchangeDiscovery } from "@waku/discovery";
-import type { LightNode, PeersByDiscoveryResult } from "@waku/interfaces";
+import type {
+  LightNode,
+  PeersByDiscoveryResult,
+  ShardInfo
+} from "@waku/interfaces";
 import { createLightNode, Tags } from "@waku/sdk";
 import { Logger, singleShardInfoToPubsubTopic } from "@waku/utils";
 import { expect } from "chai";
@@ -16,7 +20,8 @@ import {
 } from "../../src/index.js";
 
 export const log = new Logger("test:pe");
-const pubsubTopic = [singleShardInfoToPubsubTopic({ clusterId: 0, shard: 2 })];
+const pubsubTopic = [singleShardInfoToPubsubTopic({ clusterId: 0, shard: 0 })];
+const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
 
 describe("Peer Exchange", function () {
   this.timeout(150_000);
@@ -52,6 +57,7 @@ describe("Peer Exchange", function () {
 
   it("getPeersByDiscovery", async function () {
     waku = await createLightNode({
+      shardInfo,
       libp2p: {
         peerDiscovery: [
           bootstrap({ list: [(await nwaku2.getMultiaddrWithId()).toString()] }),

--- a/packages/tests/tests/peer-exchange/index.spec.ts
+++ b/packages/tests/tests/peer-exchange/index.spec.ts
@@ -1,27 +1,23 @@
 import { bootstrap } from "@libp2p/bootstrap";
 import type { PeerId } from "@libp2p/interface";
 import { wakuPeerExchangeDiscovery } from "@waku/discovery";
-import type {
-  LightNode,
-  PeersByDiscoveryResult,
-  ShardInfo
-} from "@waku/interfaces";
+import type { LightNode, PeersByDiscoveryResult } from "@waku/interfaces";
 import { createLightNode, Tags } from "@waku/sdk";
-import { Logger, singleShardInfoToPubsubTopic } from "@waku/utils";
+import { Logger } from "@waku/utils";
 import { expect } from "chai";
 import Sinon, { SinonSpy } from "sinon";
 
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestPubsubTopic,
+  DefaultTestShardInfo,
   makeLogFileName,
   ServiceNode,
   tearDownNodes
 } from "../../src/index.js";
 
 export const log = new Logger("test:pe");
-const pubsubTopic = [singleShardInfoToPubsubTopic({ clusterId: 0, shard: 0 })];
-const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
 
 describe("Peer Exchange", function () {
   this.timeout(150_000);
@@ -36,13 +32,13 @@ describe("Peer Exchange", function () {
     nwaku1 = new ServiceNode(makeLogFileName(this.ctx) + "1");
     nwaku2 = new ServiceNode(makeLogFileName(this.ctx) + "2");
     await nwaku1.start({
-      pubsubTopic: pubsubTopic,
+      pubsubTopic: [DefaultTestPubsubTopic],
       discv5Discovery: true,
       peerExchange: true,
       relay: true
     });
     await nwaku2.start({
-      pubsubTopic: pubsubTopic,
+      pubsubTopic: [DefaultTestPubsubTopic],
       discv5Discovery: true,
       peerExchange: true,
       discv5BootstrapNode: (await nwaku1.info()).enrUri,
@@ -57,11 +53,11 @@ describe("Peer Exchange", function () {
 
   it("getPeersByDiscovery", async function () {
     waku = await createLightNode({
-      shardInfo,
+      shardInfo: DefaultTestShardInfo,
       libp2p: {
         peerDiscovery: [
           bootstrap({ list: [(await nwaku2.getMultiaddrWithId()).toString()] }),
-          wakuPeerExchangeDiscovery(pubsubTopic)
+          wakuPeerExchangeDiscovery([DefaultTestPubsubTopic])
         ]
       }
     });
@@ -108,7 +104,7 @@ describe("Peer Exchange", function () {
       libp2p: {
         peerDiscovery: [
           bootstrap({ list: [(await nwaku2.getMultiaddrWithId()).toString()] }),
-          wakuPeerExchangeDiscovery(pubsubTopic)
+          wakuPeerExchangeDiscovery([DefaultTestPubsubTopic])
         ]
       }
     });
@@ -134,7 +130,7 @@ describe("Peer Exchange", function () {
 
     nwaku3 = new ServiceNode(makeLogFileName(this) + "3");
     await nwaku3.start({
-      pubsubTopic: pubsubTopic,
+      pubsubTopic: [DefaultTestPubsubTopic],
       discv5Discovery: true,
       peerExchange: true,
       discv5BootstrapNode: (await nwaku1.info()).enrUri,

--- a/packages/tests/tests/wait_for_remote_peer.node.spec.ts
+++ b/packages/tests/tests/wait_for_remote_peer.node.spec.ts
@@ -66,7 +66,7 @@ describe("Wait for remote peer", function () {
     await waku1.dial(multiAddrWithId);
     await waitPromise;
 
-    const peers = waku1.relay.getMeshPeers();
+    const peers = waku1.relay.getMeshPeers(DefaultTestPubsubTopic);
     const nimPeerId = multiAddrWithId.getPeerId();
 
     expect(nimPeerId).to.not.be.undefined;
@@ -76,7 +76,8 @@ describe("Wait for remote peer", function () {
   it("Relay - times out", function (done) {
     this.timeout(5000);
     createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     })
       .then((waku1) => waku1.start().then(() => waku1))
       .then((waku1) => {

--- a/packages/tests/tests/wait_for_remote_peer.node.spec.ts
+++ b/packages/tests/tests/wait_for_remote_peer.node.spec.ts
@@ -1,6 +1,6 @@
 import { waitForRemotePeer } from "@waku/core";
 import type { LightNode, RelayNode } from "@waku/interfaces";
-import { Protocols } from "@waku/interfaces";
+import { DefaultPubsubTopic, Protocols } from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
 import { createRelayNode } from "@waku/sdk/relay";
 import { expect } from "chai";
@@ -48,7 +48,8 @@ describe("Wait for remote peer", function () {
       relay: true,
       store: false,
       filter: false,
-      lightpush: false
+      lightpush: false,
+      pubsubTopic: [DefaultPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
@@ -96,7 +97,8 @@ describe("Wait for remote peer", function () {
       store: true,
       relay: false,
       lightpush: false,
-      filter: false
+      filter: false,
+      pubsubTopic: [DefaultPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
@@ -124,7 +126,8 @@ describe("Wait for remote peer", function () {
       store: true,
       relay: false,
       lightpush: false,
-      filter: false
+      filter: false,
+      pubsubTopic: [DefaultPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
@@ -154,7 +157,8 @@ describe("Wait for remote peer", function () {
       lightpush: true,
       filter: false,
       relay: false,
-      store: false
+      store: false,
+      pubsubTopic: [DefaultPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
@@ -182,7 +186,8 @@ describe("Wait for remote peer", function () {
       filter: true,
       lightpush: false,
       relay: false,
-      store: false
+      store: false,
+      pubsubTopic: [DefaultPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
@@ -210,7 +215,8 @@ describe("Wait for remote peer", function () {
       filter: true,
       lightpush: true,
       relay: false,
-      store: true
+      store: true,
+      pubsubTopic: [DefaultPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 

--- a/packages/tests/tests/wait_for_remote_peer.node.spec.ts
+++ b/packages/tests/tests/wait_for_remote_peer.node.spec.ts
@@ -1,12 +1,14 @@
 import { waitForRemotePeer } from "@waku/core";
-import type { LightNode, RelayNode, ShardInfo } from "@waku/interfaces";
-import { DefaultPubsubTopic, Protocols } from "@waku/interfaces";
+import type { LightNode, RelayNode } from "@waku/interfaces";
+import { Protocols } from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
 import { createRelayNode } from "@waku/sdk/relay";
 import { expect } from "chai";
 
 import {
   afterEachCustom,
+  DefaultTestPubsubTopic,
+  DefaultTestShardInfo,
   delay,
   makeLogFileName,
   NOISE_KEY_1,
@@ -19,8 +21,6 @@ import {
   TestPubsubTopic,
   TestShardInfo
 } from "./relay/utils.js";
-
-const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
 
 describe("Wait for remote peer", function () {
   let waku1: RelayNode;
@@ -51,13 +51,13 @@ describe("Wait for remote peer", function () {
       store: false,
       filter: false,
       lightpush: false,
-      pubsubTopic: [DefaultPubsubTopic]
+      pubsubTopic: [DefaultTestPubsubTopic]
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku1 = await createRelayNode({
       staticNoiseKey: NOISE_KEY_1,
-      shardInfo
+      shardInfo: DefaultTestShardInfo
     });
     await waku1.start();
 
@@ -106,7 +106,7 @@ describe("Wait for remote peer", function () {
 
     waku2 = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
-      shardInfo
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);
@@ -135,7 +135,7 @@ describe("Wait for remote peer", function () {
 
     waku2 = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
-      shardInfo
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     const waitPromise = waitForRemotePeer(waku2, [Protocols.Store], 2000);
@@ -166,7 +166,7 @@ describe("Wait for remote peer", function () {
 
     waku2 = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
-      shardInfo
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);
@@ -195,7 +195,7 @@ describe("Wait for remote peer", function () {
 
     waku2 = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
-      shardInfo
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);
@@ -224,7 +224,7 @@ describe("Wait for remote peer", function () {
 
     waku2 = await createLightNode({
       staticNoiseKey: NOISE_KEY_1,
-      shardInfo
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);

--- a/packages/tests/tests/wait_for_remote_peer.node.spec.ts
+++ b/packages/tests/tests/wait_for_remote_peer.node.spec.ts
@@ -1,5 +1,5 @@
 import { waitForRemotePeer } from "@waku/core";
-import type { LightNode, RelayNode } from "@waku/interfaces";
+import type { LightNode, RelayNode, ShardInfo } from "@waku/interfaces";
 import { DefaultPubsubTopic, Protocols } from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
 import { createRelayNode } from "@waku/sdk/relay";
@@ -19,6 +19,8 @@ import {
   TestPubsubTopic,
   TestShardInfo
 } from "./relay/utils.js";
+
+const shardInfo: ShardInfo = { clusterId: 0, shards: [0] };
 
 describe("Wait for remote peer", function () {
   let waku1: RelayNode;
@@ -54,7 +56,8 @@ describe("Wait for remote peer", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku1 = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo
     });
     await waku1.start();
 
@@ -97,13 +100,13 @@ describe("Wait for remote peer", function () {
       store: true,
       relay: false,
       lightpush: false,
-      filter: false,
-      pubsubTopic: [DefaultPubsubTopic]
+      filter: false
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);
@@ -126,13 +129,13 @@ describe("Wait for remote peer", function () {
       store: true,
       relay: false,
       lightpush: false,
-      filter: false,
-      pubsubTopic: [DefaultPubsubTopic]
+      filter: false
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo
     });
     await waku2.start();
     const waitPromise = waitForRemotePeer(waku2, [Protocols.Store], 2000);
@@ -157,13 +160,13 @@ describe("Wait for remote peer", function () {
       lightpush: true,
       filter: false,
       relay: false,
-      store: false,
-      pubsubTopic: [DefaultPubsubTopic]
+      store: false
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);
@@ -186,13 +189,13 @@ describe("Wait for remote peer", function () {
       filter: true,
       lightpush: false,
       relay: false,
-      store: false,
-      pubsubTopic: [DefaultPubsubTopic]
+      store: false
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);
@@ -215,13 +218,13 @@ describe("Wait for remote peer", function () {
       filter: true,
       lightpush: true,
       relay: false,
-      store: true,
-      pubsubTopic: [DefaultPubsubTopic]
+      store: true
     });
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);

--- a/packages/tests/tests/waku.node.spec.ts
+++ b/packages/tests/tests/waku.node.spec.ts
@@ -20,6 +20,8 @@ import { expect } from "chai";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestShardInfo,
+  DefaultTestSingleShardInfo,
   makeLogFileName,
   NOISE_KEY_1,
   NOISE_KEY_2,
@@ -51,7 +53,8 @@ describe("Waku Dial [node only]", function () {
       const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
       waku = await createLightNode({
-        staticNoiseKey: NOISE_KEY_1
+        staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo
       });
       await waku.start();
       await waku.dial(multiAddrWithId);
@@ -84,7 +87,8 @@ describe("Waku Dial [node only]", function () {
       const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
       waku = await createLightNode({
-        staticNoiseKey: NOISE_KEY_1
+        staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo
       });
       await waku.start();
       await waku.dial(multiAddrWithId);
@@ -112,6 +116,7 @@ describe("Waku Dial [node only]", function () {
       const multiAddrWithId = await nwaku.getMultiaddrWithId();
       waku = await createLightNode({
         staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo,
         libp2p: {
           peerDiscovery: [bootstrap({ list: [multiAddrWithId.toString()] })]
         }
@@ -137,6 +142,7 @@ describe("Waku Dial [node only]", function () {
 
       waku = await createLightNode({
         staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo,
         libp2p: {
           peerDiscovery: [bootstrap({ list: [nwakuMa.toString()] })]
         }
@@ -166,11 +172,13 @@ describe("Decryption Keys", function () {
   let waku2: RelayNode;
   beforeEachCustom(this, async () => {
     [waku1, waku2] = await Promise.all([
-      createRelayNode({ staticNoiseKey: NOISE_KEY_1 }).then((waku) =>
-        waku.start().then(() => waku)
-      ),
+      createRelayNode({
+        staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo
+      }).then((waku) => waku.start().then(() => waku)),
       createRelayNode({
         staticNoiseKey: NOISE_KEY_2,
+        shardInfo: DefaultTestShardInfo,
         libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } }
       }).then((waku) => waku.start().then(() => waku))
     ]);
@@ -194,12 +202,18 @@ describe("Decryption Keys", function () {
     this.timeout(10000);
 
     const symKey = generateSymmetricKey();
-    const decoder = createDecoder(TestContentTopic, symKey);
+    const decoder = createDecoder(
+      TestContentTopic,
+      symKey,
+      DefaultTestSingleShardInfo
+    );
 
     const encoder = createEncoder({
       contentTopic: TestContentTopic,
+      pubsubTopicShardInfo: DefaultTestSingleShardInfo,
       symKey
     });
+
     const messageText = "Message is encrypted";
     const messageTimestamp = new Date("1995-12-17T03:24:00");
     const message = {
@@ -239,10 +253,12 @@ describe("User Agent", function () {
     [waku1, waku2] = await Promise.all([
       createRelayNode({
         staticNoiseKey: NOISE_KEY_1,
-        userAgent: waku1UserAgent
+        userAgent: waku1UserAgent,
+        shardInfo: DefaultTestShardInfo
       }).then((waku) => waku.start().then(() => waku)),
       createRelayNode({
         staticNoiseKey: NOISE_KEY_2,
+        shardInfo: DefaultTestShardInfo,
         libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } }
       }).then((waku) => waku.start().then(() => waku))
     ]);

--- a/packages/utils/src/common/sharding.ts
+++ b/packages/utils/src/common/sharding.ts
@@ -228,6 +228,7 @@ export function contentTopicsByPubsubTopic(
  */
 export function determinePubsubTopic(
   contentTopic: string,
+  // TODO: make it accept ShardInfo https://github.com/waku-org/js-waku/issues/2086
   pubsubTopicShardInfo?: SingleShardInfo | PubsubTopic
 ): string {
   if (typeof pubsubTopicShardInfo == "string") {


### PR DESCRIPTION
## Problem

After deprecating named sharding in nwaku, the pubsub topic `/waku/2/default-waku/proto` is no longer valid. We are migrating the default to`/waku/2/rs/0/0` for tests and shard info for TWN (see https://github.com/waku-org/js-waku/pull/2085).

Nwaku nodes weren't starting in some interop tests because of being set up with this no longer valid pubsub topic.

Similarly, as metadata protocol was recently activated for cluster 0, updated some tests in which clusters and shards weren't consistent between nodes, which led to disconnections.

Related to https://github.com/waku-org/nwaku/issues/2621

Includes: https://github.com/waku-org/js-waku/pull/2085

