### PR TITLE
chore: enable back filterAll if set by consumer

### DIFF
--- a/packages/interfaces/src/libp2p.ts
+++ b/packages/interfaces/src/libp2p.ts
@@ -30,4 +30,9 @@ export type CreateLibp2pOptions = Libp2pOptions & {
    */
   hideWebSocketInfo?: boolean;
   pingMaxInboundStreams?: number;
+  /**
+   * Applies secure web socket filters.
+   * @default true
+   */
+  filterMultiaddrs?: boolean;
 };

--- a/packages/sdk/src/create/libp2p.ts
+++ b/packages/sdk/src/create/libp2p.ts
@@ -64,13 +64,16 @@ export async function defaultLibp2p(
     ? { metadata: wakuMetadata(pubsubTopics) }
     : {};
 
-  const filter = process?.env?.NODE_ENV === "test" ? filterAll : wss;
+  const filter =
+    options?.filterMultiaddrs === false || process?.env?.NODE_ENV === "test"
+      ? filterAll
+      : wss;
 
   return createLibp2p({
     connectionManager: {
       minConnections: 1
     },
-    transports: [webSockets({ filter })],
+    transports: [webSockets({ filter: filter })],
     streamMuxers: [mplex()],
     connectionEncryption: [noise()],
     ...options,


### PR DESCRIPTION
## Problem

In https://github.com/waku-org/js-waku/pull/1989 we made it so `fitlerAll` is applied only in tests.
Reasoning for it was that in running dogfooding apps we were seeing a lot of errors and we wanted to prevent light node trying to establish a connection that will definitely fail.

But it prevents local development with js-waku so that locally run nodes or nodes run under IP - are ignored and connection is not established or event attempted.

## Solution

Add `fitlerMultiaddrs` flag to `libp2p` configuration so that is it is set to `false` - then such behavior is off.

## Notes

- Example of problem https://discord.com/channels/1110799176264056863/1272550972631158888/1273946249980018768
- Updates to docs: https://github.com/waku-org/docs.waku.org/pull/209
