### PR TITLE
chore: CI should have human readable logs + json for reporting

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WAKUNODE_IMAGE: ${{ inputs.nim_wakunode_image }}
+      REPORT_PATH: packages/tests/reports/mocha-results.json
+      GITHUB_WORKSPACE: ${{ github.workspace }}
     permissions:
       contents: read
       actions: read
@@ -47,6 +49,9 @@ jobs:
 
       - run: npm run build:esm
 
+      - name: Create reports directory
+        run: mkdir -p packages/tests/reports
+
       - run: ${{ (inputs.test_type == 'node-optional') && 'npm run test:optional --workspace=@waku/tests' || 'npm run test:node' }}
 
       - name: Test Report
@@ -54,7 +59,7 @@ jobs:
         if: success() || failure()
         with:
           name: Test Report - ${{ inputs.test_type }}
-          path: 'packages/tests/reports/mocha-*.json'
+          path: packages/tests/reports/mocha-results.json
           reporter: mocha-json
           fail-on-error: true
 

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -31,7 +31,6 @@ jobs:
     env:
       WAKUNODE_IMAGE: ${{ inputs.nim_wakunode_image }}
       REPORT_PATH: packages/tests/reports/mocha-results.json
-      GITHUB_WORKSPACE: ${{ github.workspace }}
     permissions:
       contents: read
       actions: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "karma-webkit-launcher": "^2.4.0",
         "karma-webpack": "github:codymikol/karma-webpack#2337a82beb078c0d8e25ae8333a06249b8e72828",
         "lint-staged": "^15.4.3",
+        "mocha-multi-reporters": "^1.5.1",
         "playwright": "^1.40.1",
         "size-limit": "^11.0.1",
         "ts-loader": "^9.5.1",
@@ -26334,6 +26335,23 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha-multi-reporters": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.5.1.tgz",
+      "integrity": "sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "mocha": ">=3.1.2"
       }
     },
     "node_modules/mocha/node_modules/cliui": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "karma-webkit-launcher": "^2.4.0",
     "karma-webpack": "github:codymikol/karma-webpack#2337a82beb078c0d8e25ae8333a06249b8e72828",
     "lint-staged": "^15.4.3",
+    "mocha-multi-reporters": "^1.5.1",
     "playwright": "^1.40.1",
     "size-limit": "^11.0.1",
     "ts-loader": "^9.5.1",

