### PR TITLE
feat(sds): adds ephemeral messages, delivered message callback and event

### DIFF
--- a/packages/sds/package.json
+++ b/packages/sds/package.json
@@ -59,6 +59,7 @@
         "node": ">=20"
     },
     "dependencies": {
+        "@libp2p/interface": "^2.7.0",
         "@noble/hashes": "^1.7.1",
         "@waku/message-hash": "^0.1.18",
         "@waku/proto": "^0.0.9",


### PR DESCRIPTION
### Problem / Description
<!--
What problem does this PR address?
Clearly describe the issue or feature the PR aims to solve.
-->

Per the [spec](https://rfc.vac.dev/vac/raw/sds/#ephemeral-messages), SDS optionally supports ephemeral messages. These are messages that do not have the same persistence/reliability requirements as regular messages, and effectively skip the buffers.

Part of the requirement is that they are delivered right away upon receipt, which revealed that there's currently no way to notify the library consumer when a message reaches the delivered state.

### Solution
<!--
Describe how the problem is solved in this PR.
- Provide an overview of the changes made.
- Highlight any significant design decisions or architectural changes.
-->

Add a function for sending ephemeral messages.
Add an optional callback for delivered messages that is called whenever a message reaches that state.
Use libp2p event emitter to emit an event with the message ID when a message is delivered.
The number of optional arguments in the class constructor was getting large so I replaced it with a single options struct.

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->
- Resolves https://github.com/waku-org/js-waku/issues/2259
- Depends on https://github.com/waku-org/js-waku/pull/2293

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
