### PR TITLE
feat: create default shard info, update tests

### DIFF
--- a/packages/discovery/src/dns/constants.ts
+++ b/packages/discovery/src/dns/constants.ts
@@ -3,14 +3,11 @@ import type { NodeCapabilityCount } from "@waku/interfaces";
 /**
  * The ENR tree for the different fleets.
  * SANDBOX and TEST fleets are for The Waku Network.
- * DEPRECATED_DEFAULT_PUBSUB is the fleet of nodes supporting the now deprecated DefaultPubsubTopic.
  */
 export const enrTree = {
   SANDBOX:
     "enrtree://AIRVQ5DDA4FFWLRBCHJWUWOO6X6S4ZTZ5B667LQ6AJU6PEYDLRD5O@sandbox.waku.nodes.status.im",
-  TEST: "enrtree://AOGYWMBYOUIMOENHXCHILPKY3ZRFEULMFI4DOM442QSZ73TT2A7VI@test.waku.nodes.status.im",
-  DEPRECATED_DEFAULT_PUBSUB:
-    "enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im"
+  TEST: "enrtree://AOGYWMBYOUIMOENHXCHILPKY3ZRFEULMFI4DOM442QSZ73TT2A7VI@test.waku.nodes.status.im"
 };
 
 export const DEFAULT_BOOTSTRAP_TAG_NAME = "bootstrap";

--- a/packages/interfaces/src/constants.ts
+++ b/packages/interfaces/src/constants.ts
@@ -1,9 +1,14 @@
-/**
- * DefaultPubsubTopic is the default gossipsub topic to use for Waku.
- */
-export const DefaultPubsubTopic = "/waku/2/rs/0/0";
+import { ShardInfo } from "./enr";
 
 /**
  * The default cluster ID for The Waku Network
  */
 export const DEFAULT_CLUSTER_ID = 1;