--- a/packages/core/.mocharc.cjs
+++ b/packages/core/.mocharc.cjs
@@ -15,10 +15,13 @@ if (process.env.CI) {
   console.log("Running tests in parallel");
   config.parallel = true;
   config.jobs = 6;
-  console.log("Using JSON reporter for test results");
-  config.reporter = 'json';
+  console.log("Using multi reporters for test results");
+  config.reporter = 'mocha-multi-reporters';
   config.reporterOptions = {
-    output: 'reports/mocha-results.json'
+    reporterEnabled: 'spec, json',
+    jsonReporterOptions: {
+      output: 'reports/mocha-results.json'
+    }
   };
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");

--- a/packages/discovery/.mocharc.cjs
+++ b/packages/discovery/.mocharc.cjs
@@ -15,10 +15,13 @@ if (process.env.CI) {
   console.log("Running tests in parallel");
   config.parallel = true;
   config.jobs = 6;
-  console.log("Using JSON reporter for test results");
-  config.reporter = 'json';
+  console.log("Using multi reporters for test results");
+  config.reporter = 'mocha-multi-reporters';
   config.reporterOptions = {
-    output: 'reports/mocha-results.json'
+    reporterEnabled: 'spec, json',
+    jsonReporterOptions: {
+      output: 'reports/mocha-results.json'
+    }
   };
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");

--- a/packages/enr/.mocharc.cjs
+++ b/packages/enr/.mocharc.cjs
@@ -15,10 +15,13 @@ if (process.env.CI) {
   console.log("Running tests in parallel");
   config.parallel = true;
   config.jobs = 6;
-  console.log("Using JSON reporter for test results");
-  config.reporter = 'json';
+  console.log("Using multi reporters for test results");
+  config.reporter = 'mocha-multi-reporters';
   config.reporterOptions = {
-    output: 'reports/mocha-results.json'
+    reporterEnabled: 'spec, json',
+    jsonReporterOptions: {
+      output: 'reports/mocha-results.json'
+    }
   };
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");

--- a/packages/message-encryption/.mocharc.cjs
+++ b/packages/message-encryption/.mocharc.cjs
@@ -15,10 +15,13 @@ if (process.env.CI) {
   console.log("Running tests in parallel");
   config.parallel = true;
   config.jobs = 6;
-  console.log("Using JSON reporter for test results");
-  config.reporter = 'json';
+  console.log("Using multi reporters for test results");
+  config.reporter = 'mocha-multi-reporters';
   config.reporterOptions = {
-    output: 'reports/mocha-results.json'
+    reporterEnabled: 'spec, json',
+    jsonReporterOptions: {
+      output: 'reports/mocha-results.json'
+    }
   };
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");

--- a/packages/message-hash/.mocharc.cjs
+++ b/packages/message-hash/.mocharc.cjs
@@ -15,10 +15,13 @@ if (process.env.CI) {
   console.log("Running tests in parallel");
   config.parallel = true;
   config.jobs = 6;
-  console.log("Using JSON reporter for test results");
-  config.reporter = 'json';
+  console.log("Using multi reporters for test results");
+  config.reporter = 'mocha-multi-reporters';
   config.reporterOptions = {
-    output: 'reports/mocha-results.json'
+    reporterEnabled: 'spec, json',
+    jsonReporterOptions: {
+      output: 'reports/mocha-results.json'
+    }
   };
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");

--- a/packages/relay/.mocharc.cjs
+++ b/packages/relay/.mocharc.cjs
@@ -15,10 +15,13 @@ if (process.env.CI) {
   console.log("Running tests in parallel");
   config.parallel = true;
   config.jobs = 6;
-  console.log("Using JSON reporter for test results");
-  config.reporter = 'json';
+  console.log("Using multi reporters for test results");
+  config.reporter = 'mocha-multi-reporters';
   config.reporterOptions = {
-    output: 'reports/mocha-results.json'
+    reporterEnabled: 'spec, json',
+    jsonReporterOptions: {
+      output: 'reports/mocha-results.json'
+    }
   };
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");

--- a/packages/sdk/.mocharc.cjs
+++ b/packages/sdk/.mocharc.cjs
@@ -15,10 +15,13 @@ if (process.env.CI) {
   console.log("Running tests in parallel");
   config.parallel = true;
   config.jobs = 6;
-  console.log("Using JSON reporter for test results");
-  config.reporter = 'json';
+  console.log("Using multi reporters for test results");
+  config.reporter = 'mocha-multi-reporters';
   config.reporterOptions = {
-    output: 'reports/mocha-results.json'
+    reporterEnabled: 'spec, json',
+    jsonReporterOptions: {
+      output: 'reports/mocha-results.json'
+    }
   };
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");

--- a/packages/tests/.mocharc.cjs
+++ b/packages/tests/.mocharc.cjs
@@ -14,10 +14,13 @@ if (process.env.CI) {
   console.log("Running tests in parallel");
   config.parallel = true;
   config.jobs = 6;
-  console.log("Using JSON reporter for test results");
-  config.reporter = 'json';
+  console.log("Using multi reporters for test results");
+  config.reporter = 'mocha-multi-reporters';
   config.reporterOptions = {
-    output: 'reports/mocha-results.json'
+    reporterEnabled: 'spec, json',
+    jsonReporterOptions: {
+      output: 'reports/mocha-results.json'
+    }
   };
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");

--- a/packages/tests/.mocharc.cjs
+++ b/packages/tests/.mocharc.cjs
@@ -15,13 +15,27 @@ if (process.env.CI) {
   config.parallel = true;
   config.jobs = 6;
   console.log("Using multi reporters for test results");
-  config.reporter = 'mocha-multi-reporters';
-  config.reporterOptions = {
-    reporterEnabled: 'spec, json',
-    jsonReporterOptions: {
-      output: 'reports/mocha-results.json'
+  config.reporter = 'spec';
+
+  // Write JSON results to file without printing to console
+  if (process.env.REPORT_PATH) {
+    const fs = require('fs');
+    const path = require('path');
+    const reportDir = path.dirname(process.env.REPORT_PATH);
+    if (!fs.existsSync(reportDir)) {
+      fs.mkdirSync(reportDir, { recursive: true });
     }
-  };
+    config.reporter = 'mocha-multi-reporters';
+    config.reporterOptions = {
+      reporterEnabled: 'spec, json',
+      reporterOptions: {
+        json: {
+          stdout: '/dev/null',  // Don't print JSON to stdout
+          options: { output: process.env.REPORT_PATH }
+        }
+      }
+    };
+  }
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");
 }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -86,6 +86,6 @@
     "interface-datastore": "^8.2.10",
     "libp2p": "2.1.8",
     "mocha": "^10.3.0",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5"  
   }
 }

--- a/packages/tests/src/run-tests.js
+++ b/packages/tests/src/run-tests.js
@@ -34,32 +34,30 @@ async function main() {
   if (process.env.CI) {
     const reportsDir = getPackagePath("reports");
     const reportFile = resolve(reportsDir, "mocha-results.json");
-    const configFile = resolve(reportsDir, "config.json");
 
     await mkdir(reportsDir, { recursive: true });
 
-    // Create a clean reporter config
+    // Use both spec and JSON reporters in CI
+    mochaArgs.push(
+      "--reporter",
+      "mocha-multi-reporters",
+      "--reporter-options",
+      `configFile=${getPackagePath("reporter-config.json")}`
+    );
+
+    // Create reporter config file
     const reporterConfig = {
-      reporterEnabled: "spec",
+      reporterEnabled: "spec, json",
       reporterOptions: {
         json: {
-          stdout: false,
-          options: {
-            output: reportFile
-          }
+          output: reportFile
         }
       }
     };
 
-    // Write the config file
-    await writeFile(configFile, JSON.stringify(reporterConfig, null, 2));
-
-    // Add a separate JSON reporter directly
-    mochaArgs.push(
-      "--reporter-option",
-      `output=${reportFile}`,
-      "--reporter",
-      "json"
+    await writeFile(
+      getPackagePath("reporter-config.json"),
+      JSON.stringify(reporterConfig, null, 2)
     );
   } else {
     // In non-CI environments, just use spec reporter

--- a/packages/tests/tests/store/index.node.spec.ts
+++ b/packages/tests/tests/store/index.node.spec.ts
@@ -45,7 +45,7 @@ import {
 } from "./utils.js";
 
 describe("Waku Store, general", function () {
-  this.timeout(15000);
+  this.timeout(120000);
   let waku: LightNode;
   let waku2: LightNode;
   let nwaku: ServiceNode;

--- a/packages/utils/.mocharc.cjs
+++ b/packages/utils/.mocharc.cjs
@@ -15,10 +15,13 @@ if (process.env.CI) {
   console.log("Running tests in parallel");
   config.parallel = true;
   config.jobs = 6;
-  console.log("Using JSON reporter for test results");
-  config.reporter = 'json';
+  console.log("Using multi reporters for test results");
+  config.reporter = 'mocha-multi-reporters';
   config.reporterOptions = {
-    output: 'reports/mocha-results.json'
+    reporterEnabled: 'spec, json',
+    jsonReporterOptions: {
+      output: 'reports/mocha-results.json'
+    }
   };
 } else {
   console.log("Running tests serially. To enable parallel execution update mocha config");


### PR DESCRIPTION
### Problem / Description
We recently switched to a JSON reporter for our tests. 
This created a side-effect where logs were now being printed in JSON, instead of human-readable format (spec)

### Solution
Use multi-reporter:
- use `spec` (human readable) for logs (stdout)
- use JSON for report


---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [x] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [x] All **CI checks** pass successfully.
