### PR TITLE
fix: temporarily remove peer cross dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39118,17 +39118,13 @@
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
-        "@waku/enr": "^0.0.24",
-        "@waku/interfaces": "0.0.25",
-        "@waku/proto": "0.0.7",
-        "@waku/utils": "0.0.18",
         "libp2p": "^1.8.1"
       },
       "peerDependenciesMeta": {
         "@multiformats/multiaddr": {
           "optional": true
         },
-        "@waku/interfaces": {
+        "libp2p": {
           "optional": true
         }
       }
@@ -39184,18 +39180,10 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@libp2p/interface": "^1.6.3",
-        "@waku/core": "0.0.30",
-        "@waku/enr": "0.0.24",
-        "@waku/interfaces": "0.0.25",
-        "@waku/proto": "0.0.7",
-        "@waku/utils": "0.0.18"
+        "@libp2p/interface": "^1.6.3"
       },
       "peerDependenciesMeta": {
         "@libp2p/interface": {
-          "optional": true
-        },
-        "@waku/interfaces": {
           "optional": true
         }
       }
@@ -39236,15 +39224,10 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@multiformats/multiaddr": "^12.0.0",
-        "@waku/interfaces": "0.0.25",
-        "@waku/utils": "0.0.18"
+        "@multiformats/multiaddr": "^12.0.0"
       },
       "peerDependenciesMeta": {
         "@multiformats/multiaddr": {
-          "optional": true
-        },
-        "@waku/interfaces": {
           "optional": true
         }
       }
@@ -39298,17 +39281,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "peerDependencies": {
-        "@waku/core": "0.0.30",
-        "@waku/interfaces": "0.0.25",
-        "@waku/proto": "0.0.7",
-        "@waku/utils": "0.0.18"
-      },
-      "peerDependenciesMeta": {
-        "@waku/interfaces": {
-          "optional": true
-        }
       }
     },
     "packages/message-hash": {
@@ -39340,15 +39312,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "peerDependencies": {
-        "@waku/interfaces": "0.0.25",
-        "@waku/utils": "0.0.18"
-      },
-      "peerDependenciesMeta": {
-        "@waku/interfaces": {
-          "optional": true
-        }
       }
     },
     "packages/proto": {
@@ -39420,17 +39383,10 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@chainsafe/libp2p-gossipsub": "^12.0.0",
-        "@waku/core": "0.0.30",
-        "@waku/interfaces": "0.0.25",
-        "@waku/proto": "0.0.7",
-        "@waku/utils": "0.0.18"
+        "@chainsafe/libp2p-gossipsub": "^12.0.0"
       },
       "peerDependenciesMeta": {
         "@chainsafe/libp2p-gossipsub": {
-          "optional": true
-        },
-        "@waku/interfaces": {
           "optional": true
         }
       }
@@ -39469,17 +39425,10 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@libp2p/bootstrap": "^10",
-        "@waku/core": "0.0.30",
-        "@waku/interfaces": "0.0.25",
-        "@waku/message-hash": "^0.1.14",
-        "@waku/utils": "0.0.18"
+        "@libp2p/bootstrap": "^10"
       },
       "peerDependenciesMeta": {
         "@libp2p/bootstrap": {
-          "optional": true
-        },
-        "@waku/interfaces": {
           "optional": true
         }
       }
