### PR TITLE
doc: build first to avoid not found deps issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ To build and test this repository, you need:
 - [Node.js & npm](https://nodejs.org/en/).
 - Chrome (for browser testing).
 
+Run `npm run build` at least once so that intra-dependencies are resolved.
+
 To ensure interoperability with [nim-waku](https://github.com/status-im/nim-waku/), some tests are run against a nim-waku node.
 This is why the relevant docker images for the node is pulled as part of the `pretest` script that runs before `npm run test`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6344,41 +6344,6 @@
         "node": ">=v12.0.0"
       }
     },
-    "node_modules/@leichtgewicht/base64-codec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/base64-codec/-/base64-codec-1.0.0.tgz",
-      "integrity": "sha512-0cgP4lRBzh3F4tlpTfs7F+PJyBN8j5yUC9KrQFWp/bREswgzZVHE8T1rNyRDWgvALwwpPtnJDQfqWUmxI33Epg==",
-      "license": "MIT"
-    },
-    "node_modules/@leichtgewicht/dns-packet": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/dns-packet/-/dns-packet-6.0.3.tgz",
-      "integrity": "sha512-qmVHhFBFiBvPsk/wJ/EdoWHb+tGkzY4haybmDPukhF6w0+8wpEbrHTIRE9LzeUu2P0bAbmrK8WOXt5V5QN6jQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@leichtgewicht/ip-codec": "^2.0.4",
-        "bytes.js": "^0.0.2",
-        "utf8-bytes": "^0.0.1",
-        "utf8-codec": "^1.0.0",
-        "utf8-length": "^0.0.1",
-        "utf8-string-bytes": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@leichtgewicht/dns-socket": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/dns-socket/-/dns-socket-5.0.0.tgz",
-      "integrity": "sha512-Sbrn/OG0HTTPGSkwIDCHy8/tUI6UglIzFsMNjzZn/Na1/i5owSm6rVi9CfKNNjRcUlYEzICELYW6EoZdjwVY2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@leichtgewicht/dns-packet": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -14168,12 +14133,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/bytes.js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/bytes.js/-/bytes.js-0.0.2.tgz",
-      "integrity": "sha512-KrLm4hv5Qs9w6b0U7h1bCdqxrsf+e9QMsfHeyQFzAz94x/5Aqa+FTEUSNBtt5d2VuV3Hfiea3c4ti74RZDDYkg==",
-      "license": "MIT"
-    },
     "node_modules/c8": {
       "version": "10.1.3",
       "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
@@ -17094,6 +17053,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/dns-over-http-resolver": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-3.0.8.tgz",
+      "integrity": "sha512-ng8JaOf34kdLE9Ni8U8rxHrrHtNKKBzW4oC1Zv68EmNnmt6SIYOahI3ZWYvD+N/9dQfCHlMivHQrCxhjAKWlnA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "quick-lru": "^7.0.0",
+        "weald": "^1.0.2"
+      }
+    },
+    "node_modules/dns-over-http-resolver/node_modules/quick-lru": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.0.tgz",
+      "integrity": "sha512-MX8gB7cVYTrYcFfAnfLlhRd0+Toyl8yX8uBx1MrX7K0jegiz9TumwOK27ldXrgDlHRdVi+MqU9Ssw6dr4BNreg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -17104,22 +17085,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/dns-query": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/dns-query/-/dns-query-0.11.2.tgz",
-      "integrity": "sha512-zF8qxQpqCB467o4A63DLpQClo77H642JEKMx0Ra9GFww7Rx0234Fo8NoG0LBoSBZxamWkXfLxhzDG19bTBHvXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@leichtgewicht/base64-codec": "^1.0.0",
-        "@leichtgewicht/dns-packet": "^6.0.2",
-        "@leichtgewicht/dns-socket": "^5.0.0",
-        "@leichtgewicht/ip-codec": "^2.0.4",
-        "utf8-codec": "^1.0.0"
-      },
-      "bin": {
-        "dns-query": "bin/dns-query"
       }
     },
     "node_modules/docker-modem": {
@@ -40957,30 +40922,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/utf8-bytes": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
-      "integrity": "sha512-GifWmJAx2qAXT+lZLhbkWhBsy7pr6xWHiPWlVToDiELdWgZwt4Ogjf9tlgvKuALzTFR/d+EPQQI9ogJV3957Jg==",
-      "license": "MIT"
-    },
-    "node_modules/utf8-codec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
-      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
-      "license": "MIT"
-    },
-    "node_modules/utf8-length": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/utf8-length/-/utf8-length-0.0.1.tgz",
-      "integrity": "sha512-j/XH2ftofBiobnyApxlN/J6j/ixwT89WEjDcjT66d2i0+GIn9RZfzt8lpEXXE4jUe4NsjBSUq70kS2euQ4nnMw==",
-      "license": "MIT"
-    },
-    "node_modules/utf8-string-bytes": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/utf8-string-bytes/-/utf8-string-bytes-1.0.3.tgz",
-      "integrity": "sha512-i/I1Omf6lADjVBlwJpQifZOePV15snHny9w04+lc71+3t8PyWuLC/7clyoOSHOBNGXFe2PAGxmTiZ+Z4HWsPyw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/util": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -42119,7 +42060,7 @@
         "@waku/proto": "^0.0.8",
         "@waku/utils": "0.0.21",
         "debug": "^4.3.4",
