### PR TITLE
chore(ci): remove verbose log level to improve readability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,6 @@ jobs:
     with:
       nim_wakunode_image: ${{ inputs.nim_wakunode_image || 'wakuorg/nwaku:v0.31.0' }}
       test_type: node
-      debug: waku*
 
   node_optional:
     uses: ./.github/workflows/test-node.yml


### PR DESCRIPTION
### Problem / Description
Tests in the CI run with `debug=waku*` which makes the job completely unreadable

### Solution
Remove `waku*` log level

