### PR TITLE
fix: bloom filter protobuf decoding

### DIFF
--- a/packages/sds/src/bloom_filter/bloom.ts
+++ b/packages/sds/src/bloom_filter/bloom.ts
@@ -124,7 +124,7 @@ export class BloomFilter {
     hashN: (item: string, n: number, maxValue: number) => number
   ): BloomFilter {
     const bloomFilter = new BloomFilter(options, hashN);
-    const view = new DataView(bytes.buffer);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     for (let i = 0; i < bloomFilter.data.length; i++) {
       bloomFilter.data[i] = view.getBigUint64(i * 8, false);
     }

--- a/packages/sds/src/message_channel/events.spec.ts
+++ b/packages/sds/src/message_channel/events.spec.ts
@@ -7,12 +7,10 @@ import { DEFAULT_BLOOM_FILTER_OPTIONS } from "./message_channel.js";
 
 describe("Message serialization", () => {
   it("Bloom filter", () => {
-    const messageIds = ["first", "second", "third"];
+    const messageId = "first";
 
     const bloomFilter = new DefaultBloomFilter(DEFAULT_BLOOM_FILTER_OPTIONS);
-    for (const id of messageIds) {
-      bloomFilter.insert(id);
-    }
+    bloomFilter.insert(messageId);
 
     const message: Message = {
       messageId: "123",
@@ -21,14 +19,15 @@ describe("Message serialization", () => {
       lamportTimestamp: 0,
       bloomFilter: bloomFilter.toBytes()
     };
+
     const bytes = encodeMessage(message);
     const decMessage = decodeMessage(bytes);
+
     const decBloomFilter = DefaultBloomFilter.fromBytes(
       decMessage!.bloomFilter!,
       DEFAULT_BLOOM_FILTER_OPTIONS
     );
-    for (const id of messageIds) {
-      expect(decBloomFilter.lookup(id)).to.be.true;
-    }
+
+    expect(decBloomFilter.lookup(messageId)).to.be.true;
   });
 });

--- a/packages/sds/src/message_channel/events.spec.ts
+++ b/packages/sds/src/message_channel/events.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+
+import { DefaultBloomFilter } from "../bloom_filter/bloom.js";
+
+import { decodeMessage, encodeMessage, Message } from "./events.js";
+import { DEFAULT_BLOOM_FILTER_OPTIONS } from "./message_channel.js";
+
+describe("Message serialization", () => {
+  it("Bloom filter", () => {
+    const messageIds = ["first", "second", "third"];
+
+    const bloomFilter = new DefaultBloomFilter(DEFAULT_BLOOM_FILTER_OPTIONS);
+    for (const id of messageIds) {
+      bloomFilter.insert(id);
+    }
+
+    const message: Message = {
+      messageId: "123",
+      channelId: "my-channel",
+      causalHistory: [],
+      lamportTimestamp: 0,
+      bloomFilter: bloomFilter.toBytes()
+    };
+    const bytes = encodeMessage(message);
+    const decMessage = decodeMessage(bytes);
+    const decBloomFilter = DefaultBloomFilter.fromBytes(
+      decMessage!.bloomFilter!,
+      DEFAULT_BLOOM_FILTER_OPTIONS
+    );
+    for (const id of messageIds) {
+      expect(decBloomFilter.lookup(id)).to.be.true;
+    }
+  });
+});


### PR DESCRIPTION
### Problem / Description

Bloom filters cannot be used once decoded from protobuf.

### Solution

This is because the `UInt8Array` passed is coming from the whole protobuf decoding, ie, with more bytes than just the bloom filter.
Which is why, it is important to always use the offset and length when using the buffer of a byte array.
This is to ensure the right bytes are used to re-build the bloom filter.

### Notes

It took me many hours to find the culprit
Resolves https://github.com/waku-org/js-waku/issues/2385

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [ ] ~Code changes are **covered by e2e tests**, if applicable.~
- [ ] ~**Dogfooding has been performed**, if feasible.~
- [ ] ~A **test version has been published**, if required.~
- [ ] All **CI checks** pass successfully.
