### PR TITLE
chore: change default filter ping interval to 1 min

### DIFF
--- a/packages/sdk/src/protocols/filter/constants.ts
+++ b/packages/sdk/src/protocols/filter/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_KEEP_ALIVE = 10_000;
+export const DEFAULT_KEEP_ALIVE = 60_000;
 
 export const DEFAULT_SUBSCRIBE_OPTIONS = {
   keepAlive: DEFAULT_KEEP_ALIVE


### PR DESCRIPTION
## Problem

10 seconds as a ping interval might be an overkill and would flood ping requests from multiple clients.

## Solution

Change it to 1 min

## Notes

- Related to https://discord.com/channels/1110799176264056863/1292612132227125430/1295320677385244674

