### PR TITLE
fix: should not self-acknowledge messages

### DIFF
--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -11,6 +11,7 @@ export enum MessageChannelEvent {
   SyncReceived = "syncReceived"
 }
 
+export type MessageId = string;
 export type Message = proto_sds_message.SdsMessage;
 export type HistoryEntry = proto_sds_message.HistoryEntry;
 export type ChannelId = string;
@@ -26,13 +27,13 @@ export function decodeMessage(data: Uint8Array): Message {
 export type MessageChannelEvents = {
   [MessageChannelEvent.MessageSent]: CustomEvent<Message>;
   [MessageChannelEvent.MessageDelivered]: CustomEvent<{
-    messageId: string;
+    messageId: MessageId;
     sentOrReceived: "sent" | "received";
   }>;
   [MessageChannelEvent.MessageReceived]: CustomEvent<Message>;
-  [MessageChannelEvent.MessageAcknowledged]: CustomEvent<string>;
+  [MessageChannelEvent.MessageAcknowledged]: CustomEvent<MessageId>;
   [MessageChannelEvent.PartialAcknowledgement]: CustomEvent<{
-    messageId: string;
+    messageId: MessageId;
     count: number;
   }>;
   [MessageChannelEvent.MissedMessages]: CustomEvent<HistoryEntry[]>;

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -293,6 +293,21 @@ describe("MessageChannel", function () {
       );
     });
 
+    it("should not mark messages in causal history as acknowledged if it's our own message", async () => {
+      for (const m of messagesA) {
+        await sendMessage(channelA, utf8ToBytes(m), async (message) => {
+          await receiveMessage(channelA, message); // same channel used on purpose
+          return { success: true };
+        });
+      }
+      await channelA.processTasks();
+
+      // All messages remain in the buffer
+      expect((channelA as any).outgoingBuffer.length).to.equal(
+        messagesA.length
+      );
+    });
+
     it("should track probabilistic acknowledgements of messages received in bloom filter", async () => {
       const acknowledgementCount = (channelA as any).acknowledgementCount;
 

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -391,6 +391,20 @@ describe("MessageChannel", function () {
         ).to.equal(true);
       });
     });
+
+    it("should not track probabilistic acknowledgements of messages received in bloom filter of own messages", async () => {
+      for (const m of messagesA) {
+        await sendMessage(channelA, utf8ToBytes(m), async (message) => {
+          await receiveMessage(channelA, message);
+          return { success: true };
+        });
+      }
+
+      const acknowledgements: ReadonlyMap<MessageId, number> = (channelA as any)
+        .acknowledgements;
+
+      expect(acknowledgements.size).to.equal(0);
+    });
   });
 
   describe("Sweeping incoming buffer", () => {

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 
 import { DefaultBloomFilter } from "../bloom_filter/bloom.js";
 
-import { HistoryEntry, Message } from "./events.js";
+import { HistoryEntry, Message, MessageId } from "./events.js";
 import {
   DEFAULT_BLOOM_FILTER_OPTIONS,
   MessageChannel
@@ -326,7 +326,7 @@ describe("MessageChannel", function () {
         }
       );
 
-      const acknowledgements: ReadonlyMap<string, number> = (channelA as any)
+      const acknowledgements: ReadonlyMap<MessageId, number> = (channelA as any)
         .acknowledgements;
       // Other than the message IDs which were included in causal history,
       // the remaining messages sent by channel A should be considered possibly acknowledged
@@ -566,7 +566,7 @@ describe("MessageChannel", function () {
 
       const localLog = (channelA as any).localHistory as {
         timestamp: number;
-        messageId: string;
+        messageId: MessageId;
       }[];
       expect(localLog.length).to.equal(0);
     });
@@ -585,7 +585,7 @@ describe("MessageChannel", function () {
 
       const localLog = (channelB as any).localHistory as {
         timestamp: number;
-        messageId: string;
+        messageId: MessageId;
       }[];
       expect(localLog.length).to.equal(0);
 

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -40,6 +40,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
   private incomingBuffer: Message[];
   private localHistory: { timestamp: number; historyEntry: HistoryEntry }[];
   private timeReceived: Map<MessageId, number>;
+  // TODO: Would be better if it's persisted
   private outgoingMessages: Set<MessageId>;
   private readonly causalHistorySize: number;
   private readonly acknowledgementCount: number;

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -40,7 +40,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
   private incomingBuffer: Message[];
   private localHistory: { timestamp: number; historyEntry: HistoryEntry }[];
   private timeReceived: Map<MessageId, number>;
-  // TODO: Would be better if it's persisted
+  // TODO: To be removed once sender id is added to SDS protocol
   private outgoingMessages: Set<MessageId>;
   private readonly causalHistorySize: number;
   private readonly acknowledgementCount: number;

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -1,5 +1,5 @@
 import { TypedEventEmitter } from "@libp2p/interface";
-import { sha256 } from "@noble/hashes/sha256";
+import { sha256 } from "@noble/hashes/sha2";
 import { bytesToHex } from "@noble/hashes/utils";
 import { Logger } from "@waku/utils";
 
@@ -40,10 +40,10 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
   private incomingBuffer: Message[];
   private localHistory: { timestamp: number; historyEntry: HistoryEntry }[];
   private causalHistorySize: number;
-  private acknowledgementCount: number;
+  private readonly acknowledgementCount: number;
   private timeReceived: Map<MessageId, number>;
-  private receivedMessageTimeoutEnabled: boolean;
-  private receivedMessageTimeout: number;
+  private readonly receivedMessageTimeoutEnabled: boolean;
+  private readonly receivedMessageTimeout: number;
 
   private tasks: Task[] = [];
   private handlers: Handlers = {

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -11,7 +11,8 @@ import {
   HistoryEntry,
   Message,
   MessageChannelEvent,
-  MessageChannelEvents
+  MessageChannelEvents,
+  type MessageId
 } from "./events.js";
 
 export const DEFAULT_BLOOM_FILTER_OPTIONS = {
@@ -35,12 +36,12 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
   private lamportTimestamp: number;
   private filter: DefaultBloomFilter;
   private outgoingBuffer: Message[];
-  private acknowledgements: Map<string, number>;
+  private acknowledgements: Map<MessageId, number>;
   private incomingBuffer: Message[];
   private localHistory: { timestamp: number; historyEntry: HistoryEntry }[];
   private causalHistorySize: number;
   private acknowledgementCount: number;
-  private timeReceived: Map<string, number>;
+  private timeReceived: Map<MessageId, number>;
   private receivedMessageTimeoutEnabled: boolean;
   private receivedMessageTimeout: number;
 
@@ -85,7 +86,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
       options.receivedMessageTimeout ?? DEFAULT_RECEIVED_MESSAGE_TIMEOUT;
   }
 
-  public static getMessageId(payload: Uint8Array): string {
+  public static getMessageId(payload: Uint8Array): MessageId {
     return bytesToHex(sha256(payload));
   }
 


### PR DESCRIPTION
### Problem / Description

In the SDS implementation, all messages received are used for acknowledgement purposes.
Including messages that were sent by the local node.

In the context of Waku, one cannot assume their nodes only received messages from other nodes.

### Solution

Track messages that were sent by the local node, and discard them for acknowledgement purposes.\

### Notes

Long term solution is to introduced a `senderId` in SDS. This can be tracked another PR for spec and code.
This present solution helps moving the needle to something usable.

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [ ] ~Code changes are **covered by e2e tests**, if applicable.~
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [x] All **CI checks** pass successfully.
