### PR TITLE
chore: remove mocha retries

### DIFF
--- a/packages/core/.mocharc.cjs
+++ b/packages/core/.mocharc.cjs
@@ -8,7 +8,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 4,
+  retries: 0,
 };
 
 if (process.env.CI) {

--- a/packages/discovery/.mocharc.cjs
+++ b/packages/discovery/.mocharc.cjs
@@ -8,7 +8,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 4
+  retries: 0
 };
 
 if (process.env.CI) {

--- a/packages/enr/.mocharc.cjs
+++ b/packages/enr/.mocharc.cjs
@@ -8,7 +8,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 4
+  retries: 0
 };
 
 if (process.env.CI) {

--- a/packages/message-encryption/.mocharc.cjs
+++ b/packages/message-encryption/.mocharc.cjs
@@ -8,7 +8,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 4
+  retries: 0
 };
 
 if (process.env.CI) {

--- a/packages/relay/.mocharc.cjs
+++ b/packages/relay/.mocharc.cjs
@@ -8,7 +8,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 4
+  retries: 0
 };
 
 if (process.env.CI) {

--- a/packages/rln/.mocharc.cjs
+++ b/packages/rln/.mocharc.cjs
@@ -8,7 +8,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 4
+  retries: 0
 };
 
 if (process.env.CI) {

--- a/packages/sdk/.mocharc.cjs
+++ b/packages/sdk/.mocharc.cjs
@@ -8,7 +8,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 4
+  retries: 0
 };
 
 if (process.env.CI) {

--- a/packages/sds/.mocharc.cjs
+++ b/packages/sds/.mocharc.cjs
@@ -8,7 +8,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 2
+  retries: 0
 };
 
 if (process.env.CI) {

--- a/packages/tests/.mocharc.cjs
+++ b/packages/tests/.mocharc.cjs
@@ -7,7 +7,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 4
+  retries: 0
 };
 
 if (process.env.CI) {

--- a/packages/utils/.mocharc.cjs
+++ b/packages/utils/.mocharc.cjs
@@ -8,7 +8,7 @@ const config = {
     'loader=ts-node/esm'
   ],
   exit: true,
-  retries: 4
+  retries: 0
 };
 
 if (process.env.CI) {


### PR DESCRIPTION
### Problem / Description
Right now we have generous `4` retries policy.
This is a bad smell on it's own that we need to retry a test 4 times.

It was introduced as a remedy to flanky tests.
The path forward as I see is to identify such tests and fix or plan a proper investigation. 

### Solution
Remove retries and see.

### Notes
- Resolves
- Related to

---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
