### PR TITLE
chore: remove store cursor creation

### DIFF
--- a/packages/interfaces/src/store.ts
+++ b/packages/interfaces/src/store.ts
@@ -1,7 +1,5 @@
 import type { IDecodedMessage, IDecoder } from "./message.js";
 
-export type StoreCursor = Uint8Array;
-
 /**
  * Parameters for a store query request, as specified in the Waku Store v3 RFC.
  */
@@ -77,8 +75,6 @@ export type QueryRequestParams = {
 
 export type IStore = {
   readonly multicodec: string;
-
-  createCursor(message: IDecodedMessage): StoreCursor;
   queryGenerator: <T extends IDecodedMessage>(
     decoders: IDecoder<T>[],
     options?: Partial<QueryRequestParams>

--- a/packages/sdk/src/store/store.ts
+++ b/packages/sdk/src/store/store.ts
@@ -1,7 +1,7 @@
 import type { PeerId } from "@libp2p/interface";
 import { peerIdFromString } from "@libp2p/peer-id";
 import { multiaddr } from "@multiformats/multiaddr";
-import { messageHash, StoreCore } from "@waku/core";
+import { StoreCore } from "@waku/core";
 import {
   IDecodedMessage,
   IDecoder,
@@ -9,7 +9,6 @@ import {
   Libp2p,
   Protocols,
   QueryRequestParams,
-  StoreCursor,
   StoreProtocolOptions
 } from "@waku/interfaces";
 import { isDefined, Logger } from "@waku/utils";
@@ -158,16 +157,6 @@ export class Store implements IStore {
     );
 
     return abort;
-  }
-
-  /**
-   * Creates a cursor based on the provided decoded message.
-   *
-   * @param message - The decoded message.
-   * @returns A StoreCursor representing the message.
-   */
-  public createCursor(message: IDecodedMessage): StoreCursor {
-    return messageHash(message.pubsubTopic, message);
   }
 
   /**

--- a/packages/tests/tests/store/cursor.node.spec.ts
+++ b/packages/tests/tests/store/cursor.node.spec.ts
@@ -1,4 +1,4 @@
-import { DecodedMessage } from "@waku/core";
+import { DecodedMessage, messageHash } from "@waku/core";
 import type { LightNode } from "@waku/interfaces";
 import { bytesToUtf8 } from "@waku/utils/bytes";
 import { expect } from "chai";
@@ -65,7 +65,10 @@ describe("Waku Store, cursor", function () {
       }
 
       // create cursor to extract messages after the cursorIndex
-      const cursor = waku.store.createCursor(messages[cursorIndex]);
+      const cursor = messageHash(
+        messages[cursorIndex].pubsubTopic,
+        messages[cursorIndex]
+      );
 
       const messagesAfterCursor: DecodedMessage[] = [];
       for await (const page of waku.store.queryGenerator([TestDecoder], {
@@ -114,7 +117,7 @@ describe("Waku Store, cursor", function () {
     }
 
     // create cursor to extract messages after the cursorIndex
-    const cursor = waku.store.createCursor(messages[5]);
+    const cursor = messageHash(messages[5].pubsubTopic, messages[5]);
 
     // query node2 with the cursor from node1
     const messagesAfterCursor: DecodedMessage[] = [];


### PR DESCRIPTION
## Summary
- drop `createCursor` helper and StoreCursor type
- adjust test to compute cursor directly with `messageHash`

## Testing
- `npm --prefix packages/interfaces run check:tsc`
- `npm --prefix packages/sdk run check:tsc` *(fails: Cannot find module '@waku/interfaces')*
- `npm --prefix packages/sdk test` *(fails: Cannot find module '@waku/discovery')*
- `node packages/tests/src/run-tests.js packages/tests/tests/store/cursor.node.spec.ts` *(fails: docker: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6359ae6088331b52a8bc57194d832