### PR TITLE
feat: add event emission to track peer connection and Waku protocols

### DIFF
--- a/packages/core/src/lib/connection_manager/connection_limiter.spec.ts
+++ b/packages/core/src/lib/connection_manager/connection_limiter.spec.ts
@@ -3,7 +3,8 @@ import { multiaddr } from "@multiformats/multiaddr";
 import {
   CONNECTION_LOCKED_TAG,
   IWakuEventEmitter,
-  Tags
+  Tags,
+  WakuEventType
 } from "@waku/interfaces";
 import { expect } from "chai";
 import sinon from "sinon";
@@ -143,7 +144,7 @@ describe("ConnectionLimiter", () => {
         .true;
       expect(
         (events.addEventListener as sinon.SinonStub).calledWith(
-          "waku:connection",
+          WakuEventType.Connection,
           sinon.match.func
         )
       ).to.be.true;
@@ -178,7 +179,7 @@ describe("ConnectionLimiter", () => {
         .true;
       expect(
         (events.removeEventListener as sinon.SinonStub).calledWith(
-          "waku:connection",
+          WakuEventType.Connection,
           sinon.match.func
         )
       ).to.be.true;

--- a/packages/core/src/lib/connection_manager/connection_limiter.ts
+++ b/packages/core/src/lib/connection_manager/connection_limiter.ts
@@ -5,7 +5,8 @@ import {
   IWakuEventEmitter,
   Libp2p,
   Libp2pEventHandler,
-  Tags
+  Tags,
+  WakuEventType
 } from "@waku/interfaces";
 import { Logger } from "@waku/utils";
 
@@ -69,7 +70,10 @@ export class ConnectionLimiter implements IConnectionLimiter {
       );
     }
 
-    this.events.addEventListener("waku:connection", this.onWakuConnectionEvent);
+    this.events.addEventListener(
+      WakuEventType.Connection,
+      this.onWakuConnectionEvent
+    );
 
     /**
      * NOTE: Event is not being emitted on closing nor losing a connection.
@@ -90,7 +94,7 @@ export class ConnectionLimiter implements IConnectionLimiter {
 
   public stop(): void {
     this.events.removeEventListener(
-      "waku:connection",
+      WakuEventType.Connection,
       this.onWakuConnectionEvent
     );
 

--- a/packages/core/src/lib/connection_manager/network_monitor.spec.ts
+++ b/packages/core/src/lib/connection_manager/network_monitor.spec.ts
@@ -1,4 +1,4 @@
-import { IWakuEventEmitter, Libp2p } from "@waku/interfaces";
+import { IWakuEventEmitter, Libp2p, WakuEventType } from "@waku/interfaces";
 import { expect } from "chai";
 import sinon from "sinon";
 
@@ -341,7 +341,7 @@ describe("NetworkMonitor", () => {
       const dispatchedEvent = dispatchEventStub.getCall(0)
         .args[0] as CustomEvent<boolean>;
       expect(dispatchedEvent).to.be.instanceOf(CustomEvent);
-      expect(dispatchedEvent.type).to.equal("waku:connection");
+      expect(dispatchedEvent.type).to.equal(WakuEventType.Connection);
       expect(dispatchedEvent.detail).to.be.true;
     });
   });

--- a/packages/core/src/lib/connection_manager/network_monitor.ts
+++ b/packages/core/src/lib/connection_manager/network_monitor.ts
@@ -1,4 +1,4 @@
-import { IWakuEventEmitter, Libp2p } from "@waku/interfaces";
+import { IWakuEventEmitter, Libp2p, WakuEventType } from "@waku/interfaces";
 
 type NetworkMonitorConstructorOptions = {
   libp2p: Libp2p;
@@ -104,7 +104,7 @@ export class NetworkMonitor implements INetworkMonitor {
 
   private dispatchNetworkEvent(): void {
     this.events.dispatchEvent(
-      new CustomEvent<boolean>("waku:connection", {
+      new CustomEvent<boolean>(WakuEventType.Connection, {
         detail: this.isConnected()
       })
     );

--- a/packages/core/src/lib/connection_manager/network_monitor.ts
+++ b/packages/core/src/lib/connection_manager/network_monitor.ts
@@ -1,4 +1,4 @@
-import { IdentifyResult } from "@libp2p/interface";
+import { IdentifyResult, PeerId } from "@libp2p/interface";
 import {
   IWakuEventEmitter,
   Libp2p,
@@ -128,9 +128,15 @@ export class NetworkMonitor implements INetworkMonitor {
 
     if (protocols.length > 0) {
       this.events.dispatchEvent(
-        new CustomEvent<Protocols[]>(WakuEventType.ConnectedPeer, {
-          detail: protocols
-        })
+        new CustomEvent<{ peerId: PeerId; protocols: Protocols[] }>(
+          WakuEventType.ConnectedPeer,
+          {
+            detail: {
+              peerId: event.detail.peerId,
+              protocols
+            }
+          }
+        )
       );
     }
   }

--- a/packages/interfaces/src/waku.ts
+++ b/packages/interfaces/src/waku.ts
@@ -25,28 +25,33 @@ export type CreateEncoderParams = CreateDecoderParams & {
   ephemeral?: boolean;
 };
 
+export enum WakuEventType {
+  Connection = "waku:connection",
+  Health = "waku:health"
+}
+
 export interface IWakuEvents {
   /**
    * Emitted when a connection is established or lost.
    *
    * @example
    * ```typescript
-   * waku.addEventListener("waku:connection", (event) => {
+   * waku.addEventListener(WakuEventType.Connection, (event) => {
    *   console.log(event.detail); // true if connected, false if disconnected
    * });
    */
-  "waku:connection": CustomEvent<boolean>;
+  [WakuEventType.Connection]: CustomEvent<boolean>;
 
   /**
    * Emitted when the health status changes.
    *
    * @example
    * ```typescript
-   * waku.addEventListener("waku:health", (event) => {
+   * waku.addEventListener(WakuEventType.Health, (event) => {
    *   console.log(event.detail); // 'Unhealthy', 'MinimallyHealthy', or 'SufficientlyHealthy'
    * });
    */
-  "waku:health": CustomEvent<HealthStatus>;
+  [WakuEventType.Health]: CustomEvent<HealthStatus>;
 }
 
 export type IWakuEventEmitter = TypedEventEmitter<IWakuEvents>;
@@ -61,12 +66,12 @@ export interface IWaku {
   /**
    * Emits events related to the Waku node.
    * Those are:
-   * - "waku:connection"
-   * - "waku:health"
+   * - WakuEventType.Connection
+   * - WakuEventType.Health
    *
    * @example
    * ```typescript
-   * waku.events.addEventListener("waku:connection", (event) => {
+   * waku.events.addEventListener(WakuEventType.Connection, (event) => {
    *   console.log(event.detail); // true if connected, false if disconnected
    * });
    * ```

--- a/packages/interfaces/src/waku.ts
+++ b/packages/interfaces/src/waku.ts
@@ -27,7 +27,8 @@ export type CreateEncoderParams = CreateDecoderParams & {
 
 export enum WakuEventType {
   Connection = "waku:connection",
-  Health = "waku:health"
+  Health = "waku:health",
+  ConnectedPeer = "waku:connected-peer"
 }
 
 export interface IWakuEvents {
@@ -52,6 +53,16 @@ export interface IWakuEvents {
    * });
    */
   [WakuEventType.Health]: CustomEvent<HealthStatus>;
+
+  /**
+   * Emitted when the node connects to a peer, and returns the Waku protocol the peer
+   * supports. Useful if specific actions need a specific protocol (e.g. store query
+   * when connecting to a store node).
+   *
+   * Aims to replace [[waitForRemotePeerWithCodec]]
+   */
+
+  [WakuEventType.ConnectedPeer]: CustomEvent<Protocols[]>;
 }
 
 export type IWakuEventEmitter = TypedEventEmitter<IWakuEvents>;

--- a/packages/interfaces/src/waku.ts
+++ b/packages/interfaces/src/waku.ts
@@ -62,7 +62,10 @@ export interface IWakuEvents {
    * Aims to replace [[waitForRemotePeerWithCodec]]
    */
 
-  [WakuEventType.ConnectedPeer]: CustomEvent<Protocols[]>;
+  [WakuEventType.ConnectedPeer]: CustomEvent<{
+    protocols: Protocols[];
+    peerId: PeerId;
+  }>;
 }
 
 export type IWakuEventEmitter = TypedEventEmitter<IWakuEvents>;

--- a/packages/sdk/src/health_indicator/health_indicator.spec.ts
+++ b/packages/sdk/src/health_indicator/health_indicator.spec.ts
@@ -1,6 +1,11 @@
 import { Connection, Peer } from "@libp2p/interface";
 import { FilterCodecs, LightPushCodec } from "@waku/core";
-import { HealthStatus, IWakuEventEmitter, Libp2p } from "@waku/interfaces";
+import {
+  HealthStatus,
+  IWakuEventEmitter,
+  Libp2p,
+  WakuEventType
+} from "@waku/interfaces";
 import { expect } from "chai";
 import sinon from "sinon";
 
@@ -33,8 +38,9 @@ describe("HealthIndicator", () => {
 
     // Start monitoring
     const statusChangePromise = new Promise<HealthStatus>((resolve) => {
-      events.addEventListener("waku:health", (e: CustomEvent<HealthStatus>) =>
-        resolve(e.detail)
+      events.addEventListener(
+        WakuEventType.Health,
+        (e: CustomEvent<HealthStatus>) => resolve(e.detail)
       );
     });
 
@@ -50,8 +56,9 @@ describe("HealthIndicator", () => {
 
   it("should transition to MinimallyHealthy with one compatible peer", async () => {
     const statusChangePromise = new Promise<HealthStatus>((resolve) => {
-      events.addEventListener("waku:health", (e: CustomEvent<HealthStatus>) =>
-        resolve(e.detail)
+      events.addEventListener(
+        WakuEventType.Health,
+        (e: CustomEvent<HealthStatus>) => resolve(e.detail)
       );
     });
 
@@ -71,8 +78,9 @@ describe("HealthIndicator", () => {
 
   it("should transition to SufficientlyHealthy with multiple compatible peers", async () => {
     const statusChangePromise = new Promise<HealthStatus>((resolve) => {
-      events.addEventListener("waku:health", (e: CustomEvent<HealthStatus>) =>
-        resolve(e.detail)
+      events.addEventListener(
+        WakuEventType.Health,
+        (e: CustomEvent<HealthStatus>) => resolve(e.detail)
       );
     });
 

--- a/packages/sdk/src/health_indicator/health_indicator.ts
+++ b/packages/sdk/src/health_indicator/health_indicator.ts
@@ -1,6 +1,11 @@
 import type { IdentifyResult, PeerId } from "@libp2p/interface";
 import { FilterCodecs, LightPushCodec } from "@waku/core";
-import { HealthStatus, IWakuEventEmitter, Libp2p } from "@waku/interfaces";
+import {
+  HealthStatus,
+  IWakuEventEmitter,
+  Libp2p,
+  WakuEventType
+} from "@waku/interfaces";
 import { Logger } from "@waku/utils";
 
 type PeerEvent<T> = (_event: CustomEvent<T>) => void;
@@ -124,7 +129,7 @@ export class HealthIndicator implements IHealthIndicator {
     if (this.value !== newValue) {
       this.value = newValue;
       this.events.dispatchEvent(
-        new CustomEvent<HealthStatus>("waku:health", {
+        new CustomEvent<HealthStatus>(WakuEventType.Health, {
           detail: this.value
         })
       );

--- a/packages/tests/tests/connection-mananger/network_monitor.spec.ts
+++ b/packages/tests/tests/connection-mananger/network_monitor.spec.ts
@@ -3,7 +3,7 @@ import type { PeerId } from "@libp2p/interface";
 import { TypedEventEmitter } from "@libp2p/interface";
 import { peerIdFromPrivateKey } from "@libp2p/peer-id";
 import { Multiaddr } from "@multiformats/multiaddr";
-import { LightNode, Protocols, Tags } from "@waku/interfaces";
+import { LightNode, Protocols, Tags, WakuEventType } from "@waku/interfaces";
 import { createRelayNode } from "@waku/relay";
 import { createLightNode } from "@waku/sdk";
 import { expect } from "chai";
@@ -65,10 +65,13 @@ describe("Connection state", function () {
   it("should emit `waku:online` event only when first peer is connected", async function () {
     let eventCount = 0;
     const connectionStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount++;
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount++;
+          resolve(status);
+        }
+      );
     });
 
     await waku.dial(nwaku1PeerId, [Protocols.Filter]);
@@ -87,10 +90,13 @@ describe("Connection state", function () {
 
     let eventCount = 0;
     const connectionStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount++;
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount++;
+          resolve(status);
+        }
+      );
     });
 
     await nwaku1.stop();
@@ -116,18 +122,24 @@ describe("Connection state", function () {
 
     let eventCount1 = 0;
     const connectionStatus1 = new Promise<boolean>((resolve) => {
-      waku1.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount1++;
-        resolve(status);
-      });
+      waku1.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount1++;
+          resolve(status);
+        }
+      );
     });
 
     let eventCount2 = 0;
     const connectionStatus2 = new Promise<boolean>((resolve) => {
-      waku2.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount2++;
-        resolve(status);
-      });
+      waku2.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount2++;
+          resolve(status);
+        }
+      );
     });
 
     await waku1.libp2p.peerStore.merge(waku2.peerId, {
@@ -191,7 +203,7 @@ describe("Connection state", function () {
   });
 });
 
-describe("waku:connection", function () {
+describe(WakuEventType.Connection, function () {
   let navigatorMock: any;
   let originalNavigator: any;
 
@@ -259,10 +271,13 @@ describe("waku:connection", function () {
 
     let eventCount = 0;
     const connectedStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount++;
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount++;
+          resolve(status);
+        }
+      );
     });
 
     waku.libp2p.dispatchEvent(
@@ -279,9 +294,12 @@ describe("waku:connection", function () {
     expect(eventCount).to.be.eq(1);
 
     const disconnectedStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          resolve(status);
+        }
+      );
     });
 
     waku.libp2p.dispatchEvent(
@@ -314,10 +332,13 @@ describe("waku:connection", function () {
 
     let eventCount = 0;
     const connectedStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount++;
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount++;
+          resolve(status);
+        }
+      );
     });
 
     waku.libp2p.dispatchEvent(
@@ -331,9 +352,12 @@ describe("waku:connection", function () {
     expect(eventCount).to.be.eq(1);
 
     const disconnectedStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          resolve(status);
+        }
+      );
     });
 
     navigatorMock.onLine = false;
@@ -346,9 +370,12 @@ describe("waku:connection", function () {
     expect(eventCount).to.be.eq(2);
 
     const connectionRecoveredStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          resolve(status);
+        }
+      );
     });
 
     navigatorMock.onLine = true;


### PR DESCRIPTION
### Problem / Description

There is no easy way to act upon a connected peer with a specific Waku protocol (e.g. store).
Only `waitForRemotePeer` is available but I prefer event driven logic, and it is meant to be deprecated

### Solution

New event emitted on libp2p identify, that includes the Waku protocols that the peer has mounted

---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
