### PR TITLE
fix: metadata should not send pubsub topic

### DIFF
--- a/packages/core/src/lib/filter/filter.ts
+++ b/packages/core/src/lib/filter/filter.ts
@@ -42,7 +42,6 @@ export class FilterCore {
 
   public constructor(
     private handleIncomingMessage: IncomingMessageHandler,
-    public readonly pubsubTopics: PubsubTopic[],
     libp2p: Libp2p
   ) {
     this.streamManager = new StreamManager(

--- a/packages/core/src/lib/light_push/light_push.ts
+++ b/packages/core/src/lib/light_push/light_push.ts
@@ -5,7 +5,6 @@ import {
   type IMessage,
   type Libp2p,
   ProtocolError,
-  PubsubTopic,
   type ThisOrThat
 } from "@waku/interfaces";
 import { PushResponse } from "@waku/proto";
@@ -36,10 +35,7 @@ export class LightPushCore {
 
   public readonly multicodec = LightPushCodec;
 
-  public constructor(
-    public readonly pubsubTopics: PubsubTopic[],
-    libp2p: Libp2p
-  ) {
+  public constructor(libp2p: Libp2p) {
     this.streamManager = new StreamManager(LightPushCodec, libp2p.components);
   }
 

--- a/packages/interfaces/src/connection_manager.ts
+++ b/packages/interfaces/src/connection_manager.ts
@@ -1,7 +1,5 @@
 import type { Peer, PeerId, TypedEventEmitter } from "@libp2p/interface";
 
-import { PubsubTopic } from "./misc.js";
-
 export enum Tags {
   BOOTSTRAP = "bootstrap",
   PEER_EXCHANGE = "peer-exchange",
@@ -85,7 +83,6 @@ export interface IConnectionStateEvents {
 
 export interface IConnectionManager
   extends TypedEventEmitter<IPeersByDiscoveryEvents & IConnectionStateEvents> {
-  pubsubTopics: PubsubTopic[];
   getConnectedPeers(codec?: string): Promise<Peer[]>;
   dropConnection(peerId: PeerId): Promise<void>;
   getPeersByDiscovery(): Promise<PeersByDiscoveryResult>;

--- a/packages/interfaces/src/metadata.ts
+++ b/packages/interfaces/src/metadata.ts
@@ -1,13 +1,12 @@
 import type { PeerId } from "@libp2p/interface";
 
-import { PubsubTopic, ThisOrThat } from "./misc.js";
+import { ThisOrThat } from "./misc.js";
 import type { ShardInfo } from "./sharding.js";
 
 export type MetadataQueryResult = ThisOrThat<"shardInfo", ShardInfo>;
 
 export interface IMetadata {
   readonly multicodec: string;
-  readonly pubsubTopics: PubsubTopic[];
   confirmOrAttemptHandshake(peerId: PeerId): Promise<MetadataQueryResult>;
   query(peerId: PeerId): Promise<MetadataQueryResult>;
 }

--- a/packages/relay/src/create.ts
+++ b/packages/relay/src/create.ts
@@ -1,7 +1,14 @@
-import type { CreateNodeOptions, RelayNode } from "@waku/interfaces";
+import {
+  CreateNodeOptions,
+  DefaultNetworkConfig,
+  RelayNode
+} from "@waku/interfaces";
 import { createLibp2pAndUpdateOptions, WakuNode } from "@waku/sdk";
+import { derivePubsubTopicsFromNetworkConfig, Logger } from "@waku/utils";
 
 import { Relay, RelayCreateOptions, wakuGossipSub } from "./relay.js";
+
+const log = new Logger("relay:create");
 
 /**
  * Create a Waku node that uses Waku Relay to send and receive messages,
@@ -26,7 +33,13 @@ export async function createRelayNode(
     }
   };
 
-  const { libp2p, pubsubTopics } = await createLibp2pAndUpdateOptions(options);
+  const libp2p = await createLibp2pAndUpdateOptions(options);
+
+  const pubsubTopics = derivePubsubTopicsFromNetworkConfig(
+    options?.networkConfig ?? DefaultNetworkConfig
+  );
+  log.info("Creating Waku relay node with pubsub topics", pubsubTopics);
+
   const relay = new Relay({
     pubsubTopics: pubsubTopics || [],
     libp2p

--- a/packages/relay/src/create.ts
+++ b/packages/relay/src/create.ts
@@ -46,7 +46,6 @@ export async function createRelayNode(
   });
 
   return new WakuNode(
-    pubsubTopics,
     options as CreateNodeOptions,
     libp2p,
     {},

--- a/packages/sdk/src/create/create.ts
+++ b/packages/sdk/src/create/create.ts
@@ -26,7 +26,7 @@ export async function createLightNode(
   );
   log.info("Creating Waku node with pubsub topics", pubsubTopics);
 
-  const node = new WakuNode(pubsubTopics, options, libp2p, {
+  const node = new WakuNode(options, libp2p, {
     store: true,
     lightpush: true,
     filter: true

--- a/packages/sdk/src/create/create.ts
+++ b/packages/sdk/src/create/create.ts
@@ -1,8 +1,15 @@
-import type { CreateNodeOptions, LightNode } from "@waku/interfaces";
+import {
+  CreateNodeOptions,
+  DefaultNetworkConfig,
+  LightNode
+} from "@waku/interfaces";
+import { derivePubsubTopicsFromNetworkConfig, Logger } from "@waku/utils";
 
 import { WakuNode } from "../waku/index.js";
 
 import { createLibp2pAndUpdateOptions } from "./libp2p.js";
+
+const log = new Logger("sdk:create");
 
 /**
  * Create a Waku node that uses Waku Light Push, Filter and Store to send and
@@ -12,7 +19,12 @@ import { createLibp2pAndUpdateOptions } from "./libp2p.js";
 export async function createLightNode(
   options: CreateNodeOptions = {}
 ): Promise<LightNode> {
-  const { libp2p, pubsubTopics } = await createLibp2pAndUpdateOptions(options);
+  const libp2p = await createLibp2pAndUpdateOptions(options);
+
+  const pubsubTopics = derivePubsubTopicsFromNetworkConfig(
+    options?.networkConfig ?? DefaultNetworkConfig
+  );
+  log.info("Creating Waku node with pubsub topics", pubsubTopics);
 
   const node = new WakuNode(pubsubTopics, options, libp2p, {
     store: true,

--- a/packages/sdk/src/filter/filter.ts
+++ b/packages/sdk/src/filter/filter.ts
@@ -1,4 +1,4 @@
-import { ConnectionManager, FilterCore } from "@waku/core";
+import { FilterCore } from "@waku/core";
 import type {
   Callback,
   FilterProtocolOptions,
@@ -21,7 +21,6 @@ type PubsubTopic = string;
 export class Filter implements IFilter {
   private readonly protocol: FilterCore;
   private readonly peerManager: PeerManager;
-  private readonly connectionManager: ConnectionManager;
 
   private readonly config: FilterProtocolOptions;
   private subscriptions = new Map<PubsubTopic, Subscription>();
@@ -35,11 +34,9 @@ export class Filter implements IFilter {
     };
 
     this.peerManager = params.peerManager;
-    this.connectionManager = params.connectionManager;
 
     this.protocol = new FilterCore(
       this.onIncomingMessage.bind(this),
-      params.connectionManager.pubsubTopics,
       params.libp2p
     );
   }
@@ -76,7 +73,6 @@ export class Filter implements IFilter {
     );
 
     this.throwIfTopicNotSame(pubsubTopics);
-    this.throwIfTopicNotSupported(singlePubsubTopic);
 
     let subscription = this.subscriptions.get(singlePubsubTopic);
     if (!subscription) {
@@ -118,7 +114,6 @@ export class Filter implements IFilter {
     );
 
     this.throwIfTopicNotSame(pubsubTopics);
-    this.throwIfTopicNotSupported(singlePubsubTopic);
 
     const subscription = this.subscriptions.get(singlePubsubTopic);
     if (!subscription) {
@@ -168,17 +163,6 @@ export class Filter implements IFilter {
     if (!isSameTopic) {
       throw Error(
         `Cannot subscribe to more than one pubsub topic at the same time, got pubsubTopics:${pubsubTopics}`
-      );
-    }
-  }
-
-  private throwIfTopicNotSupported(pubsubTopic: string): void {
-    const supportedPubsubTopic =
-      this.connectionManager.pubsubTopics.includes(pubsubTopic);
-
-    if (!supportedPubsubTopic) {
-      throw Error(
-        `Pubsub topic ${pubsubTopic} has not been configured on this instance.`
       );
     }
   }

--- a/packages/sdk/src/filter/types.ts
+++ b/packages/sdk/src/filter/types.ts
@@ -1,4 +1,3 @@
-import { ConnectionManager } from "@waku/core";
 import { FilterCore } from "@waku/core";
 import type { FilterProtocolOptions, Libp2p } from "@waku/interfaces";
 import { WakuMessage } from "@waku/proto";
@@ -9,7 +8,6 @@ export type FilterConstructorParams = {
   options?: Partial<FilterProtocolOptions>;
   libp2p: Libp2p;
   peerManager: PeerManager;
-  connectionManager: ConnectionManager;
 };
 
 export type SubscriptionEvents = {

--- a/packages/sdk/src/light_push/light_push.ts
+++ b/packages/sdk/src/light_push/light_push.ts
@@ -49,10 +49,7 @@ export class LightPush implements ILightPush {
     } as LightPushProtocolOptions;
 
     this.peerManager = params.peerManager;
-    this.protocol = new LightPushCore(
-      params.connectionManager.pubsubTopics,
-      params.libp2p
-    );
+    this.protocol = new LightPushCore(params.libp2p);
     this.retryManager = new RetryManager({
       peerManager: params.peerManager,
       retryIntervalMs: this.config.retryIntervalMs
@@ -84,17 +81,6 @@ export class LightPush implements ILightPush {
     const { pubsubTopic } = encoder;
 
     log.info("send: attempting to send a message to pubsubTopic:", pubsubTopic);
-
-    if (!this.protocol.pubsubTopics.includes(pubsubTopic)) {
-      return {
-        successes: [],
-        failures: [
-          {
-            error: ProtocolError.TOPIC_NOT_CONFIGURED
-          }
-        ]
-      };
-    }
 
     const peerIds = await this.peerManager.getPeers({
       protocol: Protocols.LightPush,

--- a/packages/sdk/src/peer_manager/peer_manager.ts
+++ b/packages/sdk/src/peer_manager/peer_manager.ts
@@ -245,7 +245,7 @@ export class PeerManager {
     }
 
     const wasUnlocked = new Date(value).getTime();
-    return Date.now() - wasUnlocked >= 10_000 ? true : false;
+    return Date.now() - wasUnlocked >= 10_000;
   }
 
   private dispatchFilterPeerConnect(id: PeerId): void {

--- a/packages/sdk/src/store/store.ts
+++ b/packages/sdk/src/store/store.ts
@@ -1,7 +1,7 @@
 import type { PeerId } from "@libp2p/interface";
 import { peerIdFromString } from "@libp2p/peer-id";
 import { multiaddr } from "@multiformats/multiaddr";
-import { ConnectionManager, messageHash, StoreCore } from "@waku/core";
+import { messageHash, StoreCore } from "@waku/core";
 import {
   IDecodedMessage,
   IDecoder,
@@ -21,7 +21,6 @@ const log = new Logger("waku:store:sdk");
 type StoreConstructorParams = {
   libp2p: Libp2p;
   peerManager: PeerManager;
-  connectionManager: ConnectionManager;
   options?: Partial<StoreProtocolOptions>;
 };
 
@@ -33,13 +32,11 @@ export class Store implements IStore {
   private readonly options: Partial<StoreProtocolOptions>;
   private readonly libp2p: Libp2p;
   private readonly peerManager: PeerManager;
-  private readonly connectionManager: ConnectionManager;
   private readonly protocol: StoreCore;
 
   public constructor(params: StoreConstructorParams) {
     this.options = params.options || {};
     this.peerManager = params.peerManager;
-    this.connectionManager = params.connectionManager;
     this.libp2p = params.libp2p;
 
     this.protocol = new StoreCore(params.libp2p);
@@ -229,14 +226,6 @@ export class Store implements IStore {
     }
 
     const pubsubTopicForQuery = uniquePubsubTopicsInQuery[0];
-    const isPubsubSupported =
-      this.connectionManager.pubsubTopics.includes(pubsubTopicForQuery);
-
-    if (!isPubsubSupported) {
-      throw new Error(
-        `Pubsub topic ${pubsubTopicForQuery} has not been configured on this instance. Configured topics are: ${this.connectionManager.pubsubTopics}`
-      );
-    }
 
     const decodersAsMap = new Map();
     decoders.forEach((dec) => {


### PR DESCRIPTION
The of an edge "subscribed" to given pubsub topics is incorrect as an edge node may dynamically attempt to subscribe or send messages on various shards. Especially with autosharding where sharding is abstracted to the developer.

What really matter, is for an edge node to find service nodes that are supporting the right shards.

The only scenario that may matter is for relay, but gossipsub handles the pubsub topic peer filter and management.

Removing this, simplifies the code by removing the need of pubsub topic passing to medata.

### Problem / Description

Please look at both commit texts!

### Solution
<!--
Describe how the problem is solved in this PR.
- Provide an overview of the changes made.
- Highlight any significant design decisions or architectural changes.
-->

### Notes
<!--
Additional context, considerations, or information relevant to this PR.
- Are there known limitations or trade-offs in the solution?
- Include links to related discussions, documents, or references.
-->
- Resolves
- Related to

---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
