### PR TITLE
fix: remove window reference and improve waitForRemotePeer

### DIFF
--- a/packages/sdk/src/reliability_monitor/receiver.ts
+++ b/packages/sdk/src/reliability_monitor/receiver.ts
@@ -115,7 +115,7 @@ export class ReceiverReliabilityMonitor {
       return;
     }
 
-    const timeout = window.setTimeout(
+    const timeout = setTimeout(
       (async () => {
         const receivedAnyMessage = this.verifiedPeers.has(peerIdStr);
         const receivedTestMessage = this.receivedMessagesFormPeer.has(
@@ -136,7 +136,7 @@ export class ReceiverReliabilityMonitor {
         await this.renewAndSubscribePeer(peerId);
       }) as () => void,
       MESSAGE_VERIFICATION_DELAY
-    );
+    ) as unknown as number;
 
     this.scheduledVerification.set(peerIdStr, timeout);
   }

--- a/packages/sdk/src/waku/wait_for_remote_peer.spec.ts
+++ b/packages/sdk/src/waku/wait_for_remote_peer.spec.ts
@@ -7,7 +7,7 @@ import sinon from "sinon";
 import { waitForRemotePeer } from "./wait_for_remote_peer.js";
 import { WakuNode } from "./waku.js";
 
-describe("waitForRemotePeer", () => {
+describe.only("waitForRemotePeer", () => {
   let eventTarget = new EventTarget();
 
   beforeEach(() => {
@@ -121,8 +121,8 @@ describe("waitForRemotePeer", () => {
   });
 
   it("should check connected peers if present and suitable", async () => {
-    const addEventListenerSpy = sinon.spy(eventTarget.addEventListener);
-    eventTarget.addEventListener = addEventListenerSpy;
+    const removeEventListenerSpy = sinon.spy(eventTarget.removeEventListener);
+    eventTarget.removeEventListener = removeEventListenerSpy;
 
     const wakuNode = mockWakuNode({
       isStarted: true,
@@ -144,7 +144,7 @@ describe("waitForRemotePeer", () => {
     }
 
     expect(err).to.be.undefined;
-    expect(addEventListenerSpy.notCalled).to.be.true;
+    expect(removeEventListenerSpy.notCalled).to.be.true;
   });
 
   it("should wait for LightPush peer to be connected", async () => {


### PR DESCRIPTION
## Problem

This PR resolves cold start issue and reference `window` issue.

## Solution

For cold start issue - we should start checking new connections as early as possible.

## Notes

- Resolves https://github.com/waku-org/js-waku/issues/2190