@@ -39556,14 +39505,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "peerDependencies": {
-        "@waku/interfaces": "0.0.25"
-      },
-      "peerDependenciesMeta": {
-        "@waku/interfaces": {
-          "optional": true
-        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39406,6 +39406,7 @@
         "@waku/core": "0.0.31",
         "@waku/discovery": "0.0.4",
         "@waku/interfaces": "0.0.26",
+        "@waku/message-hash": "0.1.15",
         "@waku/proto": "^0.0.8",
         "@waku/utils": "0.0.19",
         "libp2p": "^1.8.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -103,17 +103,13 @@
   },
   "peerDependencies": {
     "@multiformats/multiaddr": "^12.0.0",
-    "libp2p": "^1.8.1",
-    "@waku/enr": "^0.0.24",
-    "@waku/interfaces": "0.0.25",
-    "@waku/proto": "0.0.7",
-    "@waku/utils": "0.0.18"
+    "libp2p": "^1.8.1"
   },
   "peerDependenciesMeta": {
     "@multiformats/multiaddr": {
       "optional": true
     },
-    "@waku/interfaces": {
+    "libp2p": {
       "optional": true
     }
   },

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -81,17 +81,9 @@
     "sinon": "^18.0.0"
   },
   "peerDependencies": {
-    "@waku/core": "0.0.30",
-    "@waku/enr": "0.0.24",
-    "@waku/interfaces": "0.0.25",
-    "@waku/proto": "0.0.7",
-    "@waku/utils": "0.0.18",
     "@libp2p/interface": "^1.6.3"
   },
   "peerDependenciesMeta": {
-    "@waku/interfaces": {
-      "optional": true
-    },
     "@libp2p/interface": {
       "optional": true
     }

--- a/packages/enr/package.json
+++ b/packages/enr/package.json
@@ -79,14 +79,9 @@
     "uint8arrays": "^5.0.1"
   },
   "peerDependencies": {
-    "@waku/utils": "0.0.18",
-    "@waku/interfaces": "0.0.25",
     "@multiformats/multiaddr": "^12.0.0"
   },
   "peerDependenciesMeta": {
-    "@waku/interfaces": {
-      "optional": true
-    },
     "@multiformats/multiaddr": {
       "optional": true
     }

--- a/packages/message-encryption/package.json
+++ b/packages/message-encryption/package.json
@@ -99,17 +99,6 @@
     "process": "^0.11.10",
     "rollup": "^4.12.0"
   },
-  "peerDependencies": {
-    "@waku/core": "0.0.30",
-    "@waku/interfaces": "0.0.25",
-    "@waku/proto": "0.0.7",
-    "@waku/utils": "0.0.18"
-  },
-  "peerDependenciesMeta": {
-    "@waku/interfaces": {
-      "optional": true
-    }
-  },
   "files": [
     "dist",
     "bundle",

--- a/packages/message-hash/package.json
+++ b/packages/message-hash/package.json
@@ -72,15 +72,6 @@
     "process": "^0.11.10",
     "rollup": "^4.12.0"
   },
-  "peerDependencies": {
-    "@waku/interfaces": "0.0.25",
-    "@waku/utils": "0.0.18"
-  },
-  "peerDependenciesMeta": {
-    "@waku/interfaces": {
-      "optional": true
-    }
-  },
   "files": [
     "dist",
     "bundle",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -68,16 +68,9 @@
     "rollup": "^4.12.0"
   },
   "peerDependencies": {
-    "@waku/core": "0.0.30",
-    "@waku/interfaces": "0.0.25",
-    "@waku/proto": "0.0.7",
-    "@waku/utils": "0.0.18",
     "@chainsafe/libp2p-gossipsub": "^12.0.0"
   },
   "peerDependenciesMeta": {
-    "@waku/interfaces": {
-      "optional": true
-    },
     "@chainsafe/libp2p-gossipsub": {
       "optional": true
     }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -83,16 +83,9 @@
     "rollup": "^4.12.0"
   },
   "peerDependencies": {
-    "@libp2p/bootstrap": "^10",
-    "@waku/core": "0.0.30",
-    "@waku/interfaces": "0.0.25",
-    "@waku/message-hash": "^0.1.14",
-    "@waku/utils": "0.0.18"
+    "@libp2p/bootstrap": "^10"
   },
   "peerDependenciesMeta": {
-    "@waku/interfaces": {
-      "optional": true
-    },
     "@libp2p/bootstrap": {
       "optional": true
     }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -69,6 +69,7 @@
     "@waku/interfaces": "0.0.26",
     "@waku/proto": "^0.0.8",
     "@waku/utils": "0.0.19",
+    "@waku/message-hash": "0.1.15",
     "libp2p": "^1.8.1"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -83,14 +83,6 @@
     "fast-check": "^3.19.0",
     "rollup": "^4.12.0"
   },
-  "peerDependencies": {
-    "@waku/interfaces": "0.0.25"
-  },
-  "peerDependenciesMeta": {
-    "@waku/interfaces": {
-      "optional": true
-    }
-  },
   "files": [
     "dist",
     "bundle",


### PR DESCRIPTION
## Problem

`release-please` does not bump peer dependencies for `@waku/*` packages.

## Solution

Remove peer dependencies for now before https://github.com/waku-org/js-waku/issues/2063 is done.
