### PR TITLE
fix: do not use waku test fleet as default bootstrap

### DIFF
--- a/packages/sdk/src/create/discovery.ts
+++ b/packages/sdk/src/create/discovery.ts
@@ -10,7 +10,7 @@ import { type Libp2pComponents, PubsubTopic } from "@waku/interfaces";
 export function defaultPeerDiscoveries(
   pubsubTopics: PubsubTopic[]
 ): ((components: Libp2pComponents) => PeerDiscovery)[] {
-  const dnsEnrTrees = [enrTree["SANDBOX"], enrTree["TEST"]];
+  const dnsEnrTrees = [enrTree["SANDBOX"]];
 
   const discoveries = [
     wakuDnsDiscovery(dnsEnrTrees),

--- a/packages/tests/tests/waku.node.optional.spec.ts
+++ b/packages/tests/tests/waku.node.optional.spec.ts
@@ -18,10 +18,7 @@ describe("Use static and several ENR trees for bootstrap", function () {
     waku = await createLightNode({
       libp2p: {
         peerDiscovery: [
-          wakuDnsDiscovery(
-            [enrTree["SANDBOX"], enrTree["TEST"]],
-            NODE_REQUIREMENTS
-          )
+          wakuDnsDiscovery([enrTree["SANDBOX"]], NODE_REQUIREMENTS)
         ]
       }
     });


### PR DESCRIPTION
### Problem / Description

The waku test fleet is unstable and should not be used as boostrap.

The issue is that DNS Discovery looks for "2" nodes and stop there. Meaning that if those "discovered" nodes are not reachable (ie, coming from test suite). js-waku does not connect.

### Solution

Only use waku sandbox as default boostrap\

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->
- Resolves
- Related to

---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [x] Code changes are **covered by e2e tests**, if applicable.
- [x] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
