### PR TITLE
chore(tests): replace `pubsubTopic` param with `clusterid` plus `shard` to start nwaku

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "karma-mocha": "^2.0.1",
         "karma-webkit-launcher": "^2.4.0",
         "karma-webpack": "github:codymikol/karma-webpack#2337a82beb078c0d8e25ae8333a06249b8e72828",
-        "lint-staged": "^15.2.2",
+        "lint-staged": "^15.4.3",
         "playwright": "^1.40.1",
         "size-limit": "^11.0.1",
         "ts-loader": "^9.5.1",
@@ -11684,64 +11684,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/allure-commandline": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/allure-commandline/-/allure-commandline-2.32.0.tgz",
-      "integrity": "sha512-W03ors+ks8uy0SgQILHQvtvR0iadAfDYmTFC3p8Pk4pi8KXUW1cF+z8FN2+7deH3FE2cuYgjhhA+CdLdJfzOMQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "allure": "bin/allure"
-      }
-    },
-    "node_modules/allure-js-commons": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-2.15.1.tgz",
-      "integrity": "sha512-5V/VINplbu0APnfSZOkYpKOzucO36Q2EtTD1kqjWjl7n6tj7Hh+IHCZsH3Vpk/LXRDfj9RuXugBBvwYKV5YMJw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "md5": "^2.3.0",
-        "properties": "^1.2.1",
-        "strip-ansi": "^5.2.0"
-      }
-    },
-    "node_modules/allure-js-commons/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/allure-js-commons/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/allure-mocha": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/allure-mocha/-/allure-mocha-2.15.1.tgz",
-      "integrity": "sha512-4Hk2qUR6LdAUXNpPe73MV3DPKrBH7zy57lbAdb/D0poNIkdGEkzUYkpVPtW1imYfjqFXKBFEPOSJWqznGuiyjg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "allure-js-commons": "2.15.1"
-      },
-      "peerDependencies": {
-        "mocha": ">=6.2.x"
-      }
-    },
     "node_modules/anser": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
@@ -14844,19 +14786,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/cspell-config-lib/node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/cspell-dictionary": {
@@ -22695,9 +22624,9 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -22723,22 +22652,22 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "15.2.10",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
-      "integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
+      "version": "15.4.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.4.3.tgz",
+      "integrity": "sha512-FoH1vOeouNh1pw+90S+cnuoFwRfUD9ijY2GKy5h7HS3OR7JVir2N2xrsa0+Twc1B7cW72L+88geG5cW4wIhn7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "~5.3.0",
-        "commander": "~12.1.0",
-        "debug": "~4.3.6",
-        "execa": "~8.0.1",
-        "lilconfig": "~3.1.2",
-        "listr2": "~8.2.4",
-        "micromatch": "~4.0.8",
-        "pidtree": "~0.6.0",
-        "string-argv": "~0.3.2",
-        "yaml": "~2.5.0"
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -22751,9 +22680,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -22761,6 +22690,34 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/lint-staged/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/listr": {
@@ -25833,23 +25790,6 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/mocha-multi-reporters": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.5.1.tgz",
-      "integrity": "sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "lodash": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "mocha": ">=3.1.2"
       }
     },
     "node_modules/mocha/node_modules/cliui": {
@@ -33015,16 +32955,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
-    },
-    "node_modules/properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/properties/-/properties-1.2.1.tgz",
-      "integrity": "sha512-qYNxyMj1JeW54i/EWEFsM1cVwxJbtgPp8+0Wg9XjNaK6VE/c4oRi6PNu5p7w1mNXEIQIjV5Wwn8v8Gz82/QzdQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/proto-list": {
       "version": "1.2.4",
@@ -40203,9 +40133,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -40875,8 +40805,6 @@
         "@waku/message-encryption": "*",
         "@waku/relay": "*",
         "@waku/sdk": "*",
-        "allure-commandline": "^2.27.0",
-        "allure-mocha": "^2.9.2",
         "chai": "^4.3.10",
         "cspell": "^8.6.1",
         "datastore-core": "^10.0.2",
@@ -40884,7 +40812,6 @@
         "interface-datastore": "^8.2.10",
         "libp2p": "2.1.8",
         "mocha": "^10.3.0",
-        "mocha-multi-reporters": "^1.5.1",
         "npm-run-all": "^4.1.5"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "karma-mocha": "^2.0.1",
     "karma-webkit-launcher": "^2.4.0",
     "karma-webpack": "github:codymikol/karma-webpack#2337a82beb078c0d8e25ae8333a06249b8e72828",
-    "lint-staged": "^15.2.2",
+    "lint-staged": "^15.4.3",
     "playwright": "^1.40.1",
     "size-limit": "^11.0.1",
     "ts-loader": "^9.5.1",

--- a/packages/tests/src/lib/service_node.ts
+++ b/packages/tests/src/lib/service_node.ts
@@ -412,7 +412,8 @@ export function defaultArgs(): Args {
     restAdmin: true,
     websocketSupport: true,
     logLevel: LogLevel.Trace,
-    pubsubTopic: ["/waku/2/rs/0/0"]
+    clusterId: 0,
+    shard: [0]
   };
 }
 

--- a/packages/tests/tests/nwaku.node.spec.ts
+++ b/packages/tests/tests/nwaku.node.spec.ts
@@ -17,7 +17,8 @@ describe("nwaku", () => {
       "--rest-admin=true",
       "--websocket-support=true",
       "--log-level=TRACE",
-      "--pubsub-topic=/waku/2/rs/0/0",
+      "--cluster-id=0",
+      "--shard=0",
       "--ports-shift=42"
     ];
 


### PR DESCRIPTION
We are in the process of deprecating pubsub-topic param from nim-waku. The pubsub-topic shouldn't be used to start nim-waku and instead, a combination of 1 cluster-id plus n shard should be given. This aims to start using the new added param: shard.

Notice that this PR also suggests to update the lint-staged package so that `npx lint-staged` command works well with the new changes.

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