+
+/**
+ * DefaultShardInfo is default configuration for The Waku Network.
+ */
+export const DefaultShardInfo: ShardInfo = {
+  clusterId: DEFAULT_CLUSTER_ID,
+  shards: [0, 1, 2, 3, 4, 5, 6, 7, 8]
+};

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -73,31 +73,35 @@ export type ProtocolUseOptions = {
 export type ProtocolCreateOptions = {
   /**
    * @deprecated
-   * Waku will stop supporting named sharding. Only static sharding and autosharding will be supported moving forward.
-   */
-  pubsubTopics?: PubsubTopic[];
-  /**
-   * Waku supports usage of multiple pubsub topics. This is achieved through static sharding for now, and auto-sharding in the future.
-   * The format to specify a shard is:
-   * clusterId: number, shards: number[]
-   * To learn more about the sharding specifications implemented, see [Relay Sharding](https://rfc.vac.dev/spec/51/).
-   * The Pubsub Topic to use. Defaults to {@link @waku/core!DefaultPubsubTopic }.
+   * Should be used ONLY if some other than The Waku Network is in use.
    *
-   * If no pubsub topic is specified, the default pubsub topic is used.
-   * The set of pubsub topics that are used to initialize the Waku node, will need to be used by the protocols as well
-   * You cannot currently add or remove pubsub topics after initialization.
+   * See [Waku v2 Topic Usage Recommendations](https://github.com/vacp2p/rfc-index/blob/main/waku/informational/23/topics.md#pubsub-topics) for details.
+   *
    * This is used by:
    * - WakuRelay to receive, route and send messages,
    * - WakuLightPush to send messages,
    * - WakuStore to retrieve messages.
-   * See [Waku v2 Topic Usage Recommendations](https://github.com/vacp2p/rfc-index/blob/main/waku/informational/23/topics.md) for details.
    *
+   * If no pubsub topic is specified, the default pubsub topic will be determined from DefaultShardInfo.
+   *
+   * You cannot add or remove pubsub topics after initialization of the node.
+   */
+  pubsubTopics?: PubsubTopic[];
+  /**
+   * ShardInfo is used to determine which network is in use.
+   * Defaults to {@link @waku/interfaces!DefaultShardInfo}.
+   * Default value is configured for The Waku Network
+   *
+   * The format to specify a shard is:
+   * clusterId: number, shards: number[]
+   * To learn more about the sharding specification, see [Relay Sharding](https://rfc.vac.dev/spec/51/).
    */
   shardInfo?: Partial<ShardingParams>;
   /**
-   * Content topics are used to determine pubsubTopics
-   * If not provided pubsubTopics will be determined based on shardInfo
-   * See [Waku v2 Topic Usage Recommendations](https://github.com/vacp2p/rfc-index/blob/main/waku/informational/23/topics.md) for details.
+   * Content topics are used to determine network in use.
+   * See [Waku v2 Topic Usage Recommendations](https://github.com/vacp2p/rfc-index/blob/main/waku/informational/23/topics.md#content-topics) for details.
+   *
+   * You cannot add or remove content topics after initialization of the node.
    */
   contentTopics?: string[];
   /**

--- a/packages/message-encryption/src/symmetric.ts
+++ b/packages/message-encryption/src/symmetric.ts
@@ -1,7 +1,6 @@
 import { Decoder as DecoderV0 } from "@waku/core/lib/message/version_0";
 import {
   type EncoderOptions as BaseEncoderOptions,
-  DefaultPubsubTopic,
   type IDecoder,
   type IEncoder,
   type IMessage,
@@ -101,7 +100,6 @@ export interface EncoderOptions extends BaseEncoderOptions {
  * in [26/WAKU2-PAYLOAD](https://rfc.vac.dev/spec/26/).
  */
 export function createEncoder({
-  pubsubTopic = DefaultPubsubTopic,
   pubsubTopicShardInfo,
   contentTopic,
   symKey,
@@ -110,7 +108,7 @@ export function createEncoder({
   metaSetter
 }: EncoderOptions): Encoder {
   return new Encoder(
-    determinePubsubTopic(contentTopic, pubsubTopic ?? pubsubTopicShardInfo),
+    determinePubsubTopic(contentTopic, pubsubTopicShardInfo),
     contentTopic,
     symKey,
     sigPrivKey,
@@ -198,7 +196,7 @@ class Decoder extends DecoderV0 implements IDecoder<DecodedMessage> {
 export function createDecoder(
   contentTopic: string,
   symKey: Uint8Array,
-  pubsubTopicShardInfo: SingleShardInfo | PubsubTopic = DefaultPubsubTopic
+  pubsubTopicShardInfo?: SingleShardInfo | PubsubTopic
 ): Decoder {
   return new Decoder(
     determinePubsubTopic(contentTopic, pubsubTopicShardInfo),

--- a/packages/message-encryption/src/symmetric.ts
+++ b/packages/message-encryption/src/symmetric.ts
@@ -100,6 +100,7 @@ export interface EncoderOptions extends BaseEncoderOptions {
  * in [26/WAKU2-PAYLOAD](https://rfc.vac.dev/spec/26/).
  */
 export function createEncoder({
+  pubsubTopic,
   pubsubTopicShardInfo,
   contentTopic,
   symKey,
@@ -108,7 +109,7 @@ export function createEncoder({
   metaSetter
 }: EncoderOptions): Encoder {
   return new Encoder(
-    determinePubsubTopic(contentTopic, pubsubTopicShardInfo),
+    determinePubsubTopic(contentTopic, pubsubTopic ?? pubsubTopicShardInfo),
     contentTopic,
     symKey,
     sigPrivKey,

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -11,7 +11,6 @@ import { sha256 } from "@noble/hashes/sha256";
 import {
   ActiveSubscriptions,
   Callback,
-  DefaultPubsubTopic,
   IAsyncIterator,
   IDecodedMessage,
   IDecoder,
@@ -75,9 +74,8 @@ class Relay implements IRelay {
 
     this.observers = new Map();
 
-    // Default PubsubTopic decoder
     // TODO: User might want to decide what decoder should be used (e.g. for RLN)
-    this.defaultDecoder = new TopicOnlyDecoder();
+    this.defaultDecoder = new TopicOnlyDecoder(pubsubTopics[0]);
   }
 
   /**
@@ -204,8 +202,9 @@ class Relay implements IRelay {
     return map;
   }
 
-  public getMeshPeers(topic: TopicStr = DefaultPubsubTopic): PeerIdStr[] {
-    return this.gossipSub.getMeshPeers(topic);
+  public getMeshPeers(topic?: TopicStr): PeerIdStr[] {
+    // if no TopicStr is provided - returns empty array
+    return this.gossipSub.getMeshPeers(topic || "");
   }
 
   private subscribeToAllTopics(): void {

--- a/packages/relay/src/topic_only_message.ts
+++ b/packages/relay/src/topic_only_message.ts
@@ -1,8 +1,8 @@
-import { DefaultPubsubTopic } from "@waku/interfaces";
 import type {
   IDecodedMessage,
   IDecoder,
-  IProtoMessage
+  IProtoMessage,
+  PubsubTopic
 } from "@waku/interfaces";
 import { TopicOnlyMessage as ProtoTopicOnlyMessage } from "@waku/proto";
 
@@ -23,9 +23,12 @@ export class TopicOnlyMessage implements IDecodedMessage {
   }
 }
 
+// This decoder is used only for reading `contentTopic` from the WakuMessage
 export class TopicOnlyDecoder implements IDecoder<TopicOnlyMessage> {
-  public pubsubTopic = DefaultPubsubTopic;
   public contentTopic = "";
+
+  // pubsubTopic is ignored
+  public constructor(public pubsubTopic: PubsubTopic) {}
 
   public fromWireToProtoObj(
     bytes: Uint8Array

--- a/packages/sdk/src/create/discovery.ts
+++ b/packages/sdk/src/create/discovery.ts
@@ -5,11 +5,7 @@ import {
   wakuLocalPeerCacheDiscovery,
   wakuPeerExchangeDiscovery
 } from "@waku/discovery";
-import {
-  DefaultPubsubTopic,
-  type Libp2pComponents,
-  PubsubTopic
-} from "@waku/interfaces";
+import { type Libp2pComponents, PubsubTopic } from "@waku/interfaces";
 
 const DEFAULT_NODE_REQUIREMENTS = {
   lightPush: 1,
@@ -20,10 +16,7 @@ const DEFAULT_NODE_REQUIREMENTS = {
 export function defaultPeerDiscoveries(
   pubsubTopics: PubsubTopic[]
 ): ((components: Libp2pComponents) => PeerDiscovery)[] {
-  const isDefaultPubsubTopic = pubsubTopics.includes(DefaultPubsubTopic);
-  const dnsEnrTrees = isDefaultPubsubTopic
-    ? [enrTree["DEPRECATED_DEFAULT_PUBSUB"]]
-    : [enrTree["SANDBOX"], enrTree["TEST"]];
+  const dnsEnrTrees = [enrTree["SANDBOX"], enrTree["TEST"]];
 
   const discoveries = [
     wakuDnsDiscovery(dnsEnrTrees, DEFAULT_NODE_REQUIREMENTS),

--- a/packages/sdk/src/create/libp2p.ts
+++ b/packages/sdk/src/create/libp2p.ts
@@ -9,7 +9,7 @@ import { all as filterAll, wss } from "@libp2p/websockets/filters";
 import { wakuMetadata } from "@waku/core";
 import {
   type CreateLibp2pOptions,
-  DefaultPubsubTopic,
+  DefaultShardInfo,
   type IMetadata,
   type Libp2p,
   type Libp2pComponents,
@@ -138,12 +138,15 @@ function configureNetworkOptions(
     options.shardInfo = { contentTopics: options.contentTopics };
   }
 
+  if (!options.shardInfo) {
+    options.shardInfo = DefaultShardInfo;
+  }
+
   const shardInfo = options.shardInfo
     ? ensureShardingConfigured(options.shardInfo)
     : undefined;
 
-  options.pubsubTopics = shardInfo?.pubsubTopics ??
-    options.pubsubTopics ?? [DefaultPubsubTopic];
+  options.pubsubTopics = options.pubsubTopics ?? shardInfo?.pubsubTopics;
 
   return shardInfo?.shardInfo;
 }

--- a/packages/tests/src/constants.ts
+++ b/packages/tests/src/constants.ts
@@ -5,6 +5,8 @@
  * @module
  */
 
+import { PubsubTopic, ShardInfo, SingleShardInfo } from "@waku/interfaces";
+
 export const NOISE_KEY_1 = new Uint8Array(
   ((): number[] => {
     const b = [];
@@ -65,3 +67,13 @@ export const MOCHA_HOOK_MAX_TIMEOUT = 50_000;
 
 export const SEPOLIA_RPC_URL =
   process.env.SEPOLIA_RPC_URL || "https://sepolia.gateway.tenderly.co";
+
+export const DefaultTestPubsubTopic: PubsubTopic = "/waku/2/rs/0/0";
+export const DefaultTestShardInfo: ShardInfo = {
+  clusterId: 0,
+  shards: [0]
+};
+export const DefaultTestSingleShardInfo: SingleShardInfo = {
+  clusterId: 0,
+  shard: 0
+};

--- a/packages/tests/src/lib/index.ts
+++ b/packages/tests/src/lib/index.ts
@@ -1,12 +1,9 @@
 import { DecodedMessage } from "@waku/core";
-import {
-  DefaultPubsubTopic,
-  PubsubTopic,
-  ShardingParams
-} from "@waku/interfaces";
+import { PubsubTopic, ShardingParams } from "@waku/interfaces";
 import { ensureShardingConfigured, Logger } from "@waku/utils";
 import { expect } from "chai";
 
+import { DefaultTestPubsubTopic } from "../constants";
 import { Args, MessageRpcQuery, MessageRpcResponse } from "../types";
 import { delay, makeLogFileName } from "../utils/index.js";
 
@@ -105,7 +102,7 @@ export class ServiceNodesFleet {
 
   public async sendRelayMessage(
     message: MessageRpcQuery,
-    pubsubTopic: string = DefaultPubsubTopic
+    pubsubTopic: string = DefaultTestPubsubTopic
   ): Promise<boolean> {
     const relayMessagePromises: Promise<boolean>[] = this.nodes.map((node) =>
       node.sendMessage(message, pubsubTopic)
@@ -221,7 +218,7 @@ class MultipleNodesMessageCollector {
     }
   ): Promise<boolean> {
     const startTime = Date.now();
-    const pubsubTopic = options?.pubsubTopic || DefaultPubsubTopic;
+    const pubsubTopic = options?.pubsubTopic || DefaultTestPubsubTopic;
     const timeoutDuration = options?.timeoutDuration || 400;
     const exact = options?.exact || false;
 

--- a/packages/tests/src/lib/message_collector.ts
+++ b/packages/tests/src/lib/message_collector.ts
@@ -1,10 +1,10 @@
 import { DecodedMessage } from "@waku/core";
-import { DefaultPubsubTopic } from "@waku/interfaces";
 import { Logger } from "@waku/utils";
 import { bytesToUtf8, utf8ToBytes } from "@waku/utils/bytes";
 import { AssertionError, expect } from "chai";
 import { equals } from "uint8arrays/equals";
 
+import { DefaultTestPubsubTopic } from "../constants.js";
 import { MessageRpcResponse } from "../types.js";
 import { base64ToUtf8 } from "../utils/base64_utf8.js";
 import { delay } from "../utils/delay.js";
@@ -269,6 +269,8 @@ export class MessageCollector {
   }
 
   private getPubsubTopicToUse(pubsubTopic: string | undefined): string {
-    return pubsubTopic || this.nwaku?.pubsubTopics?.[0] || DefaultPubsubTopic;
+    return (
+      pubsubTopic || this.nwaku?.pubsubTopics?.[0] || DefaultTestPubsubTopic
+    );
   }
 }

--- a/packages/tests/src/lib/service_node.ts
+++ b/packages/tests/src/lib/service_node.ts
@@ -1,12 +1,12 @@
 import type { PeerId } from "@libp2p/interface";
 import { peerIdFromString } from "@libp2p/peer-id";
 import { Multiaddr, multiaddr } from "@multiformats/multiaddr";
-import { DefaultPubsubTopic } from "@waku/interfaces";
 import { isDefined } from "@waku/utils";
 import { Logger } from "@waku/utils";
 import pRetry from "p-retry";
 import portfinder from "portfinder";
 
+import { DefaultTestPubsubTopic } from "../constants.js";
 import {
   Args,
   LogLevel,
@@ -245,7 +245,7 @@ export class ServiceNode {
   }
 
   public async ensureSubscriptions(
-    pubsubTopics: string[] = [DefaultPubsubTopic]
+    pubsubTopics: string[] = [DefaultTestPubsubTopic]
   ): Promise<boolean> {
     return this.restCall<boolean>(
       "/relay/v1/subscriptions",
@@ -257,7 +257,7 @@ export class ServiceNode {
 
   public async messages(pubsubTopic?: string): Promise<MessageRpcResponse[]> {
     return this.restCall<MessageRpcResponse[]>(
-      `/relay/v1/messages/${encodeURIComponent(pubsubTopic || this?.args?.pubsubTopic?.[0] || DefaultPubsubTopic)}`,
+      `/relay/v1/messages/${encodeURIComponent(pubsubTopic || this?.args?.pubsubTopic?.[0] || DefaultTestPubsubTopic)}`,
       "GET",
       null,
       async (response) => {
@@ -291,7 +291,7 @@ export class ServiceNode {
     }
 
     return this.restCall<boolean>(
-      `/relay/v1/messages/${encodeURIComponent(pubsubTopic || this.args?.pubsubTopic?.[0] || DefaultPubsubTopic)}`,
+      `/relay/v1/messages/${encodeURIComponent(pubsubTopic || this.args?.pubsubTopic?.[0] || DefaultTestPubsubTopic)}`,
       "POST",
       message,
       async (response) => response.status === 200
@@ -411,7 +411,8 @@ export function defaultArgs(): Args {
     rest: true,
     restAdmin: true,
     websocketSupport: true,
-    logLevel: LogLevel.Trace
+    logLevel: LogLevel.Trace,
+    pubsubTopic: ["/waku/2/rs/0/0"]
   };
 }
 

--- a/packages/tests/tests/connection-mananger/connection_state.spec.ts
+++ b/packages/tests/tests/connection-mananger/connection_state.spec.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestShardInfo,
   delay,
   NOISE_KEY_1
 } from "../../src/index.js";
@@ -89,10 +90,12 @@ describe("Connection state", function () {
 
   it("`waku:online` between 2 js-waku relay nodes", async function () {
     const waku1 = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     const waku2 = await createRelayNode({
-      libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } }
+      libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } },
+      shardInfo: DefaultTestShardInfo
     });
 
     let eventCount1 = 0;

--- a/packages/tests/tests/enr.node.spec.ts
+++ b/packages/tests/tests/enr.node.spec.ts
@@ -12,6 +12,7 @@ import {
   ServiceNode,
   tearDownNodes
 } from "../src/index.js";
+import { DefaultTestShardInfo } from "../src/index.js";
 
 describe("ENR Interop: ServiceNode", function () {
   let waku: RelayNode;
@@ -33,7 +34,8 @@ describe("ENR Interop: ServiceNode", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku.start();
     await waku.dial(multiAddrWithId);
@@ -65,7 +67,8 @@ describe("ENR Interop: ServiceNode", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku.start();
     await waku.dial(multiAddrWithId);
@@ -98,7 +101,8 @@ describe("ENR Interop: ServiceNode", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku.start();
     await waku.dial(multiAddrWithId);

--- a/packages/tests/tests/filter/peer_management.spec.ts
+++ b/packages/tests/tests/filter/peer_management.spec.ts
@@ -1,5 +1,4 @@
 import {
-  DefaultPubsubTopic,
   ISubscriptionSDK,
   LightNode,
   SDKProtocolResult
@@ -17,6 +16,7 @@ import { describe } from "mocha";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestPubsubTopic,
   ServiceNode,
   ServiceNodesFleet
 } from "../../src/index.js";
@@ -31,7 +31,7 @@ describe("Waku Filter: Peer Management: E2E", function () {
   let serviceNodes: ServiceNodesFleet;
   let subscription: ISubscriptionSDK;
 
-  const pubsubTopic = DefaultPubsubTopic;
+  const pubsubTopic = DefaultTestPubsubTopic;
   const contentTopic = "/test";
 
   const encoder = createEncoder({

--- a/packages/tests/tests/filter/utils.ts
+++ b/packages/tests/tests/filter/utils.ts
@@ -1,6 +1,5 @@
 import { createDecoder, createEncoder, waitForRemotePeer } from "@waku/core";
 import {
-  DefaultPubsubTopic,
   ISubscriptionSDK,
   LightNode,
   ProtocolCreateOptions,
@@ -19,6 +18,7 @@ import { Context } from "mocha";
 import pRetry from "p-retry";
 
 import {
+  DefaultTestPubsubTopic,
   NOISE_KEY_1,
   ServiceNodesFleet,
   waitForConnections
@@ -76,7 +76,7 @@ export async function runMultipleNodes(
 ): Promise<[ServiceNodesFleet, LightNode]> {
   const pubsubTopics = shardInfo
     ? shardInfoToPubsubTopics(shardInfo)
-    : [DefaultPubsubTopic];
+    : [DefaultTestPubsubTopic];
   // create numServiceNodes nodes
   const serviceNodes = await ServiceNodesFleet.createAndRun(
     context,

--- a/packages/tests/tests/getPeers.spec.ts
+++ b/packages/tests/tests/getPeers.spec.ts
@@ -11,7 +11,11 @@ import {
   Tags,
   utf8ToBytes
 } from "@waku/sdk";
-import { ensureShardingConfigured, shardInfoToPubsubTopics } from "@waku/utils";
+import {
+  encodeRelayShard,
+  ensureShardingConfigured,
+  shardInfoToPubsubTopics
+} from "@waku/utils";
 import { getConnectedPeersForProtocolAndShard } from "@waku/utils/libp2p";
 import { expect } from "chai";
 import fc from "fast-check";
@@ -20,6 +24,7 @@ import Sinon from "sinon";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestShardInfo,
   delay,
   makeLogFileName,
   ServiceNode,
@@ -426,6 +431,7 @@ describe("getConnectedPeersForProtocolAndShard", function () {
     expect(peers.length).to.be.equal(1);
   });
 });
+
 describe("getPeers", function () {
   let peerStore: PeerStore;
   let connectionManager: Libp2pComponents["connectionManager"];
@@ -448,7 +454,7 @@ describe("getPeers", function () {
   let allPeers: Peer[];
 
   beforeEachCustom(this, async () => {
-    waku = await createLightNode();
+    waku = await createLightNode({ shardInfo: DefaultTestShardInfo });
     peerStore = waku.libp2p.peerStore;
     connectionManager = waku.libp2p.components.connectionManager;
 
@@ -539,6 +545,10 @@ describe("getPeers", function () {
       differentCodecPeer,
       anotherDifferentCodecPeer
     ];
+
+    allPeers.forEach((peer) => {
+      peer.metadata.set("shardInfo", encodeRelayShard(DefaultTestShardInfo));
+    });
 
     Sinon.stub(peerStore, "get").callsFake(async (peerId) => {
       return allPeers.find((peer) => peer.id.equals(peerId))!;

--- a/packages/tests/tests/light-push/peer_management.spec.ts
+++ b/packages/tests/tests/light-push/peer_management.spec.ts
@@ -16,7 +16,7 @@ import {
   TestContentTopic
 } from "../filter/utils.js";
 
-describe.only("Waku Light Push: Peer Management: E2E", function () {
+describe("Waku Light Push: Peer Management: E2E", function () {
   this.timeout(15000);
   let waku: LightNode;
   let serviceNodes: ServiceNodesFleet;

--- a/packages/tests/tests/light-push/peer_management.spec.ts
+++ b/packages/tests/tests/light-push/peer_management.spec.ts
@@ -7,14 +7,16 @@ import {
   afterEachCustom,
   beforeEachCustom,
   DefaultTestShardInfo,
+  DefaultTestSingleShardInfo,
   ServiceNodesFleet
 } from "../../src/index.js";
 import {
   runMultipleNodes,
-  teardownNodesWithRedundancy
+  teardownNodesWithRedundancy,
+  TestContentTopic
 } from "../filter/utils.js";
 
-describe("Waku Light Push: Peer Management: E2E", function () {
+describe.only("Waku Light Push: Peer Management: E2E", function () {
   this.timeout(15000);
   let waku: LightNode;
   let serviceNodes: ServiceNodesFleet;
@@ -33,8 +35,8 @@ describe("Waku Light Push: Peer Management: E2E", function () {
   });
 
   const encoder = createEncoder({
-    pubsubTopicShardInfo: DefaultTestShardInfo,
-    contentTopic: "/test"
+    pubsubTopicShardInfo: DefaultTestSingleShardInfo,
+    contentTopic: TestContentTopic
   });
 
   it("Number of peers are maintained correctly", async function () {

--- a/packages/tests/tests/light-push/peer_management.spec.ts
+++ b/packages/tests/tests/light-push/peer_management.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultPubsubTopic, LightNode } from "@waku/interfaces";
+import { LightNode } from "@waku/interfaces";
 import { createEncoder, utf8ToBytes } from "@waku/sdk";
 import { expect } from "chai";
 import { describe } from "mocha";
@@ -6,6 +6,7 @@ import { describe } from "mocha";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestPubsubTopic,
   ServiceNodesFleet
 } from "../../src/index.js";
 import {
@@ -32,7 +33,7 @@ describe("Waku Light Push: Peer Management: E2E", function () {
   });
 
   const encoder = createEncoder({
-    pubsubTopic: DefaultPubsubTopic,
+    pubsubTopic: DefaultTestPubsubTopic,
     contentTopic: "/test"
   });
 

--- a/packages/tests/tests/nwaku.node.spec.ts
+++ b/packages/tests/tests/nwaku.node.spec.ts
@@ -17,6 +17,7 @@ describe("nwaku", () => {
       "--rest-admin=true",
       "--websocket-support=true",
       "--log-level=TRACE",
+      "--pubsub-topic=/waku/2/rs/0/0",
       "--ports-shift=42"
     ];
 

--- a/packages/tests/tests/wait_for_remote_peer.node.spec.ts
+++ b/packages/tests/tests/wait_for_remote_peer.node.spec.ts
@@ -7,6 +7,8 @@ import { expect } from "chai";
 
 import {
   afterEachCustom,
+  DefaultTestPubsubTopic,
+  DefaultTestShardInfo,
   delay,
   makeLogFileName,
   NOISE_KEY_1,
@@ -53,7 +55,8 @@ describe("Wait for remote peer", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku1 = await createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku1.start();
 
@@ -62,7 +65,7 @@ describe("Wait for remote peer", function () {
     await waku1.dial(multiAddrWithId);
     await waitPromise;
 
-    const peers = waku1.relay.getMeshPeers();
+    const peers = waku1.relay.getMeshPeers(DefaultTestPubsubTopic);
     const nimPeerId = multiAddrWithId.getPeerId();
 
     expect(nimPeerId).to.not.be.undefined;
@@ -72,7 +75,8 @@ describe("Wait for remote peer", function () {
   it("Relay - times out", function (done) {
     this.timeout(5000);
     createRelayNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     })
       .then((waku1) => waku1.start().then(() => waku1))
       .then((waku1) => {
@@ -101,7 +105,8 @@ describe("Wait for remote peer", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);
@@ -129,7 +134,8 @@ describe("Wait for remote peer", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     const waitPromise = waitForRemotePeer(waku2, [Protocols.Store], 2000);
@@ -159,7 +165,8 @@ describe("Wait for remote peer", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);
@@ -187,7 +194,8 @@ describe("Wait for remote peer", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);
@@ -215,7 +223,8 @@ describe("Wait for remote peer", function () {
     const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     waku2 = await createLightNode({
-      staticNoiseKey: NOISE_KEY_1
+      staticNoiseKey: NOISE_KEY_1,
+      shardInfo: DefaultTestShardInfo
     });
     await waku2.start();
     await waku2.dial(multiAddrWithId);

--- a/packages/tests/tests/waku.node.spec.ts
+++ b/packages/tests/tests/waku.node.spec.ts
@@ -20,6 +20,8 @@ import { expect } from "chai";
 import {
   afterEachCustom,
   beforeEachCustom,
+  DefaultTestShardInfo,
+  DefaultTestSingleShardInfo,
   makeLogFileName,
   NOISE_KEY_1,
   NOISE_KEY_2,
@@ -51,7 +53,8 @@ describe("Waku Dial [node only]", function () {
       const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
       waku = await createLightNode({
-        staticNoiseKey: NOISE_KEY_1
+        staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo
       });
       await waku.start();
       await waku.dial(multiAddrWithId);
@@ -84,7 +87,8 @@ describe("Waku Dial [node only]", function () {
       const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
       waku = await createLightNode({
-        staticNoiseKey: NOISE_KEY_1
+        staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo
       });
       await waku.start();
       await waku.dial(multiAddrWithId);
@@ -112,6 +116,7 @@ describe("Waku Dial [node only]", function () {
       const multiAddrWithId = await nwaku.getMultiaddrWithId();
       waku = await createLightNode({
         staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo,
         libp2p: {
           peerDiscovery: [bootstrap({ list: [multiAddrWithId.toString()] })]
         }
@@ -137,6 +142,7 @@ describe("Waku Dial [node only]", function () {
 
       waku = await createLightNode({
         staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo,
         libp2p: {
           peerDiscovery: [bootstrap({ list: [nwakuMa.toString()] })]
         }
@@ -166,11 +172,13 @@ describe("Decryption Keys", function () {
   let waku2: RelayNode;
   beforeEachCustom(this, async () => {
     [waku1, waku2] = await Promise.all([
-      createRelayNode({ staticNoiseKey: NOISE_KEY_1 }).then((waku) =>
-        waku.start().then(() => waku)
-      ),
+      createRelayNode({
+        staticNoiseKey: NOISE_KEY_1,
+        shardInfo: DefaultTestShardInfo
+      }).then((waku) => waku.start().then(() => waku)),
       createRelayNode({
         staticNoiseKey: NOISE_KEY_2,
+        shardInfo: DefaultTestShardInfo,
         libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } }
       }).then((waku) => waku.start().then(() => waku))
     ]);
@@ -194,12 +202,18 @@ describe("Decryption Keys", function () {
     this.timeout(10000);
 
     const symKey = generateSymmetricKey();
-    const decoder = createDecoder(TestContentTopic, symKey);
+    const decoder = createDecoder(
+      TestContentTopic,
+      symKey,
+      DefaultTestSingleShardInfo
+    );
 
     const encoder = createEncoder({
       contentTopic: TestContentTopic,
+      pubsubTopicShardInfo: DefaultTestSingleShardInfo,
       symKey
     });
+
     const messageText = "Message is encrypted";
     const messageTimestamp = new Date("1995-12-17T03:24:00");
     const message = {
@@ -239,10 +253,12 @@ describe("User Agent", function () {
     [waku1, waku2] = await Promise.all([
       createRelayNode({
         staticNoiseKey: NOISE_KEY_1,
-        userAgent: waku1UserAgent
+        userAgent: waku1UserAgent,
+        shardInfo: DefaultTestShardInfo
       }).then((waku) => waku.start().then(() => waku)),
       createRelayNode({
         staticNoiseKey: NOISE_KEY_2,
+        shardInfo: DefaultTestShardInfo,
         libp2p: { addresses: { listen: ["/ip4/0.0.0.0/tcp/0/ws"] } }
       }).then((waku) => waku.start().then(() => waku))
     ]);

--- a/packages/utils/src/common/sharding.ts
+++ b/packages/utils/src/common/sharding.ts
@@ -228,7 +228,7 @@ export function contentTopicsByPubsubTopic(
  */
 export function determinePubsubTopic(
   contentTopic: string,
-  // TODO: make it accept ShardInfo
+  // TODO: make it accept ShardInfo https://github.com/waku-org/js-waku/issues/2086
   pubsubTopicShardInfo?: SingleShardInfo | PubsubTopic
 ): string {
   if (typeof pubsubTopicShardInfo == "string") {

--- a/packages/utils/src/common/sharding.ts
+++ b/packages/utils/src/common/sharding.ts
@@ -228,6 +228,7 @@ export function contentTopicsByPubsubTopic(
  */
 export function determinePubsubTopic(
   contentTopic: string,
+  // TODO: make it accept ShardInfo
   pubsubTopicShardInfo?: SingleShardInfo | PubsubTopic
 ): string {
   if (typeof pubsubTopicShardInfo == "string") {


### PR DESCRIPTION
## Problem

Named sharding is deprecated.
We need to comply

## Solution

- Keep `pubsubTopic` parameter as a fallback for consumers of the library that do not use The Waku Network or static sharding;
- Provide `DefaultShardInfo` as a fallback that is configured for The Waku Network all shards;
- Remove old `DefaultPubsubTopic`;

## Notes

- Main PR: https://github.com/waku-org/js-waku/pull/2083/files
- Addresses: https://github.com/waku-org/js-waku/issues/2082