### PR TITLE
chore: downgrade node engine to 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 env:
-  NODE_JS: "20"
+  NODE_JS: "18"
 
 jobs:
   check:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  NODE_JS: "20"
+  NODE_JS: "18"
   EXAMPLE_TEMPLATE: "web-chat"
   EXAMPLE_NAME: "example"
   EXAMPLE_PORT: "8080"

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -24,7 +24,7 @@ on:
         default: false
 
 env:
-  NODE_JS: "20"
+  NODE_JS: "18"
   # Ensure test type conditions remain consistent.
   WAKU_SERVICE_NODE_PARAMS: ${{ (inputs.test_type == 'go-waku-master') && '--min-relay-peers-to-publish=0' || '' }}
   DEBUG: ${{ inputs.debug }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39114,7 +39114,7 @@
         "sinon": "^18.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
@@ -39177,7 +39177,7 @@
         "sinon": "^18.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@libp2p/interface": "^1.6.3"
@@ -39221,7 +39221,7 @@
         "uint8arrays": "^5.0.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0"
@@ -39247,7 +39247,7 @@
         "npm-run-all": "^4.1.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "packages/message-encryption": {
@@ -39280,7 +39280,7 @@
         "rollup": "^4.12.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "packages/message-hash": {
@@ -39311,7 +39311,7 @@
         "rollup": "^4.12.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "packages/proto": {
@@ -39333,7 +39333,7 @@
         "uint8arraylist": "^2.4.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "packages/react-native-polyfills": {
@@ -39349,7 +39349,7 @@
         "expo": "~51.0.14"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "peerDependencies": {
         "expo": "~51.0.14",
@@ -39429,7 +39429,7 @@
         "sinon": "^18.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@libp2p/bootstrap": "^10"
@@ -39486,7 +39486,7 @@
         "npm-run-all": "^4.1.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "packages/utils": {
@@ -39511,7 +39511,7 @@
         "rollup": "^4.12.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "@libp2p/ping": "^1.1.2",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -48,7 +48,7 @@
     "test:browser": "NODE_ENV=test karma start karma.conf.cjs"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "@waku/interfaces": "0.0.27",

--- a/packages/enr/package.json
+++ b/packages/enr/package.json
@@ -48,7 +48,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "@ethersproject/rlp": "^5.7.0",

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -44,7 +44,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "devDependencies": {
     "@chainsafe/libp2p-gossipsub": "^13.1.0",

--- a/packages/message-encryption/package.json
+++ b/packages/message-encryption/package.json
@@ -69,7 +69,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "browser": {
     "crypto": false

--- a/packages/message-hash/package.json
+++ b/packages/message-hash/package.json
@@ -47,7 +47,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2",

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -41,7 +41,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "protons-runtime": "^5.4.0"

--- a/packages/react-native-polyfills/package.json
+++ b/packages/react-native-polyfills/package.json
@@ -34,7 +34,7 @@
     "prepublish": "npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "event-target-polyfill": "^0.0.4",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -57,7 +57,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "@chainsafe/libp2p-noise": "^15.1.0",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -47,7 +47,7 @@
     "reset-hard": "git clean -dfx -e .idea && git reset --hard && npm i && npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "@libp2p/interface-compliance-tests": "^5.4.9",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -64,7 +64,7 @@
     "test:node": "NODE_ENV=test TS_NODE_PROJECT=./tsconfig.dev.json mocha"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2",


### PR DESCRIPTION
## Problem

Some js-waku library consumers are using nodejs-mobile that doesn't support node v20 as the engine: https://github.com/nodejs-mobile/nodejs-mobile/issues/126, https://github.com/nodejs-mobile/nodejs-mobile/issues/133

## Solution

Downgrade it to 18 temporarily

## Notes


- Resolves https://github.com/waku-org/js-waku/issues/2171
- We should directly upgrade node engine to v22 once https://github.com/nodejs-mobile/nodejs-mobile/issues/133 is resolved
