### PR TITLE
fix(store): update store query validation logic to support msg hash q…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11727,6 +11727,18 @@
       "resolved": "packages/message-encryption",
       "link": true
     },
+    "node_modules/@waku/message-hash": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@waku/message-hash/-/message-hash-0.1.19.tgz",
+      "integrity": "sha512-fl+qky3MQK8l3HTT5wq23NcdYFYNqVcUVwBblX9/IArcDlDNjEEdK68K3n8rFWxBBd2JAK0RxU7MMkLiK3vWUA==",
+      "dependencies": {
+        "@noble/hashes": "^1.3.2",
+        "@waku/utils": "0.0.23"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@waku/proto": {
       "resolved": "packages/proto",
       "link": true
@@ -44183,6 +44195,7 @@
         "@types/lodash": "^4.17.15",
         "@types/sinon": "^17.0.3",
         "@waku/build-utils": "^1.0.0",
+        "@waku/interfaces": "0.0.30",
         "@waku/message-encryption": "^0.0.33",
         "deep-equal-in-any-order": "^2.0.6",
         "fast-check": "^3.23.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44574,6 +44574,7 @@
         "@waku/core": "*",
         "@waku/enr": "*",
         "@waku/interfaces": "*",
+        "@waku/message-hash": "^0.1.17",
         "@waku/utils": "*",
         "app-root-path": "^3.1.0",
         "chai-as-promised": "^7.1.1",

--- a/packages/core/src/lib/message_hash/message_hash.spec.ts
+++ b/packages/core/src/lib/message_hash/message_hash.spec.ts
@@ -1,4 +1,4 @@
-import type { IDecodedMessage, IProtoMessage } from "@waku/interfaces";
+import type { IProtoMessage } from "@waku/interfaces";
 import { bytesToHex, hexToBytes } from "@waku/utils/bytes";
 import { expect } from "chai";
 
@@ -93,19 +93,20 @@ describe("Message Hash: RFC Test Vectors", () => {
     expect(bytesToHex(hash)).to.equal(expectedHash);
   });
 
-  it("Waku message hash computation (message is IDecodedMessage)", () => {
+  it("Waku message hash computation (message is IProtoMessage with version)", () => {
     const expectedHash =
       "3f11bc950dce0e3ffdcf205ae6414c01130bb5d9f20644869bff80407fa52c8f";
     const pubsubTopic = "/waku/2/default-waku/proto";
-    const message: IDecodedMessage = {
-      version: 0,
+    const message: IProtoMessage = {
       payload: new Uint8Array(),
-      pubsubTopic,
       contentTopic: "/waku/2/default-content/proto",
       meta: hexToBytes("0x73757065722d736563726574"),
-      timestamp: new Date("2024-04-30T10:54:14.978Z"),
+      timestamp:
+        BigInt(new Date("2024-04-30T10:54:14.978Z").getTime()) *
+        BigInt(1000000),
       ephemeral: undefined,
-      rateLimitProof: undefined
+      rateLimitProof: undefined,
+      version: 0
     };
     const hash = messageHash(pubsubTopic, message);
     expect(bytesToHex(hash)).to.equal(expectedHash);
@@ -144,16 +145,17 @@ describe("messageHash and messageHashStr", () => {
     expect(hashStr).to.equal(hashStrFromBytes);
   });
 
-  it("messageHashStr works with IDecodedMessage", () => {
-    const decodedMessage: IDecodedMessage = {
-      version: 0,
+  it("messageHashStr works with IProtoMessage", () => {
+    const decodedMessage: IProtoMessage = {
       payload: new Uint8Array([1, 2, 3, 4]),
-      pubsubTopic,
       contentTopic: "/waku/2/default-content/proto",
       meta: new Uint8Array([5, 6, 7, 8]),
-      timestamp: new Date("2024-04-30T10:54:14.978Z"),
+      timestamp:
+        BigInt(new Date("2024-04-30T10:54:14.978Z").getTime()) *
+        BigInt(1000000),
       ephemeral: undefined,
-      rateLimitProof: undefined
+      rateLimitProof: undefined,
+      version: 0
     };
 
     const hashStr = messageHashStr(pubsubTopic, decodedMessage);

--- a/packages/core/src/lib/store/rpc.spec.ts
+++ b/packages/core/src/lib/store/rpc.spec.ts
@@ -1,0 +1,93 @@
+import { expect } from "chai";
+
+import { StoreQueryRequest } from "./rpc.js";
+
+describe("StoreQueryRequest validation", () => {
+  it("accepts valid content-filtered query", () => {
+    const request = StoreQueryRequest.create({
+      pubsubTopic: "/waku/2/default-waku/proto",
+      contentTopics: ["/test/1/content/proto"],
+      includeData: true,
+      paginationForward: true
+    });
+    expect(request).to.exist;
+  });
+
+  it("rejects content-filtered query with only pubsubTopic", () => {
+    expect(() =>
+      StoreQueryRequest.create({
+        pubsubTopic: "/waku/2/default-waku/proto",
+        contentTopics: [], // Empty array
+        includeData: true,
+        paginationForward: true
+      })
+    ).to.throw(
+      "Both pubsubTopic and contentTopics must be set together for content-filtered queries"
+    );
+  });
+
+  it("rejects content-filtered query with only contentTopics", () => {
+    expect(() =>
+      StoreQueryRequest.create({
+        pubsubTopic: "", // Empty string
+        contentTopics: ["/test/1/content/proto"],
+        includeData: true,
+        paginationForward: true
+      })
+    ).to.throw(
+      "Both pubsubTopic and contentTopics must be set together for content-filtered queries"
+    );
+  });
+
+  it("accepts valid message hash query", () => {
+    const request = StoreQueryRequest.create({
+      pubsubTopic: "", // Required but ignored for hash queries
+      contentTopics: [], // Required but ignored for hash queries
+      messageHashes: [new Uint8Array([1, 2, 3, 4])],
+      includeData: true,
+      paginationForward: true
+    });
+    expect(request).to.exist;
+  });
+
+  it("rejects hash query with content filter parameters", () => {
+    expect(() =>
+      StoreQueryRequest.create({
+        messageHashes: [new Uint8Array([1, 2, 3, 4])],
+        pubsubTopic: "/waku/2/default-waku/proto",
+        contentTopics: ["/test/1/content/proto"],
+        includeData: true,
+        paginationForward: true
+      })
+    ).to.throw(
+      "Message hash lookup queries cannot include content filter criteria"
+    );
+  });
+
+  it("rejects hash query with time filter", () => {
+    expect(() =>
+      StoreQueryRequest.create({
+        pubsubTopic: "",
+        contentTopics: [],
+        messageHashes: [new Uint8Array([1, 2, 3, 4])],
+        timeStart: new Date(),
+        includeData: true,
+        paginationForward: true
+      })
+    ).to.throw(
+      "Message hash lookup queries cannot include content filter criteria"
+    );
+  });
+
+  it("accepts time-filtered query with content filter", () => {
+    const request = StoreQueryRequest.create({
+      pubsubTopic: "/waku/2/default-waku/proto",
+      contentTopics: ["/test/1/content/proto"],
+      timeStart: new Date(Date.now() - 3600000),
+      timeEnd: new Date(),
+      includeData: true,
+      paginationForward: true
+    });
+    expect(request).to.exist;
+  });
+});

--- a/packages/core/src/lib/store/rpc.spec.ts
+++ b/packages/core/src/lib/store/rpc.spec.ts
@@ -17,7 +17,7 @@ describe("StoreQueryRequest validation", () => {
     expect(() =>
       StoreQueryRequest.create({
         pubsubTopic: "/waku/2/default-waku/proto",
-        contentTopics: [], // Empty array
+        contentTopics: [],
         includeData: true,
         paginationForward: true
       })
@@ -29,7 +29,7 @@ describe("StoreQueryRequest validation", () => {
   it("rejects content-filtered query with only contentTopics", () => {
     expect(() =>
       StoreQueryRequest.create({
-        pubsubTopic: "", // Empty string
+        pubsubTopic: "",
         contentTopics: ["/test/1/content/proto"],
         includeData: true,
         paginationForward: true
@@ -41,8 +41,8 @@ describe("StoreQueryRequest validation", () => {
 
   it("accepts valid message hash query", () => {
     const request = StoreQueryRequest.create({
-      pubsubTopic: "", // Required but ignored for hash queries
-      contentTopics: [], // Required but ignored for hash queries
+      pubsubTopic: "",
+      contentTopics: [],
       messageHashes: [new Uint8Array([1, 2, 3, 4])],
       includeData: true,
       paginationForward: true

--- a/packages/core/src/lib/store/rpc.ts
+++ b/packages/core/src/lib/store/rpc.ts
@@ -28,22 +28,18 @@ export class StoreQueryRequest {
         : undefined
     });
 
-    // Validate request parameters based on RFC
     const isHashQuery = params.messageHashes && params.messageHashes.length > 0;
     const hasContentTopics =
       params.contentTopics && params.contentTopics.length > 0;
     const hasTimeFilter = params.timeStart || params.timeEnd;
 
     if (isHashQuery) {
-      // Message hash lookup queries cannot include content topics or time filters
-      // but pubsubTopic is allowed/required
       if (hasContentTopics || hasTimeFilter) {
         throw new Error(
           "Message hash lookup queries cannot include content filter criteria (contentTopics, timeStart, or timeEnd)"
         );
       }
     } else {
-      // Content-filtered queries require both pubsubTopic and contentTopics to be set together
       if (
         (params.pubsubTopic &&
           (!params.contentTopics || params.contentTopics.length === 0)) ||

--- a/packages/core/src/lib/store/rpc.ts
+++ b/packages/core/src/lib/store/rpc.ts
@@ -14,6 +14,7 @@ export class StoreQueryRequest {
   public static create(params: QueryRequestParams): StoreQueryRequest {
     const request = new StoreQueryRequest({
       ...params,
+      contentTopics: params.contentTopics || [],
       requestId: uuid(),
       timeStart: params.timeStart
         ? BigInt(params.timeStart.getTime() * ONE_MILLION)
@@ -28,25 +29,32 @@ export class StoreQueryRequest {
     });
 
     // Validate request parameters based on RFC
-    if (
-      (params.pubsubTopic && !params.contentTopics) ||
-      (!params.pubsubTopic && params.contentTopics)
-    ) {
-      throw new Error(
-        "Both pubsubTopic and contentTopics must be set or unset"
-      );
-    }
+    const isHashQuery = params.messageHashes && params.messageHashes.length > 0;
+    const hasContentTopics =
+      params.contentTopics && params.contentTopics.length > 0;
+    const hasTimeFilter = params.timeStart || params.timeEnd;
 
-    if (
-      params.messageHashes &&
-      (params.pubsubTopic ||
-        params.contentTopics ||
-        params.timeStart ||
-        params.timeEnd)
-    ) {
-      throw new Error(
-        "Message hash lookup queries cannot include content filter criteria"
-      );
+    if (isHashQuery) {
+      // Message hash lookup queries cannot include content topics or time filters
+      // but pubsubTopic is allowed/required
+      if (hasContentTopics || hasTimeFilter) {
+        throw new Error(
+          "Message hash lookup queries cannot include content filter criteria (contentTopics, timeStart, or timeEnd)"
+        );
+      }
+    } else {
+      // Content-filtered queries require both pubsubTopic and contentTopics to be set together
+      if (
+        (params.pubsubTopic &&
+          (!params.contentTopics || params.contentTopics.length === 0)) ||
+        (!params.pubsubTopic &&
+          params.contentTopics &&
+          params.contentTopics.length > 0)
+      ) {
+        throw new Error(
+          "Both pubsubTopic and contentTopics must be set together for content-filtered queries"
+        );
+      }
     }
 
     return request;

--- a/packages/sdk/src/store/store.ts
+++ b/packages/sdk/src/store/store.ts
@@ -57,10 +57,32 @@ export class Store implements IStore {
     decoders: IDecoder<T>[],
     options?: Partial<QueryRequestParams>
   ): AsyncGenerator<Promise<T | undefined>[]> {
-    const { pubsubTopic, contentTopics, decodersAsMap } =
-      this.validateDecodersAndPubsubTopic(decoders);
+    // For message hash queries, don't validate decoders but still need decodersAsMap
+    const isHashQuery =
+      options?.messageHashes && options.messageHashes.length > 0;
 
-    const queryOpts = {
+    let pubsubTopic: string;
+    let contentTopics: string[];
+    let decodersAsMap: Map<string, IDecoder<T>>;
+
+    if (isHashQuery) {
+      // For hash queries, we still need decoders to decode messages
+      // but we don't validate pubsubTopic consistency
+      // Use pubsubTopic from options if provided, otherwise from first decoder
+      pubsubTopic = options.pubsubTopic || decoders[0]?.pubsubTopic || "";
+      contentTopics = [];
+      decodersAsMap = new Map();
+      decoders.forEach((dec) => {
+        decodersAsMap.set(dec.contentTopic, dec);
+      });
+    } else {
+      const validated = this.validateDecodersAndPubsubTopic(decoders);
+      pubsubTopic = validated.pubsubTopic;
+      contentTopics = validated.contentTopics;
+      decodersAsMap = validated.decodersAsMap;
+    }
+
+    const queryOpts: QueryRequestParams = {
       pubsubTopic,
       contentTopics,
       includeData: true,

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -55,6 +55,7 @@
     "@waku/core": "*",
     "@waku/enr": "*",
     "@waku/interfaces": "*",
+    "@waku/message-hash": "^0.1.17",
     "@waku/utils": "*",
     "app-root-path": "^3.1.0",
     "chai-as-promised": "^7.1.1",

--- a/packages/tests/tests/store/message_hash.spec.ts
+++ b/packages/tests/tests/store/message_hash.spec.ts
@@ -1,0 +1,104 @@
+import { DecodedMessage } from "@waku/core";
+import type { LightNode } from "@waku/interfaces";
+import { messageHash } from "@waku/message-hash";
+import { assert } from "chai";
+
+import {
+  afterEachCustom,
+  beforeEachCustom,
+  ServiceNode,
+  tearDownNodes
+} from "../../src/index.js";
+
+import {
+  runStoreNodes,
+  sendMessages,
+  TestDecoder,
+  TestShardInfo,
+  totalMsgs
+} from "./utils.js";
+
+describe("Waku Store, message hash query", function () {
+  this.timeout(15000);
+  let waku: LightNode;
+  let nwaku: ServiceNode;
+
+  beforeEachCustom(this, async () => {
+    [nwaku, waku] = await runStoreNodes(this.ctx, TestShardInfo);
+  });
+
+  afterEachCustom(this, async () => {
+    await tearDownNodes(nwaku, [waku]);
+  });
+
+  it("can query messages normally", async function () {
+    await sendMessages(
+      nwaku,
+      totalMsgs,
+      TestDecoder.contentTopic,
+      TestDecoder.pubsubTopic,
+      true
+    );
+
+    const messages: DecodedMessage[] = [];
+    for await (const page of waku.store.queryGenerator([TestDecoder])) {
+      for await (const msg of page) {
+        messages.push(msg as DecodedMessage);
+      }
+    }
+
+    assert.equal(messages.length, totalMsgs);
+  });
+
+  it("can query messages by message hash", async function () {
+    const sentMessages = await sendMessages(
+      nwaku,
+      totalMsgs,
+      TestDecoder.contentTopic,
+      TestDecoder.pubsubTopic,
+      true
+    );
+    const messageHashes = sentMessages.map((msg) =>
+      messageHash(TestDecoder.pubsubTopic, {
+        pubsubTopic: TestDecoder.pubsubTopic,
+        payload: Buffer.from(msg.payload, "base64"),
+        contentTopic: msg.contentTopic || TestDecoder.contentTopic,
+        timestamp: msg.timestamp
+          ? new Date(Number(msg.timestamp / 1000000n))
+          : undefined,
+        meta: undefined,
+        rateLimitProof: undefined,
+        ephemeral: undefined
+      })
+    );
+
+    console.log("Sent messages:", sentMessages.length);
+    console.log("First message:", sentMessages[0]);
+    console.log("Message hashes:", messageHashes.length);
+    console.log("First hash:", messageHashes[0]);
+
+    const messages: DecodedMessage[] = [];
+    let pageCount = 0;
+    try {
+      for await (const page of waku.store.queryGenerator([TestDecoder], {
+        messageHashes,
+        pubsubTopic: TestDecoder.pubsubTopic
+      })) {
+        pageCount++;
+        console.log(`Page ${pageCount} received`);
+        for await (const msg of page) {
+          messages.push(msg as DecodedMessage);
+        }
+      }
+    } catch (error) {
+      console.error("Error during query:", error);
+      throw error;
+    }
+    console.log("Total pages:", pageCount);
+    console.log("Total messages received:", messages.length);
+    assert.equal(messages.length, messageHashes.length);
+    for (const msg of messages) {
+      assert.equal(msg.contentTopic, TestDecoder.contentTopic);
+    }
+  });
+});

--- a/packages/tests/tests/store/message_hash.spec.ts
+++ b/packages/tests/tests/store/message_hash.spec.ts
@@ -1,7 +1,7 @@
 import { DecodedMessage } from "@waku/core";
-import type { LightNode } from "@waku/interfaces";
+import type { IDecodedMessage, LightNode } from "@waku/interfaces";
 import { messageHash } from "@waku/message-hash";
-import { assert } from "chai";
+import { assert, expect } from "chai";
 
 import {
   afterEachCustom,
@@ -40,14 +40,14 @@ describe("Waku Store, message hash query", function () {
       true
     );
 
-    const messages: DecodedMessage[] = [];
+    const messages: IDecodedMessage[] = [];
     for await (const page of waku.store.queryGenerator([TestDecoder])) {
       for await (const msg of page) {
-        messages.push(msg as DecodedMessage);
+        messages.push(msg as IDecodedMessage);
       }
     }
 
-    assert.equal(messages.length, totalMsgs);
+    expect(messages.length).to.equal(totalMsgs);
   });
 
   it("can query messages by message hash", async function () {
@@ -72,12 +72,7 @@ describe("Waku Store, message hash query", function () {
       })
     );
 
-    console.log("Sent messages:", sentMessages.length);
-    console.log("First message:", sentMessages[0]);
-    console.log("Message hashes:", messageHashes.length);
-    console.log("First hash:", messageHashes[0]);
-
-    const messages: DecodedMessage[] = [];
+    const messages: IDecodedMessage[] = [];
     let pageCount = 0;
     try {
       for await (const page of waku.store.queryGenerator([TestDecoder], {
@@ -85,20 +80,16 @@ describe("Waku Store, message hash query", function () {
         pubsubTopic: TestDecoder.pubsubTopic
       })) {
         pageCount++;
-        console.log(`Page ${pageCount} received`);
         for await (const msg of page) {
-          messages.push(msg as DecodedMessage);
+          messages.push(msg as IDecodedMessage);
         }
       }
     } catch (error) {
-      console.error("Error during query:", error);
       throw error;
     }
-    console.log("Total pages:", pageCount);
-    console.log("Total messages received:", messages.length);
-    assert.equal(messages.length, messageHashes.length);
+    expect(messages.length).to.equal(messageHashes.length);
     for (const msg of messages) {
-      assert.equal(msg.contentTopic, TestDecoder.contentTopic);
+      expect(msg.contentTopic).to.equal(TestDecoder.contentTopic);
     }
   });
 });

--- a/packages/tests/tests/store/message_hash.spec.ts
+++ b/packages/tests/tests/store/message_hash.spec.ts
@@ -1,7 +1,6 @@
-import { DecodedMessage } from "@waku/core";
 import type { IDecodedMessage, LightNode } from "@waku/interfaces";
 import { messageHash } from "@waku/message-hash";
-import { assert, expect } from "chai";
+import { expect } from "chai";
 
 import {
   afterEachCustom,
@@ -73,19 +72,13 @@ describe("Waku Store, message hash query", function () {
     );
 
     const messages: IDecodedMessage[] = [];
-    let pageCount = 0;
-    try {
-      for await (const page of waku.store.queryGenerator([TestDecoder], {
-        messageHashes,
-        pubsubTopic: TestDecoder.pubsubTopic
-      })) {
-        pageCount++;
-        for await (const msg of page) {
-          messages.push(msg as IDecodedMessage);
-        }
+    for await (const page of waku.store.queryGenerator([TestDecoder], {
+      messageHashes,
+      pubsubTopic: TestDecoder.pubsubTopic
+    })) {
+      for await (const msg of page) {
+        messages.push(msg as IDecodedMessage);
       }
-    } catch (error) {
-      throw error;
     }
     expect(messages.length).to.equal(messageHashes.length);
     for (const msg of messages) {

--- a/packages/tests/tests/store/message_hash.spec.ts
+++ b/packages/tests/tests/store/message_hash.spec.ts
@@ -1,5 +1,5 @@
+import { messageHash } from "@waku/core";
 import type { IDecodedMessage, LightNode } from "@waku/interfaces";
-import { messageHash } from "@waku/message-hash";
 import { expect } from "chai";
 
 import {
@@ -59,15 +59,13 @@ describe("Waku Store, message hash query", function () {
     );
     const messageHashes = sentMessages.map((msg) =>
       messageHash(TestDecoder.pubsubTopic, {
-        pubsubTopic: TestDecoder.pubsubTopic,
         payload: Buffer.from(msg.payload, "base64"),
         contentTopic: msg.contentTopic || TestDecoder.contentTopic,
-        timestamp: msg.timestamp
-          ? new Date(Number(msg.timestamp / 1000000n))
-          : undefined,
+        timestamp: msg.timestamp || undefined,
         meta: undefined,
         rateLimitProof: undefined,
-        ephemeral: undefined
+        ephemeral: undefined,
+        version: undefined
       })
     );
 

--- a/packages/tests/tests/store/utils.ts
+++ b/packages/tests/tests/store/utils.ts
@@ -17,6 +17,7 @@ import { expect } from "chai";
 import { Context } from "mocha";
 
 import { delay, NOISE_KEY_1, runNodes, ServiceNode } from "../../src/index.js";
+import { MessageRpcQuery } from "../../src/types.js";
 
 export const log = new Logger("test:store");
 
@@ -49,20 +50,20 @@ export async function sendMessages(
   instance: ServiceNode,
   numMessages: number,
   contentTopic: string,
-  pubsubTopic: string
-): Promise<void> {
+  pubsubTopic: string,
+  timestamp: boolean = false
+): Promise<MessageRpcQuery[]> {
+  const messages: MessageRpcQuery[] = new Array<MessageRpcQuery>(numMessages);
   for (let i = 0; i < numMessages; i++) {
-    expect(
-      await instance.sendMessage(
-        ServiceNode.toMessageRpcQuery({
-          payload: new Uint8Array([i]),
-          contentTopic: contentTopic
-        }),
-        pubsubTopic
-      )
-    ).to.eq(true);
+    messages[i] = ServiceNode.toMessageRpcQuery({
+      payload: new Uint8Array([i]),
+      contentTopic: contentTopic,
+      timestamp: timestamp ? new Date() : undefined
+    });
+    expect(await instance.sendMessage(messages[i], pubsubTopic)).to.eq(true);
     await delay(1); // to ensure each timestamp is unique.
   }
+  return messages;
 }
 
 export async function sendMessagesAutosharding(


### PR DESCRIPTION
### Problem / Description
<!--
What problem does this PR address?
Clearly describe the issue or feature the PR aims to solve.
-->

Waku Store v3 message hash queries were failing in js-waku due to overly strict validation that blocked necessary `pubsubTopic` parameters. The implementation was strictly following RFC 13/WAKU2-STORE specification which states hash queries "MUST NOT" include `pubsubTopic`, but this prevented functional queries against real nwaku deployments which require/accept `pubsubTopic` in hash queries.

### Solution
<!--
Describe how the problem is solved in this PR.
- Provide an overview of the changes made.
- Highlight any significant design decisions or architectural changes.
-->

Updated the store query validation logic to enable working message hash queries while maintaining protocol integrity:

1. **Relaxed RPC validation** ([packages/core/src/lib/store/rpc.ts](https://github.com/waku-org/js-waku/blob/fix/store-hash-query/packages/core/src/lib/store/rpc.ts#L32-L58)): Modified validation to allow `pubsubTopic` in message hash queries while still blocking invalid combinations like `contentTopics` and time filters

2. **Enhanced store query handling** ([packages/sdk/src/store/store.ts](https://github.com/waku-org/js-waku/blob/fix/store-hash-query/packages/sdk/src/store/store.ts)): Updated logic to properly handle `pubsubTopic` in hash queries, using provided value or falling back to decoder's pubsubTopic

3. **Added comprehensive test coverage** ([packages/tests/tests/store/message_hash.spec.ts](https://github.com/waku-org/js-waku/blob/fix/store-hash-query/packages/tests/tests/store/message_hash.spec.ts)): Created new test file with both normal and hash-based query tests to ensure functionality works correctly

4. **Updated existing tests** ([packages/core/src/lib/store/rpc.spec.ts](https://github.com/waku-org/js-waku/blob/fix/store-hash-query/packages/core/src/lib/store/rpc.spec.ts)): Added unit tests to validate the new validation logic

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->

- **Protocol discrepancy addressed**: This fix addresses a practical discrepancy between the formal Waku specification and implementation requirements. We may need to update the specifications to align with real-world usage patterns
- **Backward compatibility maintained**: Changes don't break existing functionality and maintain validation for other invalid query combinations  
- **Prioritizes functionality**: Solution enables working hash queries in production environments while documenting the spec deviation
- **Extensive testing**: Both unit tests and integration tests ensure the fix works correctly with nwaku nodes

- Resolves: Store v3 message hash query validation failures #2351 

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [x] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.