### PR TITLE
fix!: encoder does not have enough information to deduce pubsub topic

### DIFF
--- a/packages/core/src/lib/connection_manager/keep_alive_manager.ts
+++ b/packages/core/src/lib/connection_manager/keep_alive_manager.ts
@@ -1,6 +1,6 @@
 import type { PeerId } from "@libp2p/interface";
 import type { IEncoder, IRelay, Libp2p } from "@waku/interfaces";
-import { Logger, pubsubTopicToSingleShardInfo } from "@waku/utils";
+import { Logger } from "@waku/utils";
 import { utf8ToBytes } from "@waku/utils/bytes";
 
 import { createEncoder } from "../message/version_0.js";
@@ -164,8 +164,8 @@ export class KeepAliveManager implements IKeepAliveManager {
       }
 
       const encoder = createEncoder({
-        pubsubTopicShardInfo: pubsubTopicToSingleShardInfo(topic),
         contentTopic: RelayPingContentTopic,
+        pubsubTopicOrShard: topic,
         ephemeral: true
       });
 

--- a/packages/core/src/lib/light_push/light_push.ts
+++ b/packages/core/src/lib/light_push/light_push.ts
@@ -8,7 +8,7 @@ import {
   type ThisOrThat
 } from "@waku/interfaces";
 import { PushResponse } from "@waku/proto";
-import { isMessageSizeUnderCap } from "@waku/utils";
+import { determinePubsubTopic, isMessageSizeUnderCap } from "@waku/utils";
 import { Logger } from "@waku/utils";
 import all from "it-all";
 import * as lp from "it-length-prefixed";
@@ -35,7 +35,7 @@ export class LightPushCore {
 
   public readonly multicodec = LightPushCodec;
 
-  public constructor(libp2p: Libp2p) {
+  public constructor(public clusterId: number, libp2p: Libp2p) {
     this.streamManager = new StreamManager(LightPushCodec, libp2p.components);
   }
 
@@ -63,7 +63,13 @@ export class LightPushCore {
         };
       }
 
-      const query = PushRpc.createRequest(protoMessage, encoder.pubsubTopic);
+      const pubsubTopic = determinePubsubTopic(
+        encoder.contentTopic,
+        this.clusterId,
+        encoder.pubsubTopicOrShard
+      );
+
+      const query = PushRpc.createRequest(protoMessage, pubsubTopic);
       return { query, error: null };
     } catch (error) {
       log.error("Failed to prepare push message", error);

--- a/packages/core/src/lib/message/version_0.spec.ts
+++ b/packages/core/src/lib/message/version_0.spec.ts
@@ -126,27 +126,3 @@ describe("Ensures content topic is defined", () => {
     expect(wrapper).to.throw("Content topic must be specified");
   });
 });
-
-describe("Sets sharding configuration correctly", () => {
-  it("uses static shard pubsub topic instead of autosharding when set", async () => {
-    // Create an encoder setup to use autosharding
-    const ContentTopic = "/waku/2/content/test.js";
-    const autoshardingEncoder = createEncoder({
-      pubsubTopicShardInfo: { clusterId: 0 },
-      contentTopic: ContentTopic
-    });
-
-    // When autosharding is enabled, we expect the shard index to be 1
-    expect(autoshardingEncoder.pubsubTopic).to.be.eq("/waku/2/rs/0/1");
-
-    // Create an encoder setup to use static sharding with the same content topic
-    const singleShardInfo = { clusterId: 0, shard: 0 };
-    const staticshardingEncoder = createEncoder({
-      contentTopic: ContentTopic,
-      pubsubTopicShardInfo: singleShardInfo
-    });
-
-    // When static sharding is enabled, we expect the shard index to be 0
-    expect(staticshardingEncoder.pubsubTopic).to.be.eq("/waku/2/rs/0/0");
-  });
-});

--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -79,31 +79,10 @@ export interface IMetaSetter {
   (message: IProtoMessage & { meta: undefined }): Uint8Array;
 }
 
-export interface EncoderOptions {
-  /**
-   * @deprecated
-   */
-  pubsubTopic?: PubsubTopic;
-  pubsubTopicShardInfo?: SingleShardInfo;
-  /** The content topic to set on outgoing messages. */
-  contentTopic: string;
-  /**
-   * An optional flag to mark message as ephemeral, i.e., not to be stored by Waku Store nodes.
-   * @defaultValue `false`
-   */
-  ephemeral?: boolean;
-  /**
-   * A function called when encoding messages to set the meta field.
-   * @param IProtoMessage The message encoded for wire, without the meta field.
-   * If encryption is used, `metaSetter` only accesses _encrypted_ payload.
-   */
-  metaSetter?: IMetaSetter;
-}
-
 export interface IEncoder {
-  pubsubTopic: PubsubTopic;
   contentTopic: string;
   ephemeral: boolean;
+  pubsubTopicOrShard?: PubsubTopic | number;
   toWire: (message: IMessage) => Promise<Uint8Array | undefined>;
   toProtoObj: (message: IMessage) => Promise<IProtoMessage | undefined>;
 }

--- a/packages/message-encryption/src/ecies.ts
+++ b/packages/message-encryption/src/ecies.ts
@@ -1,17 +1,21 @@
 import { Decoder as DecoderV0 } from "@waku/core/lib/message/version_0";
