### PR TITLE
fix: filter missing messages

### DIFF
--- a/packages/sdk/src/protocols/filter.ts
+++ b/packages/sdk/src/protocols/filter.ts
@@ -95,9 +95,15 @@ export class SubscriptionManager implements ISubscriptionSDK {
   private addHash(hash: string, peerIdStr?: string): void {
     this.receivedMessagesHashes.all.add(hash);
 
-    if (peerIdStr) {
-      this.receivedMessagesHashes.nodes[peerIdStr].add(hash);
+    if (!peerIdStr) {
+      return;
     }
+
+    if (!this.receivedMessagesHashes.nodes[peerIdStr]) {
+      this.receivedMessagesHashes.nodes[peerIdStr] = new Set();
+    }
+
+    this.receivedMessagesHashes.nodes[peerIdStr].add(hash);
   }
 
   public async subscribe<T extends IDecodedMessage>(

--- a/packages/sdk/src/protocols/filter.ts
+++ b/packages/sdk/src/protocols/filter.ts
@@ -51,9 +51,9 @@ type ReceivedMessageHashes = {
 
 const log = new Logger("sdk:filter");
 
-const DEFAULT_MAX_PINGS = 3;
+const DEFAULT_MAX_PINGS = 2;
 const DEFAULT_MAX_MISSED_MESSAGES_THRESHOLD = 3;
-const DEFAULT_KEEP_ALIVE = 5 * 1000;
+const DEFAULT_KEEP_ALIVE = 60 * 1000;
 
 export class SubscriptionManager implements ISubscriptionSDK {
   private subscriptionCallbacks: Map<


### PR DESCRIPTION
## Problem

This PR addresses 3 problems:
- When peer is renewed and it was used in filter subscription it is not added into missing messages hash map.
Because of that `this.addHash` fails during processing of incoming messages and that terminates callback's invokation.
- Because of bug introduced for keep alive feature - `pings` are not done properly.
- To be more align with RFC - `DEFAULT_MAX_PINGS` has to be changed to `2`;

## Solution

Fix bugs, change const.

## Notes

Related bug: https://github.com/waku-org/js-waku/issues/2120
Validated against: `@waku/sdk@0.0.28-5459f48.0` in dogfooding app