### PR TITLE
feat: move Peer to PeerId

### DIFF
--- a/packages/core/src/lib/base_protocol.ts
+++ b/packages/core/src/lib/base_protocol.ts
@@ -1,5 +1,5 @@
 import type { Libp2p } from "@libp2p/interface";
-import type { Peer, Stream } from "@libp2p/interface";
+import type { PeerId, Stream } from "@libp2p/interface";
 import type {
   IBaseProtocolCore,
   Libp2pComponents,
@@ -38,7 +38,7 @@ export class BaseProtocol implements IBaseProtocolCore {
     );
   }
 
-  protected async getStream(peer: Peer): Promise<Stream> {
-    return this.streamManager.getStream(peer);
+  protected async getStream(peerId: PeerId): Promise<Stream> {
+    return this.streamManager.getStream(peerId);
   }
 }

--- a/packages/core/src/lib/filter/filter.ts
+++ b/packages/core/src/lib/filter/filter.ts
@@ -1,4 +1,4 @@
-import type { Peer, Stream } from "@libp2p/interface";
+import type { PeerId, Stream } from "@libp2p/interface";
 import type { IncomingStreamData } from "@libp2p/interface-internal";
 import {
   type ContentTopic,
@@ -53,10 +53,10 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
 
   public async subscribe(
     pubsubTopic: PubsubTopic,
-    peer: Peer,
+    peerId: PeerId,
     contentTopics: ContentTopic[]
   ): Promise<CoreProtocolResult> {
-    const stream = await this.getStream(peer);
+    const stream = await this.getStream(peerId);
 
     const request = FilterSubscribeRpc.createSubscribeRequest(
       pubsubTopic,
@@ -78,7 +78,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: ProtocolError.GENERIC_FAIL,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -93,7 +93,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
       return {
         failure: {
           error: ProtocolError.REMOTE_PEER_REJECTED,
-          peerId: peer.id
+          peerId: peerId
         },
         success: null
       };
@@ -101,28 +101,28 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
 
     return {
       failure: null,
-      success: peer.id
+      success: peerId
     };
   }
 
   public async unsubscribe(
     pubsubTopic: PubsubTopic,
-    peer: Peer,
+    peerId: PeerId,
     contentTopics: ContentTopic[]
   ): Promise<CoreProtocolResult> {
     let stream: Stream | undefined;
     try {
-      stream = await this.getStream(peer);
+      stream = await this.getStream(peerId);
     } catch (error) {
       log.error(
-        `Failed to get a stream for remote peer${peer.id.toString()}`,
+        `Failed to get a stream for remote peer${peerId.toString()}`,
         error
       );
       return {
         success: null,
         failure: {
           error: ProtocolError.NO_STREAM_AVAILABLE,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -140,22 +140,22 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: ProtocolError.GENERIC_FAIL,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
 
     return {
-      success: peer.id,
+      success: peerId,
       failure: null
     };
   }
 
   public async unsubscribeAll(
     pubsubTopic: PubsubTopic,
-    peer: Peer
+    peerId: PeerId
   ): Promise<CoreProtocolResult> {
-    const stream = await this.getStream(peer);
+    const stream = await this.getStream(peerId);
 
     const request = FilterSubscribeRpc.createUnsubscribeAllRequest(pubsubTopic);
 
@@ -171,7 +171,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
       return {
         failure: {
           error: ProtocolError.NO_RESPONSE,
-          peerId: peer.id
+          peerId: peerId
         },
         success: null
       };
@@ -187,7 +187,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
       return {
         failure: {
           error: ProtocolError.REMOTE_PEER_REJECTED,
-          peerId: peer.id
+          peerId: peerId
         },
         success: null
       };
@@ -195,24 +195,24 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
 
     return {
       failure: null,
-      success: peer.id
+      success: peerId
     };
   }
 
-  public async ping(peer: Peer): Promise<CoreProtocolResult> {
+  public async ping(peerId: PeerId): Promise<CoreProtocolResult> {
     let stream: Stream | undefined;
     try {
-      stream = await this.getStream(peer);
+      stream = await this.getStream(peerId);
     } catch (error) {
       log.error(
-        `Failed to get a stream for remote peer${peer.id.toString()}`,
+        `Failed to get a stream for remote peer${peerId.toString()}`,
         error
       );
       return {
         success: null,
         failure: {
           error: ProtocolError.NO_STREAM_AVAILABLE,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -234,7 +234,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: ProtocolError.GENERIC_FAIL,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -244,7 +244,7 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: ProtocolError.NO_RESPONSE,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -260,12 +260,12 @@ export class FilterCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: ProtocolError.REMOTE_PEER_REJECTED,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
     return {
-      success: peer.id,
+      success: peerId,
       failure: null
     };
   }

--- a/packages/core/src/lib/light_push/light_push.ts
+++ b/packages/core/src/lib/light_push/light_push.ts
@@ -1,4 +1,4 @@
-import type { Peer, Stream } from "@libp2p/interface";
+import type { PeerId, Stream } from "@libp2p/interface";
 import {
   type CoreProtocolResult,
   type IBaseProtocolCore,
@@ -76,11 +76,10 @@ export class LightPushCore extends BaseProtocol implements IBaseProtocolCore {
     }
   }
 
-  // TODO(weboko): use peer.id as parameter instead
   public async send(
     encoder: IEncoder,
     message: IMessage,
-    peer: Peer
+    peerId: PeerId
   ): Promise<CoreProtocolResult> {
     const { query, error: preparationError } = await this.preparePushMessage(
       encoder,
@@ -92,21 +91,21 @@ export class LightPushCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: preparationError,
-          peerId: peer.id
+          peerId
         }
       };
     }
 
     let stream: Stream;
     try {
-      stream = await this.getStream(peer);
+      stream = await this.getStream(peerId);
     } catch (error) {
       log.error("Failed to get stream", error);
       return {
         success: null,
         failure: {
           error: ProtocolError.NO_STREAM_AVAILABLE,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -126,7 +125,7 @@ export class LightPushCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: ProtocolError.GENERIC_FAIL,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -145,7 +144,7 @@ export class LightPushCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: ProtocolError.DECODE_FAILED,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -156,7 +155,7 @@ export class LightPushCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: ProtocolError.NO_RESPONSE,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -168,7 +167,7 @@ export class LightPushCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: rlnErrorCase,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
@@ -179,11 +178,11 @@ export class LightPushCore extends BaseProtocol implements IBaseProtocolCore {
         success: null,
         failure: {
           error: ProtocolError.REMOTE_PEER_REJECTED,
-          peerId: peer.id
+          peerId: peerId
         }
       };
     }
 
-    return { success: peer.id, failure: null };
+    return { success: peerId, failure: null };
   }
 }

--- a/packages/core/src/lib/metadata/metadata.ts
+++ b/packages/core/src/lib/metadata/metadata.ts
@@ -55,7 +55,7 @@ class Metadata extends BaseProtocol implements IMetadata {
 
     let stream;
     try {
-      stream = await this.getStream(peer);
+      stream = await this.getStream(peerId);
     } catch (error) {
       log.error("Failed to get stream", error);
       return {

--- a/packages/core/src/lib/store/store.ts
+++ b/packages/core/src/lib/store/store.ts
@@ -1,4 +1,4 @@
-import type { Peer } from "@libp2p/interface";
+import type { PeerId } from "@libp2p/interface";
 import {
   IDecodedMessage,
   IDecoder,
@@ -38,7 +38,7 @@ export class StoreCore extends BaseProtocol implements IStoreCore {
   public async *queryPerPage<T extends IDecodedMessage>(
     queryOpts: QueryRequestParams,
     decoders: Map<string, IDecoder<T>>,
-    peer: Peer
+    peerId: PeerId
   ): AsyncGenerator<Promise<T | undefined>[]> {
     if (
       queryOpts.contentTopics.toString() !==
@@ -58,7 +58,7 @@ export class StoreCore extends BaseProtocol implements IStoreCore {
 
       let stream;
       try {
-        stream = await this.getStream(peer);
+        stream = await this.getStream(peerId);
       } catch (e) {
         log.error("Failed to get stream", e);
         break;

--- a/packages/core/src/lib/stream_manager/stream_manager.spec.ts
+++ b/packages/core/src/lib/stream_manager/stream_manager.spec.ts
@@ -36,7 +36,7 @@ describe("StreamManager", () => {
 
       streamManager["getConnections"] = (_peerId: PeerId | undefined) => [con1];
 
-      const stream = await streamManager.getStream(mockPeer);
+      const stream = await streamManager.getStream(mockPeer.id);
 
       expect(stream).not.to.be.undefined;
       expect(stream?.id).to.be.eq("1");
@@ -48,7 +48,7 @@ describe("StreamManager", () => {
 
     let error: Error | undefined;
     try {
-      await streamManager.getStream(mockPeer);
+      await streamManager.getStream(mockPeer.id);
     } catch (e) {
       error = e as Error;
     }
@@ -76,7 +76,7 @@ describe("StreamManager", () => {
       con1.newStream = newStreamSpy;
       streamManager["getConnections"] = (_peerId: PeerId | undefined) => [con1];
 
-      const stream = await streamManager.getStream(mockPeer);
+      const stream = await streamManager.getStream(mockPeer.id);
 
       expect(stream).not.to.be.undefined;
       expect(stream?.id).to.be.eq("2");
@@ -102,8 +102,8 @@ describe("StreamManager", () => {
     streamManager["getConnections"] = (_peerId: PeerId | undefined) => [con1];
 
     const [stream1, stream2] = await Promise.all([
-      streamManager.getStream(mockPeer),
-      streamManager.getStream(mockPeer)
+      streamManager.getStream(mockPeer.id),
+      streamManager.getStream(mockPeer.id)
     ]);
 
     const expected = ["1", "2"].toString();

--- a/packages/discovery/src/peer-exchange/waku_peer_exchange.ts
+++ b/packages/discovery/src/peer-exchange/waku_peer_exchange.ts
@@ -57,7 +57,7 @@ export class WakuPeerExchange extends BaseProtocol implements IPeerExchange {
 
     let stream;
     try {
-      stream = await this.getStream(peer);
+      stream = await this.getStream(peerId);
     } catch (err) {
       log.error("Failed to get stream", err);
       return {

--- a/packages/sdk/src/filter/filter.ts
+++ b/packages/sdk/src/filter/filter.ts
@@ -157,8 +157,8 @@ class Filter implements IFilter {
 
     ensurePubsubTopicIsConfigured(pubsubTopic, this.protocol.pubsubTopics);
 
-    const peers = await this.peerManager.getPeers();
-    if (peers.length === 0) {
+    const peerIds = await this.peerManager.getPeers();
+    if (peerIds.length === 0) {
       return {
         error: ProtocolError.NO_PEER_AVAILABLE,
         subscription: null
@@ -166,8 +166,8 @@ class Filter implements IFilter {
     }
 
     log.info(
-      `Creating filter subscription with ${peers.length} peers: `,
-      peers.map((peer) => peer.id.toString())
+      `Creating filter subscription with ${peerIds.length} peers: `,
+      peerIds.map((id) => id.toString())
     );
 
     const subscription =

--- a/packages/sdk/src/light_push/light_push.spec.ts
+++ b/packages/sdk/src/light_push/light_push.spec.ts
@@ -17,7 +17,7 @@ import { LightPush } from "./light_push.js";
 const PUBSUB_TOPIC = "/waku/2/rs/1/4";
 const CONTENT_TOPIC = "/test/1/waku-light-push/utf8";
 
-describe.only("LightPush SDK", () => {
+describe("LightPush SDK", () => {
   let libp2p: Libp2p;
   let encoder: Encoder;
   let lightPush: LightPush;
@@ -108,7 +108,7 @@ describe.only("LightPush SDK", () => {
       { autoRetry: true }
     );
 
-    expect(attemptRetriesSpy.calledOnce).to.be.true;
+    expect(attemptRetriesSpy.callCount).to.be.eq(1);
     expect(result.successes?.length).to.be.eq(1);
     expect(result.failures?.length).to.be.eq(1);
 
@@ -162,7 +162,6 @@ function mockLightPush(options: MockLightPushOptions): LightPush {
       getPeers: () =>
         options.libp2p
           .getPeers()
-          .map((id) => mockPeer(id.toString()))
           .slice(0, options.numPeersToUse || options.libp2p.getPeers().length)
     } as unknown as PeerManager,
     options.libp2p

--- a/packages/sdk/src/light_push/light_push.spec.ts
+++ b/packages/sdk/src/light_push/light_push.spec.ts
@@ -1,4 +1,4 @@
-import { Peer } from "@libp2p/interface";
+import { Peer, PeerId } from "@libp2p/interface";
 import {
   ConnectionManager,
   createEncoder,
@@ -17,7 +17,7 @@ import { LightPush } from "./light_push.js";
 const PUBSUB_TOPIC = "/waku/2/rs/1/4";
 const CONTENT_TOPIC = "/test/1/waku-light-push/utf8";
 
-describe("LightPush SDK", () => {
+describe.only("LightPush SDK", () => {
   let libp2p: Libp2p;
   let encoder: Encoder;
   let lightPush: LightPush;
@@ -59,8 +59,8 @@ describe("LightPush SDK", () => {
 
     lightPush = mockLightPush({ libp2p, numPeersToUse: 2 });
     let sendSpy = sinon.spy(
-      (_encoder: any, _message: any, peer: Peer) =>
-        ({ success: peer.id }) as any
+      (_encoder: any, _message: any, peerId: PeerId) =>
+        ({ success: peerId }) as any
     );
     lightPush.protocol.send = sendSpy;
 
@@ -74,8 +74,8 @@ describe("LightPush SDK", () => {
     // check if setting another value works
     lightPush = mockLightPush({ libp2p, numPeersToUse: 3 });
     sendSpy = sinon.spy(
-      (_encoder: any, _message: any, peer: Peer) =>
-        ({ success: peer.id }) as any
+      (_encoder: any, _message: any, peerId: PeerId) =>
+        ({ success: peerId }) as any
     );
     lightPush.protocol.send = sendSpy;
 
@@ -91,9 +91,9 @@ describe("LightPush SDK", () => {
     });
 
     lightPush = mockLightPush({ libp2p });
-    let sendSpy = sinon.spy((_encoder: any, _message: any, peer: Peer) => {
-      if (peer.id.toString() === "1") {
-        return { success: peer.id };
+    let sendSpy = sinon.spy((_encoder: any, _message: any, peerId: PeerId) => {
+      if (peerId.toString() === "1") {
+        return { success: peerId };
       }
 
       return { failure: { error: "problem" } };

--- a/packages/sdk/src/peer_manager/peer_manager.spec.ts
+++ b/packages/sdk/src/peer_manager/peer_manager.spec.ts
@@ -48,9 +48,9 @@ describe("PeerManager", () => {
     ];
     sinon.stub(libp2p, "getConnections").returns(connections);
 
-    const peer = await peerManager.requestRenew("1");
-    expect(peer).to.not.be.undefined;
-    expect(peer?.id).to.not.equal("1");
+    const peerId = await peerManager.requestRenew("1");
+    expect(peerId).to.not.be.undefined;
+    expect(peerId).to.not.equal("1");
   });
 
   it("should handle connection events", () => {

--- a/packages/sdk/src/store/store.ts
+++ b/packages/sdk/src/store/store.ts
@@ -1,4 +1,4 @@
-import type { Peer } from "@libp2p/interface";
+import type { PeerId } from "@libp2p/interface";
 import { ConnectionManager, StoreCore } from "@waku/core";
 import {
   IDecodedMessage,
@@ -223,26 +223,29 @@ export class Store implements IStore {
     };
   }
 
-  private async getPeerToUse(): Promise<Peer | undefined> {
-    let peer: Peer | undefined;
+  private async getPeerToUse(): Promise<PeerId | undefined> {
+    let peerId: PeerId | undefined;
 
     if (this.options?.peer) {
       const connectedPeers = await this.connectionManager.getConnectedPeers();
 
-      peer = connectedPeers.find((p) => p.id.toString() === this.options?.peer);
+      const peer = connectedPeers.find(
+        (p) => p.id.toString() === this.options?.peer
+      );
+      peerId = peer?.id;
 
-      if (!peer) {
+      if (!peerId) {
         log.warn(
           `Passed node to use for Store not found: ${this.options.peer}. Attempting to use random peers.`
         );
       }
     }
 
-    const peers = await this.peerManager.getPeers();
+    const peerIds = await this.peerManager.getPeers();
 
-    if (peers.length > 0) {
+    if (peerIds.length > 0) {
       // TODO(weboko): implement smart way of getting a peer https://github.com/waku-org/js-waku/issues/2243
-      return peers[Math.floor(Math.random() * peers.length)];
+      return peerIds[Math.floor(Math.random() * peerIds.length)];
     }
 
     log.error("No peers available to use.");


### PR DESCRIPTION
### Problem / Description
<!--
What problem does this PR address?
Clearly describe the issue or feature the PR aims to solve.
-->
During core protocol operations we often await `peerStore` to get us `Peer` based on `PeerId`.
Upon looking into the code, it appears as unnecessary step. 

### Solution
<!--
Describe how the problem is solved in this PR.
- Provide an overview of the changes made.
- Highlight any significant design decisions or architectural changes.
-->
Replace that usage.

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->
- Resolves https://github.com/waku-org/js-waku/issues/2232

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [x] Code changes are **covered by e2e tests**, if applicable.
- [x] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [x] All **CI checks** pass successfully.
