### PR TITLE
feat: expose peerId and protocols from WakuNode

### DIFF
--- a/packages/interfaces/src/waku.ts
+++ b/packages/interfaces/src/waku.ts
@@ -21,6 +21,26 @@ export interface IWaku {
   connectionManager: IConnectionManager;
 
   /**
+   * Returns a unique identifier for a node on the network.
+   *
+   * @example
+   * ```typescript
+   * console.log(waku.peerId); // 12D3KooWNmk9yXHfHJ4rUduRqD1TCTHkNFMPF9WP2dqWpZDL4aUb
+   * ```
+   */
+  peerId: PeerId;
+
+  /**
+   * Returns a list of supported protocols.
+   *
+   * @example
+   * ```typescript
+   * console.log(waku.protocols); // ['/ipfs/id/1.0.0', '/ipfs/ping/1.0.0', '/vac/waku/filter-push/2.0.0-beta1', '/vac/waku/metadata/1.0.0']
+   * ```
+   */
+  protocols: string[];
+
+  /**
    * Dials to the provided peer
    *
    * @param {PeerId | MultiaddrInput} peer information to use for dialing

--- a/packages/sdk/src/waku/waku.ts
+++ b/packages/sdk/src/waku/waku.ts
@@ -128,6 +128,14 @@ export class WakuNode implements IWaku {
     );
   }
 
+  public get peerId(): PeerId {
+    return this.libp2p.peerId;
+  }
+
+  public get protocols(): string[] {
+    return this.libp2p.getProtocols();
+  }
+
   public async dial(
     peer: PeerId | MultiaddrInput,
     protocols?: Protocols[]

--- a/packages/sdk/src/waku/waku.ts
+++ b/packages/sdk/src/waku/waku.ts
@@ -219,21 +219,6 @@ export class WakuNode implements IWaku {
   public isConnected(): boolean {
     return this.connectionManager.isConnected();
   }
-
-  /**
-   * Return the local multiaddr with peer id on which libp2p is listening.
-   *
-   * @throws if libp2p is not listening on localhost.
-   */
-  public getLocalMultiaddrWithID(): string {
-    const localMultiaddr = this.libp2p
-      .getMultiaddrs()
-      .find((addr) => addr.toString().match(/127\.0\.0\.1/));
-    if (!localMultiaddr || localMultiaddr.toString() === "") {
-      throw "Not listening on localhost";
-    }
-    return localMultiaddr + "/p2p/" + this.libp2p.peerId.toString();
-  }
 }
 function mapToPeerIdOrMultiaddr(
   peerId: PeerId | MultiaddrInput

--- a/packages/sdk/src/waku/waku.ts
+++ b/packages/sdk/src/waku/waku.ts
@@ -141,7 +141,7 @@ export class WakuNode implements IWaku {
     protocols?: Protocols[]
   ): Promise<Stream> {
     const _protocols = protocols ?? [];
-    const peerId = mapToPeerIdOrMultiaddr(peer);
+    const peerId = this.mapToPeerIdOrMultiaddr(peer);
 
     if (typeof protocols === "undefined") {
       this.relay && _protocols.push(Protocols.Relay);
@@ -219,9 +219,10 @@ export class WakuNode implements IWaku {
   public isConnected(): boolean {
     return this.connectionManager.isConnected();
   }
-}
-function mapToPeerIdOrMultiaddr(
-  peerId: PeerId | MultiaddrInput
-): PeerId | Multiaddr {
-  return isPeerId(peerId) ? peerId : multiaddr(peerId);
+
+  private mapToPeerIdOrMultiaddr(
+    peerId: PeerId | MultiaddrInput
+  ): PeerId | Multiaddr {
+    return isPeerId(peerId) ? peerId : multiaddr(peerId);
+  }
 }


### PR DESCRIPTION
## Problem

Previously I met people that requested to expose additional information from `WakuNode` object.
It is also used in dogfooding app and whenever we use it - we need to access through `libp2p`.

## Solution

Abstract `libp2p` away.