-import {
-  type EncoderOptions as BaseEncoderOptions,
-  type IDecoder,
-  type IEncoder,
-  type IEncryptedMessage,
-  type IMessage,
-  type IMetaSetter,
-  type IProtoMessage,
-  type PubsubTopic,
-  type SingleShardInfo
+import { DEFAULT_CLUSTER_ID } from "@waku/interfaces";
+import type {
+  IDecoder,
+  IEncoder,
+  IEncryptedMessage,
+  IMessage,
+  IMetaSetter,
+  IProtoMessage,
+  PubsubTopic,
+  SingleShardInfo
 } from "@waku/interfaces";
 import { WakuMessage } from "@waku/proto";
-import { determinePubsubTopic, Logger } from "@waku/utils";
+import {
+  contentTopicToPubsubTopic,
+  determinePubsubTopic,
+  Logger
+} from "@waku/utils";
 
 import { generatePrivateKey } from "./crypto/utils.js";
 import { DecodedMessage } from "./decoded_message.js";
@@ -35,11 +39,11 @@ const log = new Logger("message-encryption:ecies");
 
 class Encoder implements IEncoder {
   public constructor(
-    public pubsubTopic: PubsubTopic,
     public contentTopic: string,
     private publicKey: Uint8Array,
     private sigPrivKey?: Uint8Array,
     public ephemeral: boolean = false,
+    public pubsubTopicOrShard?: PubsubTopic | number,
     public metaSetter?: IMetaSetter
   ) {
     if (!contentTopic || contentTopic === "") {
@@ -81,11 +85,25 @@ class Encoder implements IEncoder {
   }
 }
 
-export interface EncoderOptions extends BaseEncoderOptions {
+export interface EncoderOptions {
+  /** The content topic to set on outgoing messages. */
+  contentTopic: string;
   /**
-   * @deprecated
+   * An optional flag to mark message as ephemeral, i.e., not to be stored by Waku Store nodes.
+   * @defaultValue `false`
    */
-  pubsubTopic?: PubsubTopic;
+  ephemeral?: boolean;
+  /**
+   * The pubsub topic or shard to send messages on, can be omitted when using auto sharding.
+   */
+  pubsubTopicOrShard?: PubsubTopic | number;
+  /**
+   * A function called when encoding messages to set the meta field.
+   * @param IProtoMessage The message encoded for wire, without the meta field.
+   * If encryption is used, `metaSetter` only accesses _encrypted_ payload.
+   */
+  metaSetter?: IMetaSetter;
+
   /** The public key to encrypt the payload for. */
   publicKey: Uint8Array;
   /**  An optional private key to be used to sign the payload before encryption. */
@@ -105,20 +123,19 @@ export interface EncoderOptions extends BaseEncoderOptions {
  * in [26/WAKU2-PAYLOAD](https://rfc.vac.dev/spec/26/).
  */
 export function createEncoder({
-  pubsubTopic,
-  pubsubTopicShardInfo,
   contentTopic,
   publicKey,
   sigPrivKey,
   ephemeral = false,
+  pubsubTopicOrShard,
   metaSetter
 }: EncoderOptions): Encoder {
   return new Encoder(
-    determinePubsubTopic(contentTopic, pubsubTopic ?? pubsubTopicShardInfo),
     contentTopic,
     publicKey,
     sigPrivKey,
     ephemeral,
+    pubsubTopicOrShard,
     metaSetter
   );
 }
@@ -204,8 +221,24 @@ export function createDecoder(
   privateKey: Uint8Array,
   pubsubTopicShardInfo?: SingleShardInfo | PubsubTopic
 ): Decoder {
+  if (!pubsubTopicShardInfo) {
+    return new Decoder(
+      contentTopicToPubsubTopic(contentTopic, DEFAULT_CLUSTER_ID),
+      contentTopic,
+      privateKey
+    );
+  }
+
+  if (typeof pubsubTopicShardInfo == "string") {
+    return new Decoder(pubsubTopicShardInfo, contentTopic, privateKey);
+  }
+
   return new Decoder(
-    determinePubsubTopic(contentTopic, pubsubTopicShardInfo),
+    determinePubsubTopic(
+      contentTopic,
+      pubsubTopicShardInfo.clusterId,
+      pubsubTopicShardInfo.shard
+    ),
     contentTopic,
     privateKey
   );

--- a/packages/relay/src/create.ts
+++ b/packages/relay/src/create.ts
@@ -1,4 +1,8 @@
-import type { CreateNodeOptions, RelayNode } from "@waku/interfaces";
+import {
+  CreateNodeOptions,
+  DEFAULT_CLUSTER_ID,
+  RelayNode
+} from "@waku/interfaces";
 import { createLibp2pAndUpdateOptions, WakuNode } from "@waku/sdk";
 
 import { Relay, RelayCreateOptions, wakuGossipSub } from "./relay.js";
@@ -26,8 +30,11 @@ export async function createRelayNode(
     }
   };
 
+  const clusterId = options.networkConfig?.clusterId ?? DEFAULT_CLUSTER_ID;
+
   const { libp2p, pubsubTopics } = await createLibp2pAndUpdateOptions(options);
   const relay = new Relay({
+    clusterId,
     pubsubTopics: pubsubTopics || [],
     libp2p
   });

--- a/packages/relay/src/message_validator.spec.ts
+++ b/packages/relay/src/message_validator.spec.ts
@@ -9,8 +9,9 @@ import fc from "fast-check";
 
 import { messageValidator } from "./message_validator.js";
 
+const TestClusterId = 0;
 const TestContentTopic = "/app/1/topic/utf8";
-const TestPubsubTopic = determinePubsubTopic(TestContentTopic);
+const TestPubsubTopic = determinePubsubTopic(TestContentTopic, TestClusterId);
 
 describe("Message Validator", () => {
   it("Accepts a valid Waku Message", async () => {
@@ -21,7 +22,7 @@ describe("Message Validator", () => {
 
         const encoder = createEncoder({
           contentTopic: TestContentTopic,
-          pubsubTopic: TestPubsubTopic
+          pubsubTopicOrShard: TestPubsubTopic
         });
         const bytes = await encoder.toWire({ payload });
 

--- a/packages/reliability-tests/tests/longevity.spec.ts
+++ b/packages/reliability-tests/tests/longevity.spec.ts
@@ -1,15 +1,9 @@
 import { LightNode, Protocols } from "@waku/interfaces";
-import {
-  createDecoder,
-  createEncoder,
-  createLightNode,
-  utf8ToBytes
-} from "@waku/sdk";
+import { createDecoder, createLightNode, utf8ToBytes } from "@waku/sdk";
 import {
   delay,
   shardInfoToPubsubTopics,
-  singleShardInfosToShardInfo,
-  singleShardInfoToPubsubTopic
+  singleShardInfosToShardInfo
 } from "@waku/utils";
 import { expect } from "chai";
 
@@ -81,15 +75,6 @@ describe("Longevity", function () {
       messageCollector.callback
     );
     if (!hasSubscribed) throw new Error("Failed to subscribe from the start.");
-
-    const encoder = createEncoder({
-      contentTopic: ContentTopic,
-      pubsubTopicShardInfo: singleShardInfo
-    });
-
-    expect(encoder.pubsubTopic).to.eq(
-      singleShardInfoToPubsubTopic(singleShardInfo)
-    );
 
     let messageId = 0;
 

--- a/packages/rln/src/codec.ts
+++ b/packages/rln/src/codec.ts
@@ -56,10 +56,6 @@ export class RLNEncoder implements IEncoder {
     return proof;
   }
 
-  public get pubsubTopic(): string {
-    return this.encoder.pubsubTopic;
-  }
-
   public get contentTopic(): string {
     return this.encoder.contentTopic;
   }

--- a/packages/rln/src/rln.ts
+++ b/packages/rln/src/rln.ts
@@ -2,7 +2,8 @@ import { createDecoder, createEncoder } from "@waku/core";
 import type {
   ContentTopic,
   IDecodedMessage,
-  EncoderOptions as WakuEncoderOptions
+  IMetaSetter,
+  PubsubTopic
 } from "@waku/interfaces";
 import { Logger } from "@waku/utils";
 import init from "@waku/zerokit-rln-wasm";
@@ -27,9 +28,27 @@ import { Zerokit } from "./zerokit.js";
 
 const log = new Logger("waku:rln");
 
-type WakuRLNEncoderOptions = WakuEncoderOptions & {
+export interface WakuRLNEncoderOptions {
+  /** The content topic to set on outgoing messages. */
+  contentTopic: string;
+  /**
+   * An optional flag to mark message as ephemeral, i.e., not to be stored by Waku Store nodes.
+   * @defaultValue `false`
+   */
+  ephemeral?: boolean;
+  /**
+   * The pubsub topic or shard to send messages on, can be omitted when using auto sharding.
+   */
+  pubsubTopicOrShard?: PubsubTopic | number;
+  /**
+   * A function called when encoding messages to set the meta field.
+   * @param IProtoMessage The message encoded for wire, without the meta field.
+   * If encryption is used, `metaSetter` only accesses _encrypted_ payload.
+   */
+  metaSetter?: IMetaSetter;
+
   credentials: EncryptedCredentials | DecryptedCredentials;
-};
+}
 
 export class RLNInstance extends RLNCredentialsManager {
   /**

--- a/packages/sdk/src/light_push/light_push.spec.ts
+++ b/packages/sdk/src/light_push/light_push.spec.ts
@@ -14,6 +14,7 @@ import { PeerManager } from "../peer_manager/index.js";
 
 import { LightPush } from "./light_push.js";
 
+const CLUSTER_ID = 1;
 const PUBSUB_TOPIC = "/waku/2/rs/1/4";
 const CONTENT_TOPIC = "/test/1/waku-light-push/utf8";
 
@@ -168,6 +169,7 @@ type MockLightPushOptions = {
 
 function mockLightPush(options: MockLightPushOptions): LightPush {
   const lightPush = new LightPush({
+    clusterId: CLUSTER_ID,
     connectionManager: {
       isTopicConfigured: (topic: string) =>
         (options.pubsubTopics || [PUBSUB_TOPIC]).includes(topic)

--- a/packages/tests/src/utils/generate_test_data.ts
+++ b/packages/tests/src/utils/generate_test_data.ts
@@ -18,7 +18,10 @@ export function generateTestData(
     (_, i) => `/test/${i + 1}/waku-multi/default`
   );
   const encoders = contentTopics.map((topic) =>
-    createEncoder({ contentTopic: topic, pubsubTopic: options?.pubsubTopic })
+    createEncoder({
+      contentTopic: topic,
+      pubsubTopicOrShard: options?.pubsubTopic
+    })
   );
   const decoders = contentTopics.map((topic) =>
     createDecoder(topic, options?.pubsubTopic)

--- a/packages/tests/tests/ephemeral.node.spec.ts
+++ b/packages/tests/tests/ephemeral.node.spec.ts
@@ -42,7 +42,7 @@ const PubsubTopic = contentTopicToPubsubTopic(TestContentTopic, ClusterId);
 
 const TestEncoder = createEncoder({
   contentTopic: TestContentTopic,
-  pubsubTopic: PubsubTopic
+  pubsubTopicOrShard: PubsubTopic
 });
 const TestDecoder = createDecoder(TestContentTopic, PubsubTopic);
 
@@ -57,18 +57,18 @@ const AsymEncoder = createEciesEncoder({
   contentTopic: AsymContentTopic,
   publicKey,
   ephemeral: true,
-  pubsubTopic: PubsubTopic
+  pubsubTopicOrShard: PubsubTopic
 });
 const SymEncoder = createSymEncoder({
   contentTopic: SymContentTopic,
   symKey,
   ephemeral: true,
-  pubsubTopic: PubsubTopic
+  pubsubTopicOrShard: PubsubTopic
 });
 const ClearEncoder = createEncoder({
   contentTopic: TestContentTopic,
   ephemeral: true,
-  pubsubTopic: PubsubTopic
+  pubsubTopicOrShard: PubsubTopic
 });
 
 const AsymDecoder = createEciesDecoder(
@@ -200,7 +200,7 @@ describe("Waku Message Ephemeral field", function () {
     const ephemeralEncoder = createEncoder({
       contentTopic: TestContentTopic,
       ephemeral: true,
-      pubsubTopic: PubsubTopic
+      pubsubTopicOrShard: PubsubTopic
     });
 
     const messages: IDecodedMessage[] = [];
@@ -246,7 +246,7 @@ describe("Waku Message Ephemeral field", function () {
     const encoder = createSymEncoder({
       contentTopic: SymContentTopic,
       symKey,
-      pubsubTopic: PubsubTopic
+      pubsubTopicOrShard: PubsubTopic
     });
     const decoder = createSymDecoder(SymContentTopic, symKey, PubsubTopic);
 
@@ -293,7 +293,7 @@ describe("Waku Message Ephemeral field", function () {
     const encoder = createEciesEncoder({
       contentTopic: AsymContentTopic,
       publicKey: publicKey,
-      pubsubTopic: PubsubTopic
+      pubsubTopicOrShard: PubsubTopic
     });
     const decoder = createEciesDecoder(
       AsymContentTopic,

--- a/packages/tests/tests/filter/subscribe.node.spec.ts
+++ b/packages/tests/tests/filter/subscribe.node.spec.ts
@@ -84,7 +84,7 @@ const runTests = (strictCheckNodes: boolean): void => {
       const encoder = ecies.createEncoder({
         contentTopic: TestContentTopic,
         publicKey,
-        pubsubTopic: TestPubsubTopic
+        pubsubTopicOrShard: TestPubsubTopic
       });
       const decoder = ecies.createDecoder(
         TestContentTopic,
@@ -117,7 +117,7 @@ const runTests = (strictCheckNodes: boolean): void => {
       const encoder = symmetric.createEncoder({
         contentTopic: TestContentTopic,
         symKey,
-        pubsubTopic: TestPubsubTopic
+        pubsubTopicOrShard: TestPubsubTopic
       });
       const decoder = symmetric.createDecoder(
         TestContentTopic,
@@ -228,7 +228,7 @@ const runTests = (strictCheckNodes: boolean): void => {
       const newContentTopic = "/test/2/waku-filter/default";
       const newEncoder = createEncoder({
         contentTopic: newContentTopic,
-        pubsubTopic: TestPubsubTopic
+        pubsubTopicOrShard: TestPubsubTopic
       });
       const newDecoder = createDecoder(newContentTopic, TestPubsubTopic);
       await waku.filter.subscribe(
@@ -499,7 +499,7 @@ const runTests = (strictCheckNodes: boolean): void => {
       const newContentTopic = "/test/2/waku-filter/default";
       const newEncoder = createEncoder({
         contentTopic: newContentTopic,
-        pubsubTopic: TestPubsubTopic
+        pubsubTopicOrShard: TestPubsubTopic
       });
       const newDecoder = createDecoder(newContentTopic, TestPubsubTopic);
       await waku.filter.subscribe(
@@ -588,7 +588,7 @@ const runTests = (strictCheckNodes: boolean): void => {
         });
         const customEncoder = createEncoder({
           contentTopic: customContentTopic,
-          pubsubTopicShardInfo: { clusterId: ClusterId, shard: 4 }
+          pubsubTopicOrShard: 4
         });
 
         await nwaku2.start({

--- a/packages/tests/tests/filter/unsubscribe.node.spec.ts
+++ b/packages/tests/tests/filter/unsubscribe.node.spec.ts
@@ -80,7 +80,7 @@ const runTests = (strictCheckNodes: boolean): void => {
       const newContentTopic = "/test/2/waku-filter";
       const newEncoder = createEncoder({
         contentTopic: newContentTopic,
-        pubsubTopic: TestPubsubTopic
+        pubsubTopicOrShard: TestPubsubTopic
       });
       const newDecoder = createDecoder(newContentTopic, TestPubsubTopic);
       await waku.filter.subscribe(
@@ -115,7 +115,7 @@ const runTests = (strictCheckNodes: boolean): void => {
       const newContentTopic = "/test/2/waku-filter";
       const newEncoder = createEncoder({
         contentTopic: newContentTopic,
-        pubsubTopic: TestPubsubTopic
+        pubsubTopicOrShard: TestPubsubTopic
       });
       const newDecoder = createDecoder(newContentTopic, TestPubsubTopic);
       await waku.filter.subscribe(

--- a/packages/tests/tests/filter/utils.ts
+++ b/packages/tests/tests/filter/utils.ts
@@ -39,7 +39,7 @@ export const TestPubsubTopic = contentTopicToPubsubTopic(
 );
 export const TestEncoder = createEncoder({
   contentTopic: TestContentTopic,
-  pubsubTopic: TestPubsubTopic
+  pubsubTopicOrShard: TestPubsubTopic
 });
 export const TestDecoder = createDecoder(TestContentTopic, TestPubsubTopic);
 export const messageText = "Filtering works!";

--- a/packages/tests/tests/light-push/index.node.spec.ts
+++ b/packages/tests/tests/light-push/index.node.spec.ts
@@ -144,7 +144,7 @@ const runTests = (strictNodeCheck: boolean): void => {
       const customTestEncoder = createEncoder({
         contentTopic: TestContentTopic,
         metaSetter: () => new Uint8Array(10),
-        pubsubTopic: TestPubsubTopic
+        pubsubTopicOrShard: TestPubsubTopic
       });
 
       const pushResponse = await waku.lightPush.send(
@@ -168,7 +168,7 @@ const runTests = (strictNodeCheck: boolean): void => {
     it("Fails to push message with large meta", async function () {
       const customTestEncoder = createEncoder({
         contentTopic: TestContentTopic,
-        pubsubTopic: TestPubsubTopic,
+        pubsubTopicOrShard: TestPubsubTopic,
         metaSetter: () => new Uint8Array(105024) // see the note below ***
       });
 

--- a/packages/tests/tests/light-push/multiple_pubsub.node.spec.ts
+++ b/packages/tests/tests/light-push/multiple_pubsub.node.spec.ts
@@ -27,7 +27,7 @@ describe("Waku Light Push (Autosharding): Multiple PubsubTopics", function () {
 
   const customEncoder2 = createEncoder({
     contentTopic: "/test/2/waku-light-push/utf8",
-    pubsubTopic: contentTopicToPubsubTopic(
+    pubsubTopicOrShard: contentTopicToPubsubTopic(
       "/test/2/waku-light-push/utf8",
       ClusterId
     )
@@ -67,26 +67,26 @@ describe("Waku Light Push (Autosharding): Multiple PubsubTopics", function () {
 
     expect(
       await messageCollector1.waitForMessages(1, {
-        pubsubTopic: TestEncoder.pubsubTopic
+        pubsubTopic: TestEncoder.pubsubTopicOrShard as string
       })
     ).to.eq(true);
 
     expect(
       await messageCollector2.waitForMessages(1, {
-        pubsubTopic: customEncoder2.pubsubTopic
+        pubsubTopic: customEncoder2.pubsubTopicOrShard as string
       })
     ).to.eq(true);
 
     messageCollector1.verifyReceivedMessage(0, {
       expectedMessageText: "M1",
       expectedContentTopic: TestEncoder.contentTopic,
-      expectedPubsubTopic: TestEncoder.pubsubTopic
+      expectedPubsubTopic: TestEncoder.pubsubTopicOrShard as string
     });
 
     messageCollector2.verifyReceivedMessage(0, {
       expectedMessageText: "M2",
       expectedContentTopic: customEncoder2.contentTopic,
-      expectedPubsubTopic: customEncoder2.pubsubTopic
+      expectedPubsubTopic: customEncoder2.pubsubTopicOrShard as string
     });
   });
 
@@ -103,7 +103,7 @@ describe("Waku Light Push (Autosharding): Multiple PubsubTopics", function () {
         shard: [2]
       });
       await nwaku2.ensureSubscriptionsAutosharding([
-        customEncoder2.pubsubTopic
+        customEncoder2.pubsubTopicOrShard as string
       ]);
       await waku.dial(await nwaku2.getMultiaddrWithId());
       await waku.waitForPeers([Protocols.LightPush]);
@@ -118,7 +118,7 @@ describe("Waku Light Push (Autosharding): Multiple PubsubTopics", function () {
       });
 
       await serviceNodes.messageCollector.waitForMessages(1, {
-        pubsubTopic: TestEncoder.pubsubTopic
+        pubsubTopic: TestEncoder.pubsubTopicOrShard as string
       });
       await messageCollector2.waitForMessagesAutosharding(1, {
         contentTopic: customEncoder2.contentTopic
@@ -127,12 +127,12 @@ describe("Waku Light Push (Autosharding): Multiple PubsubTopics", function () {
       serviceNodes.messageCollector.verifyReceivedMessage(0, {
         expectedMessageText: "M1",
         expectedContentTopic: TestEncoder.contentTopic,
-        expectedPubsubTopic: TestEncoder.pubsubTopic
+        expectedPubsubTopic: TestEncoder.pubsubTopicOrShard as string
       });
       messageCollector2.verifyReceivedMessage(0, {
         expectedMessageText: "M2",
         expectedContentTopic: customEncoder2.contentTopic,
-        expectedPubsubTopic: customEncoder2.pubsubTopic
+        expectedPubsubTopic: customEncoder2.pubsubTopicOrShard as string
       });
     } catch (e) {
       await tearDownNodes([nwaku2], []);

--- a/packages/tests/tests/light-push/utils.ts
+++ b/packages/tests/tests/light-push/utils.ts
@@ -26,7 +26,7 @@ export const TestShardInfo = {
 };
 export const TestEncoder = createEncoder({
   contentTopic: TestContentTopic,
-  pubsubTopic: TestPubsubTopic
+  pubsubTopicOrShard: TestPubsubTopic
 });
 export const messageText = "Light Push works!";
 export const messagePayload = { payload: utf8ToBytes(messageText) };

--- a/packages/tests/tests/relay/index.node.spec.ts
+++ b/packages/tests/tests/relay/index.node.spec.ts
@@ -51,12 +51,12 @@ describe("Waku Relay", function () {
     const eciesEncoder = createEciesEncoder({
       contentTopic: asymTopic,
       publicKey,
-      pubsubTopic: TestPubsubTopic
+      pubsubTopicOrShard: TestPubsubTopic
     });
     const symEncoder = createSymEncoder({
       contentTopic: symTopic,
       symKey,
-      pubsubTopic: TestPubsubTopic
+      pubsubTopicOrShard: TestPubsubTopic
     });
 
     const eciesDecoder = createEciesDecoder(

--- a/packages/tests/tests/relay/multiple_pubsub.node.spec.ts
+++ b/packages/tests/tests/relay/multiple_pubsub.node.spec.ts
@@ -32,14 +32,8 @@ describe("Waku Relay, multiple pubsub topics", function () {
   let waku2: RelayNode;
   let waku3: RelayNode;
 
-  const customPubsubTopic1 = singleShardInfoToPubsubTopic({
-    clusterId: 3,
-    shard: 1
-  });
-  const customPubsubTopic2 = singleShardInfoToPubsubTopic({
-    clusterId: 3,
-    shard: 2
-  });
+  const customPubsubTopic1 = singleShardInfoToPubsubTopic(3, 1);
+  const customPubsubTopic2 = singleShardInfoToPubsubTopic(3, 2);
   const shardInfo1: ShardInfo = { clusterId: 3, shards: [1] };
   const singleShardInfo1: SingleShardInfo = {
     clusterId: 3,
@@ -53,12 +47,12 @@ describe("Waku Relay, multiple pubsub topics", function () {
     shard: 2
   };
   const customEncoder1 = createEncoder({
-    pubsubTopicShardInfo: singleShardInfo1,
+    pubsubTopicOrShard: singleShardInfo1.shard,
     contentTopic: customContentTopic1
   });
   const customDecoder1 = createDecoder(customContentTopic1, singleShardInfo1);
   const customEncoder2 = createEncoder({
-    pubsubTopicShardInfo: singleShardInfo2,
+    pubsubTopicOrShard: singleShardInfo2.shard,
     contentTopic: customContentTopic2
   });
   const customDecoder2 = createDecoder(customContentTopic2, singleShardInfo2);
@@ -350,7 +344,7 @@ describe("Waku Relay (Autosharding), multiple pubsub topics", function () {
   };
   const customEncoder1 = createEncoder({
     contentTopic: customContentTopic1,
-    pubsubTopicShardInfo: pubsubTopicToSingleShardInfo(autoshardingPubsubTopic1)
+    pubsubTopicOrShard: autoshardingPubsubTopic1
   });
   const customDecoder1 = createDecoder(
     customContentTopic1,
@@ -358,7 +352,7 @@ describe("Waku Relay (Autosharding), multiple pubsub topics", function () {
   );
   const customEncoder2 = createEncoder({
     contentTopic: customContentTopic2,
-    pubsubTopicShardInfo: pubsubTopicToSingleShardInfo(autoshardingPubsubTopic2)
+    pubsubTopicOrShard: autoshardingPubsubTopic2
   });
   const customDecoder2 = createDecoder(
     customContentTopic2,

--- a/packages/tests/tests/relay/publish.node.spec.ts
+++ b/packages/tests/tests/relay/publish.node.spec.ts
@@ -115,7 +115,7 @@ describe("Waku Relay, Publish", function () {
   it("Fails to publish message with wrong content topic", async function () {
     const wrong_encoder = createEncoder({
       contentTopic: "/test/1/wrong/utf8",
-      pubsubTopic: TestPubsubTopic
+      pubsubTopicOrShard: TestPubsubTopic
     });
     await waku1.relay.send(wrong_encoder, {
       payload: utf8ToBytes("")
@@ -127,10 +127,7 @@ describe("Waku Relay, Publish", function () {
 
   it("Fails to publish message with wrong pubsubtopic", async function () {
     const wrong_encoder = createEncoder({
-      pubsubTopicShardInfo: {
-        clusterId: TestShardInfo.clusterId,
-        shard: TestShardInfo.shards[0] + 1
-      },
+      pubsubTopicOrShard: TestShardInfo.shards[0] + 1,
       contentTopic: TestContentTopic
     });
     const pushResponse = await waku1.relay.send(wrong_encoder, {
@@ -218,7 +215,7 @@ describe("Waku Relay, Publish", function () {
   it("Publish message with large meta", async function () {
     const customTestEncoder = createEncoder({
       contentTopic: TestContentTopic,
-      pubsubTopic: TestPubsubTopic,
+      pubsubTopicOrShard: TestPubsubTopic,
       metaSetter: () => new Uint8Array(10 ** 6)
     });
 

--- a/packages/tests/tests/relay/subscribe.node.spec.ts
+++ b/packages/tests/tests/relay/subscribe.node.spec.ts
@@ -133,7 +133,7 @@ describe("Waku Relay, Subscribe", function () {
     const secondContentTopic = "/test/2/waku-relay/utf8";
     const secondEncoder = createEncoder({
       contentTopic: secondContentTopic,
-      pubsubTopic: TestPubsubTopic
+      pubsubTopicOrShard: TestPubsubTopic
     });
     const secondDecoder = createDecoder(secondContentTopic, TestPubsubTopic);
 
@@ -304,7 +304,7 @@ describe("Waku Relay, Subscribe", function () {
       const newContentTopic = testItem.value;
       const newEncoder = createEncoder({
         contentTopic: newContentTopic,
-        pubsubTopic: TestPubsubTopic
+        pubsubTopicOrShard: TestPubsubTopic
       });
       const newDecoder = createDecoder(newContentTopic, TestPubsubTopic);
 

--- a/packages/tests/tests/relay/utils.ts
+++ b/packages/tests/tests/relay/utils.ts
@@ -28,7 +28,7 @@ export const TestPubsubTopic = contentTopicToPubsubTopic(
 );
 export const TestEncoder = createEncoder({
   contentTopic: TestContentTopic,
-  pubsubTopic: TestPubsubTopic
+  pubsubTopicOrShard: TestPubsubTopic
 });
 export const TestDecoder = createDecoder(TestContentTopic, TestPubsubTopic);
 export const TestWaitMessageOptions = { pubsubTopic: TestPubsubTopic };

--- a/packages/tests/tests/sharding/auto_sharding.spec.ts
+++ b/packages/tests/tests/sharding/auto_sharding.spec.ts
@@ -1,9 +1,6 @@
 import { LightNode, ProtocolError } from "@waku/interfaces";
 import { createEncoder, createLightNode, utf8ToBytes } from "@waku/sdk";
-import {
-  contentTopicToPubsubTopic,
-  contentTopicToShardIndex
-} from "@waku/utils";
+import { contentTopicToPubsubTopic, determinePubsubTopic } from "@waku/utils";
 import { expect } from "chai";
 
 import {
@@ -44,11 +41,7 @@ describe("Autosharding: Running Nodes", function () {
     );
 
     const encoder = createEncoder({
-      contentTopic: ContentTopic,
-      pubsubTopicShardInfo: {
-        clusterId: clusterId,
-        shard: contentTopicToShardIndex(ContentTopic)
-      }
+      contentTopic: ContentTopic
     });
 
     const request = await waku.lightPush.send(encoder, {
@@ -58,7 +51,7 @@ describe("Autosharding: Running Nodes", function () {
     expect(request.successes.length).to.eq(numServiceNodes);
     expect(
       await serviceNodes.messageCollector.waitForMessages(1, {
-        pubsubTopic: encoder.pubsubTopic
+        pubsubTopic: determinePubsubTopic(encoder.contentTopic, clusterId)
       })
     ).to.eq(true);
   });
@@ -76,11 +69,7 @@ describe("Autosharding: Running Nodes", function () {
     );
 
     const encoder = createEncoder({
-      contentTopic: ContentTopic,
-      pubsubTopicShardInfo: {
-        clusterId: clusterId,
-        shard: contentTopicToShardIndex(ContentTopic)
-      }
+      contentTopic: ContentTopic
     });
 
     const request = await waku.lightPush.send(encoder, {
@@ -90,7 +79,7 @@ describe("Autosharding: Running Nodes", function () {
     expect(request.successes.length).to.eq(numServiceNodes);
     expect(
       await serviceNodes.messageCollector.waitForMessages(1, {
-        pubsubTopic: encoder.pubsubTopic
+        pubsubTopic: determinePubsubTopic(ContentTopic, clusterId)
       })
     ).to.eq(true);
   });
@@ -119,11 +108,7 @@ describe("Autosharding: Running Nodes", function () {
       );
 
       const encoder = createEncoder({
-        contentTopic: ContentTopic,
-        pubsubTopicShardInfo: {
-          clusterId: clusterId,
-          shard: contentTopicToShardIndex(ContentTopic)
-        }
+        contentTopic: ContentTopic
       });
 
       const request = await waku.lightPush.send(encoder, {
@@ -133,7 +118,7 @@ describe("Autosharding: Running Nodes", function () {
       expect(request.successes.length).to.eq(numServiceNodes);
       expect(
         await serviceNodes.messageCollector.waitForMessages(1, {
-          pubsubTopic: encoder.pubsubTopic
+          pubsubTopic: determinePubsubTopic(ContentTopic, clusterId)
         })
       ).to.eq(true);
     });
@@ -166,19 +151,11 @@ describe("Autosharding: Running Nodes", function () {
     );
 
     const encoder1 = createEncoder({
-      contentTopic: ContentTopic,
-      pubsubTopicShardInfo: {
-        clusterId: clusterId,
-        shard: contentTopicToShardIndex(ContentTopic)
-      }
+      contentTopic: ContentTopic
     });
 
     const encoder2 = createEncoder({
-      contentTopic: ContentTopic2,
-      pubsubTopicShardInfo: {
-        clusterId: clusterId,
-        shard: contentTopicToShardIndex(ContentTopic2)
-      }
+      contentTopic: ContentTopic2
     });
 
     const request1 = await waku.lightPush.send(encoder1, {
@@ -187,7 +164,7 @@ describe("Autosharding: Running Nodes", function () {
     expect(request1.successes.length).to.eq(numServiceNodes);
     expect(
       await serviceNodes.messageCollector.waitForMessages(1, {
-        pubsubTopic: encoder1.pubsubTopic
+        pubsubTopic: determinePubsubTopic(ContentTopic, clusterId)
       })
     ).to.eq(true);
 
@@ -197,7 +174,7 @@ describe("Autosharding: Running Nodes", function () {
     expect(request2.successes.length).to.eq(numServiceNodes);
     expect(
       await serviceNodes.messageCollector.waitForMessages(1, {
-        pubsubTopic: encoder2.pubsubTopic
+        pubsubTopic: determinePubsubTopic(ContentTopic, clusterId)
       })
     ).to.eq(true);
   });
@@ -214,11 +191,7 @@ describe("Autosharding: Running Nodes", function () {
 
     // use a content topic that is not configured
     const encoder = createEncoder({
-      contentTopic: ContentTopic2,
-      pubsubTopicShardInfo: {
-        clusterId: clusterId,
-        shard: contentTopicToShardIndex(ContentTopic2)
-      }
+      contentTopic: ContentTopic2
     });
 
     const { successes, failures } = await waku.lightPush.send(encoder, {

--- a/packages/tests/tests/store/error_handling.node.spec.ts
+++ b/packages/tests/tests/store/error_handling.node.spec.ts
@@ -92,7 +92,7 @@ describe("Waku Store, error handling", function () {
   });
 
   it("Query Generator, No message returned", async function () {
-    const WrongTestPubsubTopic = determinePubsubTopic("/test/1/wrong/utf8");
+    const WrongTestPubsubTopic = determinePubsubTopic("/test/1/wrong/utf8", 0);
     const messages = await processQueriedMessages(
       waku,
       [TestDecoder],

--- a/packages/tests/tests/store/index.node.spec.ts
+++ b/packages/tests/tests/store/index.node.spec.ts
@@ -254,17 +254,17 @@ describe("Waku Store, general", function () {
     const eciesEncoder = createEciesEncoder({
       contentTopic: asymTopic,
       publicKey,
-      pubsubTopic: TestPubsubTopic1
+      pubsubTopicOrShard: TestPubsubTopic1
     });
     const symEncoder = createSymEncoder({
       contentTopic: symTopic,
       symKey,
-      pubsubTopic: TestPubsubTopic1
+      pubsubTopicOrShard: TestPubsubTopic1
     });
 
     const otherEncoder = createEciesEncoder({
       contentTopic: TestContentTopic1,
-      pubsubTopic: TestPubsubTopic1,
+      pubsubTopicOrShard: TestPubsubTopic1,
       publicKey: getPublicKey(generatePrivateKey())
     });
 

--- a/packages/tests/tests/store/utils.ts
+++ b/packages/tests/tests/store/utils.ts
@@ -8,8 +8,7 @@ import {
   LightNode,
   NetworkConfig,
   Protocols,
-  ShardInfo,
-  type SingleShardInfo
+  ShardInfo
 } from "@waku/interfaces";
 import { createLightNode } from "@waku/sdk";
 import { Logger, singleShardInfoToPubsubTopic } from "@waku/utils";
@@ -27,16 +26,18 @@ export const TestShardInfo: ShardInfo = {
   shards: [1, 2]
 };
 
-export const TestShardInfo1: SingleShardInfo = { clusterId: 3, shard: 1 };
-export const TestPubsubTopic1 = singleShardInfoToPubsubTopic(TestShardInfo1);
+export const TestShard1 = 1;
+export const TestPubsubTopic1 = singleShardInfoToPubsubTopic(
+  TestClusterId,
+  TestShard1
+);
 
-export const TestShardInfo2: SingleShardInfo = { clusterId: 3, shard: 2 };
-export const TestPubsubTopic2 = singleShardInfoToPubsubTopic(TestShardInfo2);
+export const TestPubsubTopic2 = singleShardInfoToPubsubTopic(TestClusterId, 2);
 
 export const TestContentTopic1 = "/test/1/waku-store/utf8";
 export const TestEncoder = createEncoder({
   contentTopic: TestContentTopic1,
-  pubsubTopicShardInfo: TestShardInfo1
+  pubsubTopicOrShard: TestShard1
 });
 export const TestDecoder = createDecoder(TestContentTopic1, TestPubsubTopic1);
 
@@ -124,17 +125,6 @@ export async function startAndConnectLightNode(
 
   log.info("Waku node created");
   return waku;
-}
-
-export function chunkAndReverseArray(
-  arr: number[],
-  chunkSize: number
-): number[] {
-  const result: number[] = [];
-  for (let i = 0; i < arr.length; i += chunkSize) {
-    result.push(...arr.slice(i, i + chunkSize).reverse());
-  }
-  return result.reverse();
 }
 
 export const adjustDate = (baseDate: Date, adjustMs: number): Date => {

--- a/packages/tests/tests/waku.node.spec.ts
+++ b/packages/tests/tests/waku.node.spec.ts
@@ -213,7 +213,7 @@ describe("Decryption Keys", function () {
 
     const encoder = createEncoder({
       contentTopic: TestContentTopic,
-      pubsubTopicShardInfo: DefaultTestSingleShardInfo,
+      pubsubTopicOrShard: DefaultTestSingleShardInfo.shard,
       symKey
     });
 

--- a/packages/utils/src/common/sharding/index.spec.ts
+++ b/packages/utils/src/common/sharding/index.spec.ts
@@ -230,9 +230,10 @@ describe("contentTopicsByPubsubTopic", () => {
 
 describe("singleShardInfoToPubsubTopic", () => {
   it("should convert a SingleShardInfo object to the correct PubsubTopic", () => {
-    const singleShardInfo = { clusterId: 2, shard: 2 };
+    const clusterId = 2;
+    const shard = 2;
     const expectedTopic = "/waku/2/rs/2/2";
-    expect(singleShardInfoToPubsubTopic(singleShardInfo)).to.equal(
+    expect(singleShardInfoToPubsubTopic(clusterId, shard)).to.equal(
       expectedTopic
     );
   });
@@ -360,34 +361,30 @@ describe("determinePubsubTopic", () => {
   const contentTopic = "/app/46/sometopic/someencoding";
   it("should return the pubsub topic directly if a string is provided", () => {
     const topic = "/waku/2/rs/1/3";
-    expect(determinePubsubTopic(contentTopic, topic)).to.equal(topic);
+    expect(determinePubsubTopic(contentTopic, 0, topic)).to.equal(topic);
   });
 
   it("should return a calculated topic if SingleShardInfo is provided", () => {
-    const info = { clusterId: 1, shard: 2 };
+    const clusterId = 1;
+    const shard = 2;
     const expectedTopic = "/waku/2/rs/1/2";
-    expect(determinePubsubTopic(contentTopic, info)).to.equal(expectedTopic);
-  });
-
-  it("should fall back to default pubsub topic when pubsubTopicShardInfo is not provided", () => {
-    expect(determinePubsubTopic(contentTopic)).to.equal("/waku/2/rs/1/6");
-  });
-
-  it("should process correctly when SingleShardInfo has no clusterId but has a shard", () => {
-    const info = { shard: 0 };
-    const expectedTopic = `/waku/2/rs/${DEFAULT_CLUSTER_ID}/0`;
-    expect(determinePubsubTopic(contentTopic, info as any)).to.equal(
+    expect(determinePubsubTopic(contentTopic, clusterId, shard)).to.equal(
       expectedTopic
     );
   });
 
+  it("should process correctly when SingleShardInfo has no clusterId but has a shard", () => {
+    const shard = 0;
+    const expectedTopic = `/waku/2/rs/${DEFAULT_CLUSTER_ID}/0`;
+    expect(
+      determinePubsubTopic(contentTopic, undefined as any, shard)
+    ).to.equal(expectedTopic);
+  });
+
   it("should derive a pubsub topic using contentTopic when SingleShardInfo only contains clusterId", () => {
-    const info = { clusterId: 2 };
-    const expectedTopic = contentTopicToPubsubTopic(
-      contentTopic,
-      info.clusterId
-    );
-    expect(determinePubsubTopic(contentTopic, info as any)).to.equal(
+    const clusterId = 2;
+    const expectedTopic = contentTopicToPubsubTopic(contentTopic, clusterId);
+    expect(determinePubsubTopic(contentTopic, clusterId)).to.equal(
       expectedTopic
     );
   });

--- a/packages/utils/src/common/sharding/index.ts
+++ b/packages/utils/src/common/sharding/index.ts
@@ -40,11 +40,11 @@ export function derivePubsubTopicsFromNetworkConfig(
 }
 
 export const singleShardInfoToPubsubTopic = (
-  shardInfo: SingleShardInfo
+  clusterId: number,
+  shard: number
 ): PubsubTopic => {
-  if (shardInfo.shard === undefined) throw new Error("Invalid shard");
-
-  return `/waku/2/rs/${shardInfo.clusterId ?? DEFAULT_CLUSTER_ID}/${shardInfo.shard}`;
+  // TODO: remove this "default".
+  return `/waku/2/rs/${clusterId ?? DEFAULT_CLUSTER_ID}/${shard}`;
 };
 
 export const singleShardInfosToShardInfo = (
@@ -284,18 +284,22 @@ export function contentTopicsByPubsubTopic(
  */
 export function determinePubsubTopic(
   contentTopic: string,
-  // TODO: make it accept ShardInfo https://github.com/waku-org/js-waku/issues/2086
-  pubsubTopicShardInfo?: SingleShardInfo | PubsubTopic
+  clusterId: number,
+  pubsubTopicOrShard?: PubsubTopic | number
 ): string {
-  if (typeof pubsubTopicShardInfo == "string") {
-    return pubsubTopicShardInfo;
+  if (typeof pubsubTopicOrShard == "string") {
+    return pubsubTopicOrShard;
   }
 
-  return pubsubTopicShardInfo?.shard !== undefined
-    ? singleShardInfoToPubsubTopic(pubsubTopicShardInfo)
+  // TODO: We should know whether we are using auto-sharding or static sharding
+  // instead of deducing things.
+  return pubsubTopicOrShard !== undefined
+    ? singleShardInfoToPubsubTopic(clusterId, pubsubTopicOrShard)
     : contentTopicToPubsubTopic(
         contentTopic,
-        pubsubTopicShardInfo?.clusterId ?? DEFAULT_CLUSTER_ID
+        clusterId ?? DEFAULT_CLUSTER_ID,
+        pubsubTopicOrShard
+        // TODO: Num network shards is never passed!
       );
 }
 


### PR DESCRIPTION

### Problem / Description

A decoder needs supplementary information such as the cluster id or the number of shards in the network to compute the pubsub topic.

This information is held by the Waku node (running on a specific network). It was "working" because default value were applied.

This is the start to a larger clean-up in terms of sharding logic.

### Solution

Do note calculate pubsub topic when creating an encoder, just store whatever information is provided.

Then, proceed to calculate pubsub topic depending on circumstances (name vs static vs auto sharding) when the message is being sent.

### Notes

The goal is to fix up sharding in js-waku, which suffers the same issue as nwaku. See https://github.com/waku-org/nwaku/pull/3468

Namely, that `shards` at node level make little sense, and that it should only refer to shards that relay is subscribed to.


---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [x] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
