### PR TITLE
chore: skip flaky test due to nwaku bug

### DIFF
--- a/packages/tests/src/utils/nodes.ts
+++ b/packages/tests/src/utils/nodes.ts
@@ -68,6 +68,15 @@ export async function runMultipleNodes(
 
   await waitForConnections(numServiceNodes, waku);
 
+  for (let i = 0; i < serviceNodes.nodes.length; i++) {
+    const node = serviceNodes.nodes[i];
+    const peers = await node.peers();
+
+    if (peers.length < 1) {
+      throw new Error(`Expected at least 1 connection for nwaku.`);
+    }
+  }
+
   return [serviceNodes, waku];
 }
 

--- a/packages/tests/tests/light-push/index.node.spec.ts
+++ b/packages/tests/tests/light-push/index.node.spec.ts
@@ -65,7 +65,8 @@ const runTests = (strictNodeCheck: boolean): void => {
       });
     });
 
-    it("Push 30 different messages", async function () {
+    // TODO: skiped till https://github.com/waku-org/nwaku/issues/3369 resolved
+    it.skip("Push 30 different messages", async function () {
       const generateMessageText = (index: number): string => `M${index}`;
 
       for (let i = 0; i < 30; i++) {

--- a/packages/tests/tests/light-push/index.node.spec.ts
+++ b/packages/tests/tests/light-push/index.node.spec.ts
@@ -283,4 +283,4 @@ const runTests = (strictNodeCheck: boolean): void => {
   });
 };
 
-[true].map(runTests);
+[true, false].map(runTests);


### PR DESCRIPTION
### Problem / Description
<!--
What problem does this PR address?
Clearly describe the issue or feature the PR aims to solve.
-->
`nwaku` has a bug that makes one test case flaky
https://github.com/waku-org/nwaku/issues/3369

### Solution
<!--
Describe how the problem is solved in this PR.
- Provide an overview of the changes made.
- Highlight any significant design decisions or architectural changes.
-->
Skip the test and make a blocking task on js-waku side.

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->
- Related to https://github.com/waku-org/js-waku/issues/2176
