### PR TITLE
fix: health indicator properly handle peer:identify event

### DIFF
--- a/packages/sdk/src/health_indicator/health_indicator.spec.ts
+++ b/packages/sdk/src/health_indicator/health_indicator.spec.ts
@@ -60,7 +60,9 @@ describe("HealthIndicator", () => {
     sinon.stub(libp2p, "getConnections").returns(connections);
     sinon.stub(libp2p.peerStore, "get").resolves(peer);
 
-    libp2p.dispatchEvent(new CustomEvent("peer:connect", { detail: "1" }));
+    libp2p.dispatchEvent(
+      new CustomEvent("peer:identify", { detail: { peerId: "1" } })
+    );
 
     const changedStatus = await statusChangePromise;
     expect(changedStatus).to.equal(HealthStatus.MinimallyHealthy);
@@ -84,7 +86,9 @@ describe("HealthIndicator", () => {
     peerStoreStub.withArgs(connections[0].remotePeer).resolves(peer1);
     peerStoreStub.withArgs(connections[1].remotePeer).resolves(peer2);
 
-    libp2p.dispatchEvent(new CustomEvent("peer:connect", { detail: "2" }));
+    libp2p.dispatchEvent(
+      new CustomEvent("peer:identify", { detail: { peerId: "2" } })
+    );
 
     const changedStatus = await statusChangePromise;
     expect(changedStatus).to.equal(HealthStatus.SufficientlyHealthy);
@@ -99,9 +103,13 @@ describe("HealthIndicator", () => {
 
     healthIndicator.start();
     expect(addEventSpy.calledTwice).to.be.true;
+    expect(addEventSpy.firstCall.args[0]).to.equal("peer:identify");
+    expect(addEventSpy.secondCall.args[0]).to.equal("peer:disconnect");
 
     healthIndicator.stop();
     expect(removeEventSpy.calledTwice).to.be.true;
+    expect(removeEventSpy.firstCall.args[0]).to.equal("peer:identify");
+    expect(removeEventSpy.secondCall.args[0]).to.equal("peer:disconnect");
   });
 });
 


### PR DESCRIPTION
### Problem / Description
<!--
What problem does this PR address?
Clearly describe the issue or feature the PR aims to solve.
-->
`HealthIndicator` was using `peer:connect` to identify presence of peers and map their protocols.
Unfortunately it seems that when `peer:connect` is fired, the peer is not yet was identified. 
Due to that we need to use `peer:identify` event.

### Solution
<!--
Describe how the problem is solved in this PR.
- Provide an overview of the changes made.
- Highlight any significant design decisions or architectural changes.
-->
User `peer:identify` event.

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->
- Resolves https://github.com/waku-org/js-waku/issues/2327

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [x] Code changes are **covered by e2e tests**, if applicable.
- [x] **Dogfooding has been performed**, if feasible.
- ~[ ] A **test version has been published**, if required.~
- [x] All **CI checks** pass successfully.
