### PR TITLE
fix: improve dependencies handling of @libp2p in pnpm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40479,6 +40479,7 @@
         "uint8arrays": "^5.0.1"
       },
       "devDependencies": {
+        "@libp2p/interface": "2.0.1",
         "@libp2p/peer-id": "5.0.1",
         "@multiformats/multiaddr": "^12.3.0",
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -40498,14 +40499,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "peerDependencies": {
-        "@libp2p/interface": "2.0.1"
-      },
-      "peerDependenciesMeta": {
-        "@libp2p/interface": {
-          "optional": true
-        }
       }
     },
     "packages/discovery/node_modules/@libp2p/peer-id": {
@@ -40761,14 +40754,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "peerDependencies": {
-        "@libp2p/bootstrap": "^10"
-      },
-      "peerDependenciesMeta": {
-        "@libp2p/bootstrap": {
-          "optional": true
-        }
       }
     },
     "packages/sdk/node_modules/@sinonjs/fake-timers": {

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -62,6 +62,7 @@
     "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
+    "@libp2p/interface": "2.0.1",
     "@libp2p/peer-id": "5.0.1",
     "@multiformats/multiaddr": "^12.3.0",
     "@rollup/plugin-commonjs": "^25.0.7",
@@ -78,14 +79,6 @@
     "npm-run-all": "^4.1.5",
     "rollup": "^4.12.0",
     "sinon": "^18.0.0"
-  },
-  "peerDependencies": {
-    "@libp2p/interface": "2.0.1"
-  },
-  "peerDependenciesMeta": {
-    "@libp2p/interface": {
-      "optional": true
-    }
   },
   "files": [
     "dist",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -92,14 +92,6 @@
     "rollup": "^4.12.0",
     "sinon": "^19.0.2"
   },
-  "peerDependencies": {
-    "@libp2p/bootstrap": "^10"
-  },
-  "peerDependenciesMeta": {
-    "@libp2p/bootstrap": {
-      "optional": true
-    }
-  },
   "files": [
     "dist",
     "bundle",


### PR DESCRIPTION
## Problem

`pnpm` gets confused with `peerDependencies` `js-waku` has and misses `@libp2p/bootstrap` package.

## Solution

This PR removes `peerDependencies` as they are making `pnpm` misbehave with how it resolves dependencies. 
There is no problem with `pnpm` as I see, it's more of a problem with `peerDeps` getting out of sync with other deps while `libp2p` goes through upgrade. 

## Notes

`@waku/sdk` is published under `0.0.30-1c0c5ee.0` version with this fix. 

As for `peerDependencies` - removing them to prevent any confusion. Let's add them back once requested by consumers. 

- Resolves https://github.com/waku-org/js-waku/issues/2199