### PR TITLE
chore: change amount of used peers to 2

### DIFF
--- a/packages/sdk/src/protocols/base_protocol.ts
+++ b/packages/sdk/src/protocols/base_protocol.ts
@@ -14,7 +14,7 @@ interface Options {
 }
 
 const RENEW_TIME_LOCK_DURATION = 30 * 1000;
-const DEFAULT_NUM_PEERS_TO_USE = 3;
+const DEFAULT_NUM_PEERS_TO_USE = 2;
 const DEFAULT_MAINTAIN_PEERS_INTERVAL = 30_000;
 
 export class BaseProtocolSDK implements IBaseProtocolSDK {

--- a/packages/tests/src/utils/nodes.ts
+++ b/packages/tests/src/utils/nodes.ts
@@ -23,7 +23,7 @@ export async function runMultipleNodes(
   networkConfig: NetworkConfig = DefaultNetworkConfig,
   customArgs?: Args,
   strictChecking: boolean = false,
-  numServiceNodes = 3,
+  numServiceNodes = 2,
   withoutFilter = false
 ): Promise<[ServiceNodesFleet, LightNode]> {
   // create numServiceNodes nodes

--- a/packages/tests/tests/filter/subscribe.node.spec.ts
+++ b/packages/tests/tests/filter/subscribe.node.spec.ts
@@ -51,7 +51,7 @@ const runTests = (strictCheckNodes: boolean): void => {
     });
 
     it("Subscribe and receive messages via lightPush", async function () {
-      expect(waku.libp2p.getConnections()).has.length(3);
+      expect(waku.libp2p.getConnections()).has.length(2);
 
       await waku.filter.subscribe(
         [TestDecoder],

--- a/packages/tests/tests/light-push/index.node.spec.ts
+++ b/packages/tests/tests/light-push/index.node.spec.ts
@@ -23,8 +23,8 @@ import {
 } from "./utils.js";
 
 const runTests = (strictNodeCheck: boolean): void => {
-  const numServiceNodes = 3;
-  describe(`Waku Light Push: Multiple Nodes: Strict Check: ${strictNodeCheck}`, function () {
+  const numServiceNodes = 2;
+  describe.only(`Waku Light Push: Multiple Nodes: Strict Check: ${strictNodeCheck}`, function () {
     // Set the timeout for all tests in this suite. Can be overwritten at test level
     this.timeout(15000);
     let waku: LightNode;

--- a/packages/tests/tests/light-push/index.node.spec.ts
+++ b/packages/tests/tests/light-push/index.node.spec.ts
@@ -24,7 +24,7 @@ import {
 
 const runTests = (strictNodeCheck: boolean): void => {
   const numServiceNodes = 2;
-  describe.only(`Waku Light Push: Multiple Nodes: Strict Check: ${strictNodeCheck}`, function () {
+  describe(`Waku Light Push: Multiple Nodes: Strict Check: ${strictNodeCheck}`, function () {
     // Set the timeout for all tests in this suite. Can be overwritten at test level
     this.timeout(15000);
     let waku: LightNode;


### PR DESCRIPTION
## Problem

As per RFC protocols should use 2 peers https://github.com/waku-org/specs/blob/master/standards/application/req-res-reliability.md#sending-with-redundancy

But 3 are used

## Solution

Make them use 2
