### PR TITLE
chore: sds and rln before tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
         "packages/sdk",
         "packages/relay",
         "packages/tests",
+        "packages/sds",
+        "packages/rln",
         "packages/browser-tests",
         "packages/build-utils",
-        "packages/react-native-polyfills",
-        "packages/sds",
-        "packages/rln"
+        "packages/react-native-polyfills"
       ],
       "dependencies": {
         "@waku/utils": "^0.0.21"

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "packages/message-encryption",
     "packages/sdk",
     "packages/relay",
+    "packages/sds",
+    "packages/rln",
     "packages/tests",
     "packages/browser-tests",
     "packages/build-utils",
-    "packages/react-native-polyfills",
-    "packages/sds",
-    "packages/rln"
+    "packages/react-native-polyfills"
   ],
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
### Problem / Description
We currently build/run tests on core/functionality packages like RLN and SDS **after** `tests`. We should have tests run mostly at the end, with scope to extend SDS/RLN tests into the `tests` package.

### Solution
This PR rearranges the monorepo setup to build/test functional packages like RLN and SDS before the tests suite package.

### Notes


---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
