### PR TITLE
fix: npm action branch detection

### DIFF
--- a/.github/actions/npm/action.yml
+++ b/.github/actions/npm/action.yml
@@ -3,12 +3,8 @@ name: npm i
 runs:
   using: "composite"
   steps:
-    - run: echo "$GITHUB_CONTEXT"
+    - if: ${{ github.ref == 'refs/heads/master' || github.head_ref == 'release-please--branches--master' }}
+      run: npm i
       shell: bash
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-    - run: npm i
-      shell: bash
-      if: ${{ contains('refs/heads/master refs/heads/release-please--branches--master', github.ref) }}
-    - uses: bahmutov/npm-install@v1
-      if: ${{ !contains('refs/heads/master refs/heads/release-please--branches--master', github.ref) }}
+    - if: ${{ github.ref != 'refs/heads/master' && github.head_ref != 'release-please--branches--master' }}
+      uses: bahmutov/npm-install@v1


### PR DESCRIPTION
### Problem / Description
<!--
What problem does this PR address?
Clearly describe the issue or feature the PR aims to solve.
-->
`npm i` custom command fails to resolve dependencies on releases

### Solution
<!--
Describe how the problem is solved in this PR.
- Provide an overview of the changes made.
- Highlight any significant design decisions or architectural changes.
-->
It seems some changes were done to Github context and `ref` cannot be used for detecting branch names. 

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->
- Resolves https://github.com/waku-org/js-waku/issues/2296
- Related to https://github.com/waku-org/js-waku/pull/2304

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [x] Code changes are **covered by e2e tests**, if applicable.
- [x] **Dogfooding has been performed**, if feasible.
- [x] A **test version has been published**, if required.
- [x] All **CI checks** pass successfully.
