### PR TITLE
feat!: SDS improvements and fixes

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
   "language": "en",
   "words": [
     "abortable",
+    "acks",
     "Addrs",
     "ahadns",
     "Alives",

--- a/packages/proto/src/generated/sds_message.ts
+++ b/packages/proto/src/generated/sds_message.ts
@@ -81,6 +81,7 @@ export namespace HistoryEntry {
 }
 
 export interface SdsMessage {
+  senderId: string
   messageId: string
   channelId: string
   lamportTimestamp?: number
@@ -97,6 +98,11 @@ export namespace SdsMessage {
       _codec = message<SdsMessage>((obj, w, opts = {}) => {
         if (opts.lengthDelimited !== false) {
           w.fork()
+        }
+
+        if ((obj.senderId != null && obj.senderId !== '')) {
+          w.uint32(10)
+          w.string(obj.senderId)
         }
 
         if ((obj.messageId != null && obj.messageId !== '')) {
@@ -136,6 +142,7 @@ export namespace SdsMessage {
         }
       }, (reader, length, opts = {}) => {
         const obj: any = {
+          senderId: '',
           messageId: '',
           channelId: '',
           causalHistory: []
@@ -147,6 +154,10 @@ export namespace SdsMessage {
           const tag = reader.uint32()
 
           switch (tag >>> 3) {
+            case 1: {
+              obj.senderId = reader.string()
+              break
+            }
             case 2: {
               obj.messageId = reader.string()
               break

--- a/packages/proto/src/lib/sds_message.proto
+++ b/packages/proto/src/lib/sds_message.proto
@@ -6,7 +6,7 @@ message HistoryEntry {
 }
 
 message SdsMessage {
-  // 1 Reserved for sender/participant id
+  string sender_id = 1;           // Participant ID of the message sender
   string message_id = 2;          // Unique identifier of the message
   string channel_id = 3;          // Identifier of the channel to which the message belongs
   optional int32 lamport_timestamp = 10;    // Logical timestamp for causal ordering in channel

--- a/packages/sds/src/index.ts
+++ b/packages/sds/src/index.ts
@@ -3,8 +3,7 @@ import { BloomFilter } from "./bloom_filter/bloom.js";
 export {
   MessageChannel,
   MessageChannelEvent,
-  encodeMessage,
-  decodeMessage
+  MessageChannelOptions
 } from "./message_channel/index.js";
 
 export type {

--- a/packages/sds/src/index.ts
+++ b/packages/sds/src/index.ts
@@ -6,11 +6,11 @@ export {
   MessageChannelOptions
 } from "./message_channel/index.js";
 
-export type {
+export {
   Message,
-  HistoryEntry,
-  ChannelId,
-  MessageChannelEvents
+  type HistoryEntry,
+  type ChannelId,
+  type MessageChannelEvents
 } from "./message_channel/index.js";
 
 export { BloomFilter };

--- a/packages/sds/src/index.ts
+++ b/packages/sds/src/index.ts
@@ -10,7 +10,8 @@ export {
   Message,
   type HistoryEntry,
   type ChannelId,
-  type MessageChannelEvents
+  type MessageChannelEvents,
+  type SenderId
 } from "./message_channel/index.js";
 
 export { BloomFilter };

--- a/packages/sds/src/message_channel/events.spec.ts
+++ b/packages/sds/src/message_channel/events.spec.ts
@@ -15,6 +15,7 @@ describe("Message serialization", () => {
     const message = new Message(
       "123",
       "my-channel",
+      "me",
       [],
       0,
       bloomFilter.toBytes(),

--- a/packages/sds/src/message_channel/events.spec.ts
+++ b/packages/sds/src/message_channel/events.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import { DefaultBloomFilter } from "../bloom_filter/bloom.js";
 
-import { decodeMessage, encodeMessage, Message } from "./events.js";
+import { Message } from "./events.js";
 import { DEFAULT_BLOOM_FILTER_OPTIONS } from "./message_channel.js";
 
 describe("Message serialization", () => {
@@ -12,16 +12,17 @@ describe("Message serialization", () => {
     const bloomFilter = new DefaultBloomFilter(DEFAULT_BLOOM_FILTER_OPTIONS);
     bloomFilter.insert(messageId);
 
-    const message: Message = {
-      messageId: "123",
-      channelId: "my-channel",
-      causalHistory: [],
-      lamportTimestamp: 0,
-      bloomFilter: bloomFilter.toBytes()
-    };
+    const message = new Message(
+      "123",
+      "my-channel",
+      [],
+      0,
+      bloomFilter.toBytes(),
+      undefined
+    );
 
-    const bytes = encodeMessage(message);
-    const decMessage = decodeMessage(bytes);
+    const bytes = message.encode();
+    const decMessage = Message.decode(bytes);
 
     const decBloomFilter = DefaultBloomFilter.fromBytes(
       decMessage!.bloomFilter!,

--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -12,16 +12,41 @@ export enum MessageChannelEvent {
 }
 
 export type MessageId = string;
-export type Message = proto_sds_message.SdsMessage;
 export type HistoryEntry = proto_sds_message.HistoryEntry;
 export type ChannelId = string;
 
-export function encodeMessage(message: Message): Uint8Array {
-  return proto_sds_message.SdsMessage.encode(message);
-}
+export class Message implements proto_sds_message.SdsMessage {
+  public constructor(
+    public messageId: string,
+    public channelId: string,
+    public causalHistory: proto_sds_message.HistoryEntry[],
+    public lamportTimestamp?: number | undefined,
+    public bloomFilter?: Uint8Array<ArrayBufferLike> | undefined,
+    public content?: Uint8Array<ArrayBufferLike> | undefined
+  ) {}
 
-export function decodeMessage(data: Uint8Array): Message {
-  return proto_sds_message.SdsMessage.decode(data);
+  public encode(): Uint8Array {
+    return proto_sds_message.SdsMessage.encode(this);
+  }
+
+  public static decode(data: Uint8Array): Message {
+    const {
+      messageId,
+      channelId,
+      causalHistory,
+      lamportTimestamp,
+      bloomFilter,
+      content
+    } = proto_sds_message.SdsMessage.decode(data);
+    return new Message(
+      messageId,
+      channelId,
+      causalHistory,
+      lamportTimestamp,
+      bloomFilter,
+      content
+    );
+  }
 }
 
 export type MessageChannelEvents = {

--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -8,7 +8,7 @@ export enum MessageChannelEvent {
   OutMessagePossiblyAcknowledged = "sds:out:message-possibly-acknowledged",
   InMessageMissing = "sds:in:message-missing",
   OutSyncSent = "sds:out:sync-sent",
-  InSyncDelivered = "sds:in:sync-delivered",
+  InSyncReceived = "sds:in:sync-received",
   InMessageIrretrievablyLost = "sds:in:message-irretrievably-lost",
   ErrorTask = "sds:error-task"
 }
@@ -63,6 +63,6 @@ export type MessageChannelEvents = {
   [MessageChannelEvent.InMessageMissing]: CustomEvent<HistoryEntry[]>;
   [MessageChannelEvent.InMessageIrretrievablyLost]: CustomEvent<HistoryEntry[]>;
   [MessageChannelEvent.OutSyncSent]: CustomEvent<Message>;
-  [MessageChannelEvent.InSyncDelivered]: CustomEvent<Message>;
+  [MessageChannelEvent.InSyncReceived]: CustomEvent<Message>;
   [MessageChannelEvent.ErrorTask]: CustomEvent<any>;
 };

--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -1,18 +1,14 @@
 import { proto_sds_message } from "@waku/proto";
 
 export enum MessageChannelEvent {
-  // TODO: events are usually in the form `domain:name`
-  // here it should be `sds:<name>`
-  // also, it can be confusing to know if we are talking about incoming
-  // or outgoing. suggesting `sds:in` or `sds:out` format.
-  MessageSent = "messageSent",
-  MessageDelivered = "messageDelivered",
-  MessageReceived = "messageReceived",
-  MessageAcknowledged = "messageAcknowledged",
-  MessagePossiblyAcknowledged = "messagePossiblyAcknowledged",
-  MissedMessages = "missedMessages",
-  SyncSent = "syncSent",
-  SyncReceived = "syncReceived"
+  OutMessageSent = "sds:out:message-sent",
+  InMessageDelivered = "sds:in:message-delivered",
+  InMessageReceived = "sds:in:message-received",
+  OutMessageAcknowledged = "sds:out:message-acknowledged",
+  OutMessagePossiblyAcknowledged = "sds:out:message-possibly-acknowledged",
+  InMessageMissing = "sds:in:message-missing",
+  OutSyncSent = "sds:out:sync-sent",
+  InSyncDelivered = "sds:in:sync-delivered"
 }
 
 export type MessageId = string;
@@ -54,15 +50,15 @@ export class Message implements proto_sds_message.SdsMessage {
 }
 
 export type MessageChannelEvents = {
-  [MessageChannelEvent.MessageSent]: CustomEvent<Message>;
-  [MessageChannelEvent.MessageDelivered]: CustomEvent<MessageId>;
-  [MessageChannelEvent.MessageReceived]: CustomEvent<Message>;
-  [MessageChannelEvent.MessageAcknowledged]: CustomEvent<MessageId>;
-  [MessageChannelEvent.MessagePossiblyAcknowledged]: CustomEvent<{
+  [MessageChannelEvent.OutMessageSent]: CustomEvent<Message>;
+  [MessageChannelEvent.InMessageDelivered]: CustomEvent<MessageId>;
+  [MessageChannelEvent.InMessageReceived]: CustomEvent<Message>;
+  [MessageChannelEvent.OutMessageAcknowledged]: CustomEvent<MessageId>;
+  [MessageChannelEvent.OutMessagePossiblyAcknowledged]: CustomEvent<{
     messageId: MessageId;
     count: number;
   }>;
-  [MessageChannelEvent.MissedMessages]: CustomEvent<HistoryEntry[]>;
-  [MessageChannelEvent.SyncSent]: CustomEvent<Message>;
-  [MessageChannelEvent.SyncReceived]: CustomEvent<Message>;
+  [MessageChannelEvent.InMessageMissing]: CustomEvent<HistoryEntry[]>;
+  [MessageChannelEvent.OutSyncSent]: CustomEvent<Message>;
+  [MessageChannelEvent.InSyncDelivered]: CustomEvent<Message>;
 };

--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -16,11 +16,13 @@ export enum MessageChannelEvent {
 export type MessageId = string;
 export type HistoryEntry = proto_sds_message.HistoryEntry;
 export type ChannelId = string;
+export type SenderId = string;
 
 export class Message implements proto_sds_message.SdsMessage {
   public constructor(
     public messageId: string,
     public channelId: string,
+    public senderId: string,
     public causalHistory: proto_sds_message.HistoryEntry[],
     public lamportTimestamp?: number | undefined,
     public bloomFilter?: Uint8Array<ArrayBufferLike> | undefined,
@@ -35,6 +37,7 @@ export class Message implements proto_sds_message.SdsMessage {
     const {
       messageId,
       channelId,
+      senderId,
       causalHistory,
       lamportTimestamp,
       bloomFilter,
@@ -43,6 +46,7 @@ export class Message implements proto_sds_message.SdsMessage {
     return new Message(
       messageId,
       channelId,
+      senderId,
       causalHistory,
       lamportTimestamp,
       bloomFilter,

--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -1,11 +1,16 @@
 import { proto_sds_message } from "@waku/proto";
 
 export enum MessageChannelEvent {
+  // TODO: events are usually in the form `domain:name`
+  // here it should be `sds:<name>`
+  // also, it can be confusing to know if we are talking about incoming
+  // or outgoing. suggesting `sds:in` or `sds:out` format.
   MessageSent = "messageSent",
+  // TODO: Is this "delivered" event of any use?
   MessageDelivered = "messageDelivered",
   MessageReceived = "messageReceived",
   MessageAcknowledged = "messageAcknowledged",
-  PartialAcknowledgement = "partialAcknowledgement",
+  MessagePossiblyAcknowledged = "messagePossiblyAcknowledged",
   MissedMessages = "missedMessages",
   SyncSent = "syncSent",
   SyncReceived = "syncReceived"
@@ -57,7 +62,7 @@ export type MessageChannelEvents = {
   }>;
   [MessageChannelEvent.MessageReceived]: CustomEvent<Message>;
   [MessageChannelEvent.MessageAcknowledged]: CustomEvent<MessageId>;
-  [MessageChannelEvent.PartialAcknowledgement]: CustomEvent<{
+  [MessageChannelEvent.MessagePossiblyAcknowledged]: CustomEvent<{
     messageId: MessageId;
     count: number;
   }>;

--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -58,6 +58,7 @@ export type MessageChannelEvents = {
   [MessageChannelEvent.MessageSent]: CustomEvent<Message>;
   [MessageChannelEvent.MessageDelivered]: CustomEvent<{
     messageId: MessageId;
+    // TODO: this is never set to "sent"
     sentOrReceived: "sent" | "received";
   }>;
   [MessageChannelEvent.MessageReceived]: CustomEvent<Message>;

--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -6,7 +6,6 @@ export enum MessageChannelEvent {
   // also, it can be confusing to know if we are talking about incoming
   // or outgoing. suggesting `sds:in` or `sds:out` format.
   MessageSent = "messageSent",
-  // TODO: Is this "delivered" event of any use?
   MessageDelivered = "messageDelivered",
   MessageReceived = "messageReceived",
   MessageAcknowledged = "messageAcknowledged",
@@ -56,11 +55,7 @@ export class Message implements proto_sds_message.SdsMessage {
 
 export type MessageChannelEvents = {
   [MessageChannelEvent.MessageSent]: CustomEvent<Message>;
-  [MessageChannelEvent.MessageDelivered]: CustomEvent<{
-    messageId: MessageId;
-    // TODO: this is never set to "sent"
-    sentOrReceived: "sent" | "received";
-  }>;
+  [MessageChannelEvent.MessageDelivered]: CustomEvent<MessageId>;
   [MessageChannelEvent.MessageReceived]: CustomEvent<Message>;
   [MessageChannelEvent.MessageAcknowledged]: CustomEvent<MessageId>;
   [MessageChannelEvent.MessagePossiblyAcknowledged]: CustomEvent<{

--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -8,7 +8,8 @@ export enum MessageChannelEvent {
   OutMessagePossiblyAcknowledged = "sds:out:message-possibly-acknowledged",
   InMessageMissing = "sds:in:message-missing",
   OutSyncSent = "sds:out:sync-sent",
-  InSyncDelivered = "sds:in:sync-delivered"
+  InSyncDelivered = "sds:in:sync-delivered",
+  ErrorTask = "sds:error-task"
 }
 
 export type MessageId = string;
@@ -61,4 +62,5 @@ export type MessageChannelEvents = {
   [MessageChannelEvent.InMessageMissing]: CustomEvent<HistoryEntry[]>;
   [MessageChannelEvent.OutSyncSent]: CustomEvent<Message>;
   [MessageChannelEvent.InSyncDelivered]: CustomEvent<Message>;
+  [MessageChannelEvent.ErrorTask]: CustomEvent<any>;
 };

--- a/packages/sds/src/message_channel/events.ts
+++ b/packages/sds/src/message_channel/events.ts
@@ -9,6 +9,7 @@ export enum MessageChannelEvent {
   InMessageMissing = "sds:in:message-missing",
   OutSyncSent = "sds:out:sync-sent",
   InSyncDelivered = "sds:in:sync-delivered",
+  InMessageIrretrievablyLost = "sds:in:message-irretrievably-lost",
   ErrorTask = "sds:error-task"
 }
 
@@ -60,6 +61,7 @@ export type MessageChannelEvents = {
     count: number;
   }>;
   [MessageChannelEvent.InMessageMissing]: CustomEvent<HistoryEntry[]>;
+  [MessageChannelEvent.InMessageIrretrievablyLost]: CustomEvent<HistoryEntry[]>;
   [MessageChannelEvent.OutSyncSent]: CustomEvent<Message>;
   [MessageChannelEvent.InSyncDelivered]: CustomEvent<Message>;
   [MessageChannelEvent.ErrorTask]: CustomEvent<any>;

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -241,8 +241,8 @@ describe("MessageChannel", function () {
 
   describe("reviewing ack status", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId);
-      channelB = new MessageChannel(channelId);
+      channelA = new MessageChannel(channelId, { causalHistorySize: 2 });
+      channelB = new MessageChannel(channelId, { causalHistorySize: 2 });
     });
 
     it("should mark all messages in causal history as acknowledged", async () => {
@@ -409,8 +409,8 @@ describe("MessageChannel", function () {
 
   describe("Sweeping incoming buffer", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId);
-      channelB = new MessageChannel(channelId);
+      channelA = new MessageChannel(channelId, { causalHistorySize: 2 });
+      channelB = new MessageChannel(channelId, { causalHistorySize: 2 });
     });
 
     it("should detect messages with missing dependencies", async () => {
@@ -526,8 +526,8 @@ describe("MessageChannel", function () {
 
   describe("Sweeping outgoing buffer", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId);
-      channelB = new MessageChannel(channelId);
+      channelA = new MessageChannel(channelId, { causalHistorySize: 2 });
+      channelB = new MessageChannel(channelId, { causalHistorySize: 2 });
     });
 
     it("should partition messages based on acknowledgement status", async () => {
@@ -571,8 +571,8 @@ describe("MessageChannel", function () {
 
   describe("Sync messages", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId);
-      channelB = new MessageChannel(channelId);
+      channelA = new MessageChannel(channelId, { causalHistorySize: 2 });
+      channelB = new MessageChannel(channelId, { causalHistorySize: 2 });
     });
 
     it("should be sent with empty content", async () => {

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -375,7 +375,7 @@ describe("MessageChannel", function () {
         });
       }
 
-      // No more partial acknowledgements should be in channel A
+      // No more possible acknowledgements should be in channel A
       expect(possibleAcks.size).to.equal(0);
 
       // Messages that were not acknowledged should still be in the outgoing buffer

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -498,8 +498,7 @@ describe("MessageChannel", function () {
     it("should mark a message as irretrievably lost if timeout is exceeded", async () => {
       // Create a channel with very very short timeout
       const channelC: MessageChannel = new MessageChannel(channelId, {
-        receivedMessageTimeoutEnabled: true,
-        receivedMessageTimeout: 10
+        timeoutToMarkMessageIrretrievableMs: 10
       });
 
       for (const m of messagesA) {
@@ -543,8 +542,7 @@ describe("MessageChannel", function () {
       const causalHistorySize = (channelA as any).causalHistorySize;
       // Create a channel with very very short timeout
       const channelC: MessageChannel = new MessageChannel(channelId, {
-        receivedMessageTimeoutEnabled: true,
-        receivedMessageTimeout: 10
+        timeoutToMarkMessageIrretrievableMs: 10
       });
 
       for (const m of messagesA) {

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -429,23 +429,17 @@ describe("MessageChannel", function () {
 
       await sendMessage(channelA, firstMessage, callback);
 
-      await sendMessage(
-        channelA,
-        utf8ToBytes("second message"),
-        async (message) => {
-          await receiveMessage(channelB, message);
-          return { success: true };
-        }
-      );
+      const secondMessage = utf8ToBytes("second message");
+      await sendMessage(channelA, secondMessage, async (message) => {
+        await receiveMessage(channelB, message);
+        return { success: true };
+      });
 
-      await sendMessage(
-        channelB,
-        utf8ToBytes("message back, will it ack first message?"),
-        async (message) => {
-          await receiveMessage(channelA, message);
-          return { success: true };
-        }
-      );
+      const thirdMessage = utf8ToBytes("third message");
+      await sendMessage(channelB, thirdMessage, async (message) => {
+        await receiveMessage(channelA, message);
+        return { success: true };
+      });
 
       expect(messageAcked).to.be.false;
 

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -531,10 +531,8 @@ describe("MessageChannel", function () {
     });
 
     it("should partition messages based on acknowledgement status", async () => {
-      const unacknowledgedMessages: Message[] = [];
       for (const m of messagesA) {
         await sendMessage(channelA, utf8ToBytes(m), async (message) => {
-          unacknowledgedMessages.push(message);
           await receiveMessage(channelB, message);
           return { success: true };
         });

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -576,14 +576,14 @@ describe("MessageChannel", function () {
     });
 
     it("should be sent with empty content", async () => {
-      await channelA.sendSyncMessage(async (message) => {
+      await channelA.pushOutgoingSyncMessage(async (message) => {
         expect(message.content?.length).to.equal(0);
         return true;
       });
     });
 
     it("should not be added to outgoing buffer, bloom filter, or local log", async () => {
-      await channelA.sendSyncMessage();
+      await channelA.pushOutgoingSyncMessage();
 
       const outgoingBuffer = (channelA as any).outgoingBuffer as Message[];
       expect(outgoingBuffer.length).to.equal(0);
@@ -603,7 +603,7 @@ describe("MessageChannel", function () {
     it("should be delivered but not added to local log or bloom filter", async () => {
       const timestampBefore = (channelB as any).lamportTimestamp;
       let expectedTimestamp: number | undefined;
-      await channelA.sendSyncMessage(async (message) => {
+      await channelA.pushOutgoingSyncMessage(async (message) => {
         expectedTimestamp = message.lamportTimestamp;
         await receiveMessage(channelB, message);
         return true;

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -56,7 +56,7 @@ describe("MessageChannel", function () {
 
   describe("sending a message ", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId);
+      channelA = new MessageChannel(channelId, "alice");
     });
 
     it("should increase lamport timestamp", async () => {
@@ -138,8 +138,8 @@ describe("MessageChannel", function () {
 
   describe("receiving a message", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId);
-      channelB = new MessageChannel(channelId);
+      channelA = new MessageChannel(channelId, "alice");
+      channelB = new MessageChannel(channelId, "bob");
     });
 
     it("should increase lamport timestamp", async () => {
@@ -246,8 +246,10 @@ describe("MessageChannel", function () {
 
   describe("reviewing ack status", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId, { causalHistorySize: 2 });
-      channelB = new MessageChannel(channelId, { causalHistorySize: 2 });
+      channelA = new MessageChannel(channelId, "alice", {
+        causalHistorySize: 2
+      });
+      channelB = new MessageChannel(channelId, "bob", { causalHistorySize: 2 });
     });
 
     it("should mark all messages in causal history as acknowledged", async () => {
@@ -414,8 +416,10 @@ describe("MessageChannel", function () {
 
   describe("Sweeping incoming buffer", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId, { causalHistorySize: 2 });
-      channelB = new MessageChannel(channelId, { causalHistorySize: 2 });
+      channelA = new MessageChannel(channelId, "alice", {
+        causalHistorySize: 2
+      });
+      channelB = new MessageChannel(channelId, "bob", { causalHistorySize: 2 });
     });
 
     it("should detect messages with missing dependencies", async () => {
@@ -497,7 +501,7 @@ describe("MessageChannel", function () {
 
     it("should mark a message as irretrievably lost if timeout is exceeded", async () => {
       // Create a channel with very very short timeout
-      const channelC: MessageChannel = new MessageChannel(channelId, {
+      const channelC: MessageChannel = new MessageChannel(channelId, "carol", {
         timeoutToMarkMessageIrretrievableMs: 10
       });
 
@@ -541,7 +545,7 @@ describe("MessageChannel", function () {
     it("should remove messages without delivering if timeout is exceeded", async () => {
       const causalHistorySize = (channelA as any).causalHistorySize;
       // Create a channel with very very short timeout
-      const channelC: MessageChannel = new MessageChannel(channelId, {
+      const channelC: MessageChannel = new MessageChannel(channelId, "carol", {
         timeoutToMarkMessageIrretrievableMs: 10
       });
 
@@ -573,8 +577,10 @@ describe("MessageChannel", function () {
 
   describe("Sweeping outgoing buffer", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId, { causalHistorySize: 2 });
-      channelB = new MessageChannel(channelId, { causalHistorySize: 2 });
+      channelA = new MessageChannel(channelId, "alice", {
+        causalHistorySize: 2
+      });
+      channelB = new MessageChannel(channelId, "bob", { causalHistorySize: 2 });
     });
 
     it("should partition messages based on acknowledgement status", async () => {
@@ -616,8 +622,10 @@ describe("MessageChannel", function () {
 
   describe("Sync messages", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId, { causalHistorySize: 2 });
-      channelB = new MessageChannel(channelId, { causalHistorySize: 2 });
+      channelA = new MessageChannel(channelId, "alice", {
+        causalHistorySize: 2
+      });
+      channelB = new MessageChannel(channelId, "bob", { causalHistorySize: 2 });
     });
 
     it("should be sent with empty content", async () => {
@@ -689,7 +697,7 @@ describe("MessageChannel", function () {
 
   describe("Ephemeral messages", () => {
     beforeEach(() => {
-      channelA = new MessageChannel(channelId);
+      channelA = new MessageChannel(channelId, "alice");
     });
 
     it("should be sent without a timestamp, causal history, or bloom filter", async () => {
@@ -712,7 +720,7 @@ describe("MessageChannel", function () {
     });
 
     it("should be delivered immediately if received", async () => {
-      const channelB = new MessageChannel(channelId);
+      const channelB = new MessageChannel(channelId, "bob");
 
       // Track initial state
       const localHistoryBefore = (channelB as any).localHistory.length;

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -139,7 +139,7 @@ describe("MessageChannel", function () {
 
     it("should increase lamport timestamp", async () => {
       const timestampBefore = (channelA as any).lamportTimestamp;
-      await sendMessage(channelB, new Uint8Array(), async (message) => {
+      await sendMessage(channelB, utf8ToBytes("message"), async (message) => {
         await receiveMessage(channelA, message);
         return { success: true };
       });
@@ -600,17 +600,14 @@ describe("MessageChannel", function () {
       expect(localLog.length).to.equal(0);
     });
 
-    it("should be delivered but not added to local log or bloom filter", async () => {
+    it("should not be delivered", async () => {
       const timestampBefore = (channelB as any).lamportTimestamp;
-      let expectedTimestamp: number | undefined;
       await channelA.pushOutgoingSyncMessage(async (message) => {
-        expectedTimestamp = message.lamportTimestamp;
         await receiveMessage(channelB, message);
         return true;
       });
       const timestampAfter = (channelB as any).lamportTimestamp;
-      expect(timestampAfter).to.equal(expectedTimestamp);
-      expect(timestampAfter).to.be.greaterThan(timestampBefore);
+      expect(timestampAfter).to.equal(timestampBefore);
 
       const localLog = (channelB as any).localHistory as {
         timestamp: number;

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -253,13 +253,16 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
         }
 
         // Optionally, if a message has not been received after a predetermined amount of time,
-        // it is marked as irretrievably lost (implicitly by removing it from the buffer without delivery)
+        // its dependencies are marked as irretrievably lost (implicitly by removing it from the buffer without delivery)
         if (this.receivedMessageTimeoutEnabled) {
           const timeReceived = this.timeReceived.get(message.messageId);
           if (
             timeReceived &&
             Date.now() - timeReceived > this.receivedMessageTimeout
           ) {
+            this.safeSendEvent(MessageChannelEvent.InMessageIrretrievablyLost, {
+              detail: Array.from(missingDependencies)
+            });
             return { buffer, missing };
           }
         }

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -578,6 +578,16 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
       this.lamportTimestamp = message.lamportTimestamp;
     }
 
+    // Check if the entry is already present
+    const existingHistoryEntry = this.localHistory.find(
+      ({ historyEntry }) => historyEntry.messageId === message.messageId
+    );
+
+    // The history entry is already present, no need to re-add
+    if (existingHistoryEntry) {
+      return true;
+    }
+
     // The participant MUST insert the message ID into its local log,
     // based on Lamport timestamp.
     // If one or more message IDs with the same Lamport timestamp already exists,

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -380,12 +380,13 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
       return;
     }
 
+    // Ephemeral messages SHOULD be delivered immediately
     if (!message.lamportTimestamp) {
       this.deliverMessage(message);
       return;
     }
     if (message.content?.length === 0) {
-      this.safeSendEvent(MessageChannelEvent.InSyncDelivered, {
+      this.safeSendEvent(MessageChannelEvent.InSyncReceived, {
         detail: message
       });
     } else {

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -57,17 +57,17 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
     [Command.Send]: async (
       params: ParamsByAction[Command.Send]
     ): Promise<void> => {
-      await this._sendMessage(params.payload, params.callback);
+      await this._pushOutgoingMessage(params.payload, params.callback);
     },
     [Command.Receive]: async (
       params: ParamsByAction[Command.Receive]
     ): Promise<void> => {
-      this._receiveMessage(params.message);
+      this._pushIncomingMessage(params.message);
     },
     [Command.SendEphemeral]: async (
       params: ParamsByAction[Command.SendEphemeral]
     ): Promise<void> => {
-      await this._sendEphemeralMessage(params.payload, params.callback);
+      await this._pushOutgoingEphemeralMessage(params.payload, params.callback);
     }
   };
 
@@ -358,7 +358,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
     return false;
   }
 
-  private _receiveMessage(message: Message): void {
+  private _pushIncomingMessage(message: Message): void {
     const isDuplicate =
       message.content &&
       message.content.length > 0 &&
@@ -439,7 +439,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
     }
   }
 
-  private async _sendMessage(
+  private async _pushOutgoingMessage(
     payload: Uint8Array,
     callback?: (message: Message) => Promise<{
       success: boolean;
@@ -483,13 +483,13 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
           });
         }
       } catch (error) {
-        log.error("Callback execution failed in _sendMessage:", error);
+        log.error("Callback execution failed in _pushOutgoingMessage:", error);
         throw error;
       }
     }
   }
 
-  private async _sendEphemeralMessage(
+  private async _pushOutgoingEphemeralMessage(
     payload: Uint8Array,
     callback?: (message: Message) => Promise<boolean>
   ): Promise<void> {
@@ -506,7 +506,10 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
       try {
         await callback(message);
       } catch (error) {
-        log.error("Callback execution failed in _sendEphemeralMessage:", error);
+        log.error(
+          "Callback execution failed in _pushOutgoingEphemeralMessage:",
+          error
+        );
         throw error;
       }
     }

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -246,10 +246,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
         if (missingDependencies.length === 0) {
           if (this.deliverMessage(message)) {
             this.safeSendEvent(MessageChannelEvent.MessageDelivered, {
-              detail: {
-                messageId: message.messageId,
-                sentOrReceived: "received"
-              }
+              detail: message.messageId
             });
           }
           return { buffer, missing };
@@ -407,10 +404,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
     } else {
       if (this.deliverMessage(message)) {
         this.safeSendEvent(MessageChannelEvent.MessageDelivered, {
-          detail: {
-            messageId: message.messageId,
-            sentOrReceived: "received"
-          }
+          detail: message.messageId
         });
       }
     }

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -23,7 +23,7 @@ export const DEFAULT_BLOOM_FILTER_OPTIONS = {
 const DEFAULT_CAUSAL_HISTORY_SIZE = 2;
 const DEFAULT_RECEIVED_MESSAGE_TIMEOUT = 1000 * 60 * 5; // 5 minutes
 
-const log = new Logger("sds:message-channel");
+const log = new Logger("waku:sds:message-channel");
 
 interface MessageChannelOptions {
   causalHistorySize?: number;

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -40,6 +40,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
   private incomingBuffer: Message[];
   private localHistory: { timestamp: number; historyEntry: HistoryEntry }[];
   private timeReceived: Map<MessageId, number>;
+  // TODO: Would be better if it's persisted
   private outgoingMessages: Set<MessageId>;
   private readonly causalHistorySize: number;
   private readonly acknowledgementCount: number;

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -39,9 +39,10 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
   private acknowledgements: Map<MessageId, number>;
   private incomingBuffer: Message[];
   private localHistory: { timestamp: number; historyEntry: HistoryEntry }[];
-  private causalHistorySize: number;
-  private readonly acknowledgementCount: number;
   private timeReceived: Map<MessageId, number>;
+  private outgoingMessages: Set<MessageId>;
+  private readonly causalHistorySize: number;
+  private readonly acknowledgementCount: number;
   private readonly receivedMessageTimeoutEnabled: boolean;
   private readonly receivedMessageTimeout: number;
 

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -26,7 +26,7 @@ const DEFAULT_POSSIBLE_ACKS_THRESHOLD = 2;
 
 const log = new Logger("waku:sds:message-channel");
 
-interface MessageChannelOptions {
+export interface MessageChannelOptions {
   causalHistorySize?: number;
   /**
    * The time in milliseconds after which a message dependencies that could not

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -40,7 +40,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
   private incomingBuffer: Message[];
   private localHistory: { timestamp: number; historyEntry: HistoryEntry }[];
   private timeReceived: Map<MessageId, number>;
-  // TODO: Would be better if it's persisted
+  // TODO: To be removed once sender id is added to SDS protocol
   private outgoingMessages: Set<MessageId>;
   private readonly causalHistorySize: number;
   private readonly acknowledgementCount: number;

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -322,16 +322,16 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
 
     const emptyMessage = new Uint8Array();
 
-    const message: Message = {
-      messageId: MessageChannel.getMessageId(emptyMessage),
-      channelId: this.channelId,
-      lamportTimestamp: this.lamportTimestamp,
-      causalHistory: this.localHistory
+    const message = new Message(
+      MessageChannel.getMessageId(emptyMessage),
+      this.channelId,
+      this.localHistory
         .slice(-this.causalHistorySize)
         .map(({ historyEntry }) => historyEntry),
-      bloomFilter: this.filter.toBytes(),
-      content: emptyMessage
-    };
+      this.lamportTimestamp,
+      this.filter.toBytes(),
+      emptyMessage
+    );
 
     if (callback) {
       try {
@@ -442,16 +442,16 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
 
     this.outgoingMessages.add(messageId);
 
-    const message: Message = {
+    const message = new Message(
       messageId,
-      channelId: this.channelId,
-      lamportTimestamp: this.lamportTimestamp,
-      causalHistory: this.localHistory
+      this.channelId,
+      this.localHistory
         .slice(-this.causalHistorySize)
         .map(({ historyEntry }) => historyEntry),
-      bloomFilter: this.filter.toBytes(),
-      content: payload
-    };
+      this.lamportTimestamp,
+      this.filter.toBytes(),
+      payload
+    );
 
     this.outgoingBuffer.push(message);
 
@@ -483,14 +483,14 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
     payload: Uint8Array,
     callback?: (message: Message) => Promise<boolean>
   ): Promise<void> {
-    const message: Message = {
-      messageId: MessageChannel.getMessageId(payload),
-      channelId: this.channelId,
-      content: payload,
-      lamportTimestamp: undefined,
-      causalHistory: [],
-      bloomFilter: undefined
-    };
+    const message = new Message(
+      MessageChannel.getMessageId(payload),
+      this.channelId,
+      [],
+      undefined,
+      undefined,
+      payload
+    );
 
     if (callback) {
       try {

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -245,7 +245,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
         );
         if (missingDependencies.length === 0) {
           if (this.deliverMessage(message)) {
-            this.safeSendEvent(MessageChannelEvent.MessageDelivered, {
+            this.safeSendEvent(MessageChannelEvent.InMessageDelivered, {
               detail: message.messageId
             });
           }
@@ -275,7 +275,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
     );
     this.incomingBuffer = buffer;
 
-    this.safeSendEvent(MessageChannelEvent.MissedMessages, {
+    this.safeSendEvent(MessageChannelEvent.InMessageMissing, {
       detail: Array.from(missing)
     });
 
@@ -341,7 +341,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
     if (callback) {
       try {
         await callback(message);
-        this.safeSendEvent(MessageChannelEvent.SyncSent, {
+        this.safeSendEvent(MessageChannelEvent.OutSyncSent, {
           detail: message
         });
         return true;
@@ -380,11 +380,11 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
       return;
     }
     if (message.content?.length === 0) {
-      this.safeSendEvent(MessageChannelEvent.SyncReceived, {
+      this.safeSendEvent(MessageChannelEvent.InSyncDelivered, {
         detail: message
       });
     } else {
-      this.safeSendEvent(MessageChannelEvent.MessageReceived, {
+      this.safeSendEvent(MessageChannelEvent.InMessageReceived, {
         detail: message
       });
     }
@@ -403,7 +403,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
       this.timeReceived.set(message.messageId, Date.now());
     } else {
       if (this.deliverMessage(message)) {
-        this.safeSendEvent(MessageChannelEvent.MessageDelivered, {
+        this.safeSendEvent(MessageChannelEvent.InMessageDelivered, {
           detail: message.messageId
         });
       }
@@ -474,7 +474,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
             }
           });
           this.timeReceived.set(messageId, Date.now());
-          this.safeSendEvent(MessageChannelEvent.MessageSent, {
+          this.safeSendEvent(MessageChannelEvent.OutMessageSent, {
             detail: message
           });
         }
@@ -569,7 +569,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
           if (outgoingMessageId !== messageId) {
             return true;
           }
-          this.safeSendEvent(MessageChannelEvent.MessageAcknowledged, {
+          this.safeSendEvent(MessageChannelEvent.OutMessageAcknowledged, {
             detail: messageId
           });
           return false;
@@ -597,7 +597,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
       const count = (this.possibleAcks.get(message.messageId) ?? 0) + 1;
       if (count < this.possibleAcksThreshold) {
         this.possibleAcks.set(message.messageId, count);
-        this.safeSendEvent(MessageChannelEvent.MessagePossiblyAcknowledged, {
+        this.safeSendEvent(MessageChannelEvent.OutMessagePossiblyAcknowledged, {
           detail: {
             messageId: message.messageId,
             count

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -421,6 +421,9 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
           detail: { command: item.command, error, params: item.params }
         })
       );
+      this.safeSendEvent(MessageChannelEvent.ErrorTask, {
+        detail: { command: item.command, error, params: item.params }
+      });
     }
   }
 

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -577,7 +577,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
       const count = (this.acknowledgements.get(message.messageId) ?? 0) + 1;
       if (count < this.acknowledgementCount) {
         this.acknowledgements.set(message.messageId, count);
-        this.safeSendEvent(MessageChannelEvent.PartialAcknowledgement, {
+        this.safeSendEvent(MessageChannelEvent.MessagePossiblyAcknowledged, {
           detail: {
             messageId: message.messageId,
             count

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -104,8 +104,8 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
    * const channel = new MessageChannel("my-channel");
    *
    * // Queue some operations
-   * await channel.sendMessage(payload, callback);
-   * channel.receiveMessage(incomingMessage);
+   * await channel.pushOutgoingMessage(payload, callback);
+   * channel.pushIncomingMessage(incomingMessage);
    *
    * // Process all queued operations
    * await channel.processTasks();
@@ -139,7 +139,7 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
    * const channel = new MessageChannel("chat-room");
    * const message = new TextEncoder().encode("Hello, world!");
    *
-   * await channel.sendMessage(message, async (processedMessage) => {
+   * await channel.pushOutgoingMessage(message, async (processedMessage) => {
    *   console.log("Message processed:", processedMessage.messageId);
    *   return { success: true };
    * });
@@ -148,9 +148,9 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
    * await channel.processTasks();
    * ```
    */
-  public async sendMessage(
+  public async pushOutgoingMessage(
     payload: Uint8Array,
-    callback?: (message: Message) => Promise<{
+    callback?: (processedMessage: Message) => Promise<{
       success: boolean;
       retrievalHint?: Uint8Array;
     }>
@@ -177,9 +177,9 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
    * @param payload - The payload to send.
    * @param callback - A callback function that returns a boolean indicating whether the message was sent successfully.
    */
-  public async sendEphemeralMessage(
+  public async pushOutgoingEphemeralMessage(
     payload: Uint8Array,
-    callback?: (message: Message) => Promise<boolean>
+    callback?: (processedMessage: Message) => Promise<boolean>
   ): Promise<void> {
     this.tasks.push({
       command: Command.SendEphemeral,
@@ -203,13 +203,13 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
    * const channel = new MessageChannel("chat-room");
    *
    * // Receive a message from the network
-   * channel.receiveMessage(incomingMessage);
+   * channel.pushIncomingMessage(incomingMessage);
    *
    * // Process the received message
    * await channel.processTasks();
    * ```
    */
-  public receiveMessage(message: Message): void {
+  public pushIncomingMessage(message: Message): void {
     this.tasks.push({
       command: Command.Receive,
       params: {

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -39,11 +39,9 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
   private acknowledgements: Map<MessageId, number>;
   private incomingBuffer: Message[];
   private localHistory: { timestamp: number; historyEntry: HistoryEntry }[];
-  private timeReceived: Map<MessageId, number>;
-  // TODO: To be removed once sender id is added to SDS protocol
-  private outgoingMessages: Set<MessageId>;
-  private readonly causalHistorySize: number;
+  private causalHistorySize: number;
   private readonly acknowledgementCount: number;
+  private timeReceived: Map<MessageId, number>;
   private readonly receivedMessageTimeoutEnabled: boolean;
   private readonly receivedMessageTimeout: number;
 

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -523,11 +523,11 @@ export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {
     ) {
       // Messages with empty content are sync messages.
       // Messages with no timestamp are ephemeral messages.
+      // They do not need to be "delivered".
       // They are not added to the local log or bloom filter.
       return;
     }
 
-    // Only messages with non-empty content topics must be "delivered"
     if (message.lamportTimestamp > this.lamportTimestamp) {
       this.lamportTimestamp = message.lamportTimestamp;
     }


### PR DESCRIPTION
### Problem / Description

Proceed with a number of improvements and fixes as I dogfed it and attempted to wrap it.

I want to reach further maturity with the wrapper before pushing it. Those improvements are good on their own.

- implemented `senderId` as per new spec PR https://github.com/vacp2p/rfc-index/pull/170
- move `Message` to a class for easier access to `encode` and decode` methods
- tidy up the event names, to make it clearer whereas they are about incoming or outgoing messages (as some terms of the spec such as "delivered" can be confusing)
- move away from `sendMessage` and `receiveMessage` verbs are nothing is being sent or received. It is instead, push to SDS to be sent by another component.
- improve variable names: `acknowledgements` is about *possible* acks. Also, specs uses *possible* term, not *partial*.
-  added, and fixed, some tests
- added some logs
- fixed up some event emitting so only emitted when action actually happened (eg delivered)
- started to remove message duplication in history (because it creates issues to ack messages), this is not fully fixed. I'll do a dedicated PR for that.
- 

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [x] **Dogfooding has been performed**, if feasible. See fryorcraken/retro-chat
- [x] A **test version has been published**, if required. See #2526
- [x] All **CI checks** pass successfully.
