### PR TITLE
feat: sort peers for protocol by least active connections

### DIFF
--- a/packages/core/src/lib/base_protocol.ts
+++ b/packages/core/src/lib/base_protocol.ts
@@ -23,6 +23,12 @@ type GetPeersOptions = {
   maxBootstrapPeers: number;
 };
 
+const DEFAULT_GET_PEERS_OPTIONS: GetPeersOptions = {
+  prioritizeLatency: true,
+  maxBootstrapPeers: 1,
+  numPeers: 0
+};
+
 /**
  * A class with predefined helpers, to be used as a base to implement Waku
  * Protocols.
@@ -90,11 +96,7 @@ export class BaseProtocol implements IBaseProtocolCore {
   * @returns A list of peers that support the protocol sorted by latency.
   */
   public async getPeers(
-    options: GetPeersOptions = {
-      prioritizeLatency: true,
-      maxBootstrapPeers: 1,
-      numPeers: 0
-    }
+    options: GetPeersOptions = DEFAULT_GET_PEERS_OPTIONS
   ): Promise<Peer[]> {
     const { maxBootstrapPeers, numPeers, prioritizeLatency } = options;
 

--- a/packages/core/src/lib/base_protocol.ts
+++ b/packages/core/src/lib/base_protocol.ts
@@ -90,12 +90,14 @@ export class BaseProtocol implements IBaseProtocolCore {
   * @returns A list of peers that support the protocol sorted by latency.
   */
   public async getPeers(
-    { prioritizeLatency, numPeers, maxBootstrapPeers }: GetPeersOptions = {
+    options: GetPeersOptions = {
       prioritizeLatency: true,
       maxBootstrapPeers: 1,
       numPeers: 0
     }
   ): Promise<Peer[]> {
+    const { maxBootstrapPeers, numPeers, prioritizeLatency } = options;
+
     const activeConnections =
       this.components.connectionManager.getConnections();
 

--- a/packages/interfaces/src/protocols.ts
+++ b/packages/interfaces/src/protocols.ts
@@ -121,6 +121,10 @@ export type ProtocolCreateOptions = {
    */
   numPeersToUse?: number;
   /**
+   * Prioritize latency over decentralization when selecting peers.
+   */
+  prioritizeLatency?: boolean;
+  /**
    * Byte array used as key for the noise protocol used for connection encryption
    * by [`Libp2p.create`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#create)
    * This is only used for test purposes to not run out of entropy during CI runs.


### PR DESCRIPTION
## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

## Solution

<!-- describe the new behavior --> 

## Notes


- Depends on #1758 
- Resolves <issue number>
- Related to <link to specs>

Contribution checklist:
- [ ] covered by unit tests;
- [ ] covered by e2e test;
- [ ] add `!` in title if breaks public API;