-        "dns-query": "^0.11.2",
+        "dns-over-http-resolver": "^3.0.8",
         "hi-base32": "^0.5.1",
         "uint8arrays": "^5.0.1"
       },

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -51,13 +51,13 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@waku/core": "0.0.33",
+    "@waku/enr": "0.0.27",
     "@waku/interfaces": "0.0.28",
     "@waku/proto": "^0.0.8",
-    "@waku/enr": "0.0.27",
-    "@waku/core": "0.0.33",
     "@waku/utils": "0.0.21",
     "debug": "^4.3.4",
-    "dns-query": "^0.11.2",
+    "dns-over-http-resolver": "^3.0.8",
     "hi-base32": "^0.5.1",
     "uint8arrays": "^5.0.1"
   },

--- a/packages/tests/tests/waku.node.optional.spec.ts
+++ b/packages/tests/tests/waku.node.optional.spec.ts
@@ -1,30 +1,13 @@
-import { bootstrap } from "@libp2p/bootstrap";
 import { enrTree, wakuDnsDiscovery } from "@waku/discovery";
 import { LightNode } from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
 import { expect } from "chai";
 
-import {
-  afterEachCustom,
-  makeLogFileName,
-  ServiceNode,
-  tearDownNodes
-} from "../src/index.js";
-
 describe("Use static and several ENR trees for bootstrap", function () {
   let waku: LightNode;
-  let nwaku: ServiceNode;
-
-  afterEachCustom(this, async () => {
-    await tearDownNodes(nwaku, waku);
-  });
 
   it("", async function () {
     this.timeout(10_000);
-
-    nwaku = new ServiceNode(makeLogFileName(this));
-    await nwaku.start();
-    const multiAddrWithId = await nwaku.getMultiaddrWithId();
 
     const NODE_REQUIREMENTS = {
       store: 3,
@@ -35,7 +18,6 @@ describe("Use static and several ENR trees for bootstrap", function () {
     waku = await createLightNode({
       libp2p: {
         peerDiscovery: [
-          bootstrap({ list: [multiAddrWithId.toString()] }),
           wakuDnsDiscovery(
             [enrTree["SANDBOX"], enrTree["TEST"]],
             NODE_REQUIREMENTS
@@ -47,13 +29,7 @@ describe("Use static and several ENR trees for bootstrap", function () {
 
     const peersDiscovered = await waku.libp2p.peerStore.all();
 
-    // 3 from DNS Disc, 1 from bootstrap
-    expect(peersDiscovered.length).to.eq(3 + 1);
-    // should also have the bootstrap peer
-    expect(
-      peersDiscovered.find(
-        (p) => p.id.toString() === multiAddrWithId.getPeerId()?.toString()
-      )
-    ).to.not.be.undefined;
+    // 3 from DNS Disc
+    expect(peersDiscovered.length).to.eq(3);
   });
 });


### PR DESCRIPTION
### Problem / Description

XMLHttpRequest is a deprecated API and not available in browser extension.

### Solution

Remove dependency that uses XMLHttpRequest, for a modern one that uses fetch API

### Notes

The resulting changes are less configurable (removed option to set retries and DNS-over-HTTP servers). I am assuming no one uses those options.
If someone does, it is pretty easy to re-add them.

#### Checklist
- [ ] ~Code changes are **covered by unit tests**.~ the library relies on external infra (DNS-Over-HTTPS servers) so can't do a unit test
- [ ] ~Code changes are **covered by e2e tests**, if applicable.~ the library relies on external infra (DNS-Over-HTTPS servers) so can't do e2e test
- [x] **Dogfooding has been performed**, if feasible. yes, I tested with my chrome extension and DNS Discovery works
- [ ] A **test version has been published**, if required. (Not sure what you mean)
- [ ] All **CI checks** pass successfully.  (Don't you have a CI for that?)
