### PR TITLE
fix: improve node bootstrapping

### DIFF
--- a/packages/core/src/lib/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager.ts
@@ -293,7 +293,6 @@ export class ConnectionManager
         }
 
         this.dialErrorsForPeer.delete(peerId.toString());
-        this.dialAttemptsForPeer.delete(peerId.toString());
         await this.libp2p.peerStore.delete(peerId);
 
         // if it was last available peer - attempt DNS discovery

--- a/packages/core/src/lib/connection_manager.ts
+++ b/packages/core/src/lib/connection_manager.ts
@@ -2,6 +2,8 @@ import type { Peer, PeerId, PeerInfo, PeerStore } from "@libp2p/interface";
 import { CustomEvent, TypedEventEmitter } from "@libp2p/interface";
 import {
   ConnectionManagerOptions,
+  DiscoveryTrigger,
+  DNS_DISCOVERY_TAG,
   EConnectionStateEvents,
   EPeersByDiscoveryEvents,
   IConnectionManager,
@@ -291,13 +293,38 @@ export class ConnectionManager
         }
 
         this.dialErrorsForPeer.delete(peerId.toString());
+        this.dialAttemptsForPeer.delete(peerId.toString());
         await this.libp2p.peerStore.delete(peerId);
+
+        // if it was last available peer - attempt DNS discovery
+        await this.attemptDnsDiscovery();
       } catch (error) {
         throw new Error(
           `Error deleting undialable peer ${peerId.toString()} from peer store - ${error}`
         );
       }
     }
