### PR TITLE
fix: access to process variable

### DIFF
--- a/packages/sdk/src/create/libp2p.ts
+++ b/packages/sdk/src/create/libp2p.ts
@@ -17,6 +17,7 @@ import {
 import { derivePubsubTopicsFromNetworkConfig, Logger } from "@waku/utils";
 import { createLibp2p } from "libp2p";
 
+import { isTestEnvironment } from "../env.js";
 import {
   CreateWakuNodeOptions,
   DefaultPingMaxInboundStreams,
@@ -36,7 +37,7 @@ export async function defaultLibp2p(
   options?: Partial<CreateLibp2pOptions>,
   userAgent?: string
 ): Promise<Libp2p> {
-  if (!options?.hideWebSocketInfo && process?.env?.NODE_ENV !== "test") {
+  if (!options?.hideWebSocketInfo && !isTestEnvironment()) {
     /* eslint-disable no-console */
     console.info(
       "%cIgnore WebSocket connection failures",
@@ -54,7 +55,7 @@ export async function defaultLibp2p(
     : {};
 
   const filter =
-    options?.filterMultiaddrs === false || process?.env?.NODE_ENV === "test"
+    options?.filterMultiaddrs === false || isTestEnvironment()
       ? filterAll
       : wss;
 

--- a/packages/sdk/src/env.ts
+++ b/packages/sdk/src/env.ts
@@ -1,0 +1,8 @@
+export function isTestEnvironment(): boolean {
+  try {
+    return process?.env?.NODE_ENV === "test";
+  } catch (_e) {
+    // process variable is not defined in PROD environment
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem

In some build systems `process` variable is not defined. In those cases it is treated according to `ES6` spec and goes through `TDZ`.

## Solution

Add `try/catch`. 

## Notes

Resolves https://github.com/waku-org/js-waku/issues/2208