+  }
+
+  private async attemptDnsDiscovery(): Promise<void> {
+    if (this.libp2p.getConnections().length > 0) return;
+    if ((await this.libp2p.peerStore.all()).length > 0) return;
+
+    log.info("Attempting to trigger DNS discovery.");
+
+    const dnsDiscovery = Object.values(this.libp2p.components.components).find(
+      (v: unknown) => {
+        if (v && v.toString) {
+          return v.toString().includes(DNS_DISCOVERY_TAG);
+        }
+
+        return false;
+      }
+    ) as DiscoveryTrigger;
+
+    if (!dnsDiscovery) return;
+
+    await dnsDiscovery.findPeers();
   }
 
   private processDialQueue(): void {

--- a/packages/discovery/src/dns/constants.ts
+++ b/packages/discovery/src/dns/constants.ts
@@ -16,6 +16,6 @@ export const DEFAULT_BOOTSTRAP_TAG_TTL = 100_000_000;
 
 export const DEFAULT_NODE_REQUIREMENTS: Partial<NodeCapabilityCount> = {
   store: 1,
-  filter: 1,
-  lightPush: 1
+  filter: 2,
+  lightPush: 2
 };

--- a/packages/discovery/src/dns/constants.ts
+++ b/packages/discovery/src/dns/constants.ts
@@ -15,7 +15,7 @@ export const DEFAULT_BOOTSTRAP_TAG_VALUE = 50;
 export const DEFAULT_BOOTSTRAP_TAG_TTL = 100_000_000;
 
 export const DEFAULT_NODE_REQUIREMENTS: Partial<NodeCapabilityCount> = {
-  store: 2,
-  filter: 1,
-  lightPush: 1
+  store: 1,
+  filter: 2,
+  lightPush: 2
 };

--- a/packages/discovery/src/dns/constants.ts
+++ b/packages/discovery/src/dns/constants.ts
@@ -16,6 +16,6 @@ export const DEFAULT_BOOTSTRAP_TAG_TTL = 100_000_000;
 
 export const DEFAULT_NODE_REQUIREMENTS: Partial<NodeCapabilityCount> = {
   store: 1,
-  filter: 2,
-  lightPush: 2
+  filter: 1,
+  lightPush: 1
 };

--- a/packages/discovery/src/dns/dns_discovery.ts
+++ b/packages/discovery/src/dns/dns_discovery.ts
@@ -7,11 +7,13 @@ import {
 import { peerDiscoverySymbol as symbol } from "@libp2p/interface";
 import type { PeerInfo } from "@libp2p/interface";
 import type {
+  DiscoveryTrigger,
   DnsDiscOptions,
   DnsDiscoveryComponents,
   IEnr,
   NodeCapabilityCount
 } from "@waku/interfaces";
+import { DNS_DISCOVERY_TAG } from "@waku/interfaces";
 import { encodeRelayShard, Logger } from "@waku/utils";
 
 import {
@@ -29,7 +31,7 @@ const log = new Logger("peer-discovery-dns");
  */
 export class PeerDiscoveryDns
   extends TypedEventEmitter<PeerDiscoveryEvents>
-  implements PeerDiscovery
+  implements PeerDiscovery, DiscoveryTrigger
 {
   private nextPeer: (() => AsyncGenerator<IEnr>) | undefined;
   private _started: boolean;
@@ -56,8 +58,11 @@ export class PeerDiscoveryDns
     log.info("Starting peer discovery via dns");
 
     this._started = true;
+    await this.findPeers();
+  }
 
-    if (this.nextPeer === undefined) {
+  public async findPeers(): Promise<void> {
+    if (!this.nextPeer) {
       let { enrUrls } = this._options;
       if (!Array.isArray(enrUrls)) enrUrls = [enrUrls];
 
@@ -134,7 +139,7 @@ export class PeerDiscoveryDns
   }
 
   public get [Symbol.toStringTag](): string {
-    return "@waku/bootstrap";
+    return DNS_DISCOVERY_TAG;
   }
 }
 

--- a/packages/interfaces/src/dns_discovery.ts
+++ b/packages/interfaces/src/dns_discovery.ts
@@ -1,5 +1,7 @@
 import { PeerStore } from "@libp2p/interface";
 
+export const DNS_DISCOVERY_TAG = "@waku/bootstrap";
+
 export type SearchContext = {
   domain: string;
   publicKey: string;
@@ -44,4 +46,8 @@ export interface DnsDiscOptions {
    * Cause the bootstrap peer tag to be removed after this number of ms (default: 2 minutes)
    */
   tagTTL?: number;
+}
+
+export interface DiscoveryTrigger {
+  findPeers: () => Promise<void>;
 }

--- a/packages/sdk/src/create/discovery.ts
+++ b/packages/sdk/src/create/discovery.ts
@@ -7,19 +7,13 @@ import {
 } from "@waku/discovery";
 import { type Libp2pComponents, PubsubTopic } from "@waku/interfaces";
 
-const DEFAULT_NODE_REQUIREMENTS = {
-  lightPush: 1,
-  filter: 1,
-  store: 1
-};
-
 export function defaultPeerDiscoveries(
   pubsubTopics: PubsubTopic[]
 ): ((components: Libp2pComponents) => PeerDiscovery)[] {
   const dnsEnrTrees = [enrTree["SANDBOX"], enrTree["TEST"]];
 
   const discoveries = [
-    wakuDnsDiscovery(dnsEnrTrees, DEFAULT_NODE_REQUIREMENTS),
+    wakuDnsDiscovery(dnsEnrTrees),
     wakuLocalPeerCacheDiscovery(),
     wakuPeerExchangeDiscovery(pubsubTopics)
   ];


### PR DESCRIPTION
## Problem

When `js-waku` node is bootstrapped with default setting AND broken bootstrap node is used it fails sometimes. 
And in that case application using `js-waku` has bad experience. 

As explained in this comment:

The problem occurs when dns discovery gets us a broken bootstrap node is attempted to be used. 

## Solution

Increase amount of bootstrap nodes used and at the same time respect our good defaults: 2 filter and light push + 1 store nodes.

Improve dialing as when it fails for bootstrap nodes we should try using others.

## Notes
- Resolves: https://github.com/waku-org/js-waku/issues/2113