### PR TITLE
feat: StoreConnect events

### DIFF
--- a/packages/browser-tests/tests/server.spec.ts
+++ b/packages/browser-tests/tests/server.spec.ts
@@ -391,7 +391,7 @@ test.describe("Waku Server API", () => {
     });
     await axios.post(`${API_URL}/admin/v1/start-node`);
 
-    // Connect to peers
+    // FilterConnect to peers
     const dialResponse = await axios.post(`${API_URL}/admin/v1/peers`, {
       peerMultiaddrs: PEERS
     });
@@ -425,7 +425,7 @@ test.describe("Waku Server API", () => {
     });
     await axios.post(`${API_URL}/admin/v1/start-node`);
 
-    // Connect to peers
+    // FilterConnect to peers
     await axios.post(`${API_URL}/admin/v1/peers`, {
       peerMultiaddrs: PEERS
     });
@@ -465,7 +465,7 @@ test.describe("Waku Server API", () => {
     });
     await axios.post(`${API_URL}/admin/v1/start-node`);
 
-    // Connect to peers
+    // FilterConnect to peers
     await axios.post(`${API_URL}/admin/v1/peers`, {
       peerMultiaddrs: PEERS
     });
@@ -577,7 +577,7 @@ test.describe("Waku Server API", () => {
       // Start node
       await axios.post(`${API_URL}/admin/v1/start-node`);
 
-      // Connect to peers
+      // FilterConnect to peers
       await axios.post(`${API_URL}/admin/v1/peers`, {
         peerMultiaddrs: PEERS
       });

--- a/packages/core/src/lib/connection_manager/connection_limiter.spec.ts
+++ b/packages/core/src/lib/connection_manager/connection_limiter.spec.ts
@@ -3,7 +3,8 @@ import { multiaddr } from "@multiformats/multiaddr";
 import {
   CONNECTION_LOCKED_TAG,
   IWakuEventEmitter,
-  Tags
+  Tags,
+  WakuEventType
 } from "@waku/interfaces";
 import { expect } from "chai";
 import sinon from "sinon";
@@ -143,7 +144,7 @@ describe("ConnectionLimiter", () => {
         .true;
       expect(
         (events.addEventListener as sinon.SinonStub).calledWith(
-          "waku:connection",
+          WakuEventType.Connection,
           sinon.match.func
         )
       ).to.be.true;
@@ -178,7 +179,7 @@ describe("ConnectionLimiter", () => {
         .true;
       expect(
         (events.removeEventListener as sinon.SinonStub).calledWith(
-          "waku:connection",
+          WakuEventType.Connection,
           sinon.match.func
         )
       ).to.be.true;

--- a/packages/core/src/lib/connection_manager/connection_limiter.ts
+++ b/packages/core/src/lib/connection_manager/connection_limiter.ts
@@ -5,7 +5,8 @@ import {
   IWakuEventEmitter,
   Libp2p,
   Libp2pEventHandler,
-  Tags
+  Tags,
+  WakuEventType
 } from "@waku/interfaces";
 import { Logger } from "@waku/utils";
 
@@ -69,7 +70,10 @@ export class ConnectionLimiter implements IConnectionLimiter {
       );
     }
 
-    this.events.addEventListener("waku:connection", this.onWakuConnectionEvent);
+    this.events.addEventListener(
+      WakuEventType.Connection,
+      this.onWakuConnectionEvent
+    );
 
     /**
      * NOTE: Event is not being emitted on closing nor losing a connection.
@@ -90,7 +94,7 @@ export class ConnectionLimiter implements IConnectionLimiter {
 
   public stop(): void {
     this.events.removeEventListener(
-      "waku:connection",
+      WakuEventType.Connection,
       this.onWakuConnectionEvent
     );
 

--- a/packages/core/src/lib/connection_manager/network_monitor.spec.ts
+++ b/packages/core/src/lib/connection_manager/network_monitor.spec.ts
@@ -1,4 +1,4 @@
-import { IWakuEventEmitter, Libp2p } from "@waku/interfaces";
+import { IWakuEventEmitter, Libp2p, WakuEventType } from "@waku/interfaces";
 import { expect } from "chai";
 import sinon from "sinon";
 
@@ -341,7 +341,7 @@ describe("NetworkMonitor", () => {
       const dispatchedEvent = dispatchEventStub.getCall(0)
         .args[0] as CustomEvent<boolean>;
       expect(dispatchedEvent).to.be.instanceOf(CustomEvent);
-      expect(dispatchedEvent.type).to.equal("waku:connection");
+      expect(dispatchedEvent.type).to.equal(WakuEventType.Connection);
       expect(dispatchedEvent.detail).to.be.true;
     });
   });

--- a/packages/core/src/lib/connection_manager/network_monitor.ts
+++ b/packages/core/src/lib/connection_manager/network_monitor.ts
@@ -1,4 +1,4 @@
-import { IWakuEventEmitter, Libp2p } from "@waku/interfaces";
+import { IWakuEventEmitter, Libp2p, WakuEventType } from "@waku/interfaces";
 
 type NetworkMonitorConstructorOptions = {
   libp2p: Libp2p;
@@ -104,7 +104,7 @@ export class NetworkMonitor implements INetworkMonitor {
 
   private dispatchNetworkEvent(): void {
     this.events.dispatchEvent(
-      new CustomEvent<boolean>("waku:connection", {
+      new CustomEvent<boolean>(WakuEventType.Connection, {
         detail: this.isConnected()
       })
     );

--- a/packages/interfaces/src/waku.ts
+++ b/packages/interfaces/src/waku.ts
@@ -25,28 +25,33 @@ export type CreateEncoderParams = CreateDecoderParams & {
   ephemeral?: boolean;
 };
 
+export enum WakuEventType {
+  Connection = "waku:connection",
+  Health = "waku:health"
+}
+
 export interface IWakuEvents {
   /**
    * Emitted when a connection is established or lost.
    *
    * @example
    * ```typescript
-   * waku.addEventListener("waku:connection", (event) => {
+   * waku.addEventListener(WakuEventType.Connection, (event) => {
    *   console.log(event.detail); // true if connected, false if disconnected
    * });
    */
-  "waku:connection": CustomEvent<boolean>;
+  [WakuEventType.Connection]: CustomEvent<boolean>;
 
   /**
    * Emitted when the health status changes.
    *
    * @example
    * ```typescript
-   * waku.addEventListener("waku:health", (event) => {
+   * waku.addEventListener(WakuEventType.Health, (event) => {
    *   console.log(event.detail); // 'Unhealthy', 'MinimallyHealthy', or 'SufficientlyHealthy'
    * });
    */
-  "waku:health": CustomEvent<HealthStatus>;
+  [WakuEventType.Health]: CustomEvent<HealthStatus>;
 }
 
 export type IWakuEventEmitter = TypedEventEmitter<IWakuEvents>;
@@ -61,12 +66,12 @@ export interface IWaku {
   /**
    * Emits events related to the Waku node.
    * Those are:
-   * - "waku:connection"
-   * - "waku:health"
+   * - WakuEventType.Connection
+   * - WakuEventType.Health
    *
    * @example
    * ```typescript
-   * waku.events.addEventListener("waku:connection", (event) => {
+   * waku.events.addEventListener(WakuEventType.Connection, (event) => {
    *   console.log(event.detail); // true if connected, false if disconnected
    * });
    * ```

--- a/packages/sdk/src/filter/subscription.ts
+++ b/packages/sdk/src/filter/subscription.ts
@@ -363,11 +363,11 @@ export class Subscription {
 
   private setupEventListeners(): void {
     this.peerManager.events.addEventListener(
-      PeerManagerEventNames.Connect,
+      PeerManagerEventNames.FilterConnect,
       this.onPeerConnected as Libp2pEventHandler
     );
     this.peerManager.events.addEventListener(
-      PeerManagerEventNames.Disconnect,
+      PeerManagerEventNames.FilterDisconnect,
       this.onPeerDisconnected as Libp2pEventHandler
     );
   }
@@ -398,11 +398,11 @@ export class Subscription {
 
   private disposeEventListeners(): void {
     this.peerManager.events.removeEventListener(
-      PeerManagerEventNames.Connect,
+      PeerManagerEventNames.FilterConnect,
       this.onPeerConnected as Libp2pEventHandler
     );
     this.peerManager.events.removeEventListener(
-      PeerManagerEventNames.Disconnect,
+      PeerManagerEventNames.FilterDisconnect,
       this.onPeerDisconnected as Libp2pEventHandler
     );
   }

--- a/packages/sdk/src/health_indicator/health_indicator.spec.ts
+++ b/packages/sdk/src/health_indicator/health_indicator.spec.ts
@@ -1,6 +1,11 @@
 import { Connection, Peer } from "@libp2p/interface";
 import { FilterCodecs, LightPushCodec } from "@waku/core";
-import { HealthStatus, IWakuEventEmitter, Libp2p } from "@waku/interfaces";
+import {
+  HealthStatus,
+  IWakuEventEmitter,
+  Libp2p,
+  WakuEventType
+} from "@waku/interfaces";
 import { expect } from "chai";
 import sinon from "sinon";
 
@@ -34,8 +39,9 @@ describe("HealthIndicator", () => {
 
     // Start monitoring
     const statusChangePromise = new Promise<HealthStatus>((resolve) => {
-      events.addEventListener("waku:health", (e: CustomEvent<HealthStatus>) =>
-        resolve(e.detail)
+      events.addEventListener(
+        WakuEventType.Health,
+        (e: CustomEvent<HealthStatus>) => resolve(e.detail)
       );
     });
 
@@ -53,8 +59,9 @@ describe("HealthIndicator", () => {
     healthIndicator.start();
 
     const statusChangePromise = new Promise<HealthStatus>((resolve) => {
-      events.addEventListener("waku:health", (e: CustomEvent<HealthStatus>) =>
-        resolve(e.detail)
+      events.addEventListener(
+        WakuEventType.Health,
+        (e: CustomEvent<HealthStatus>) => resolve(e.detail)
       );
     });
 
@@ -76,8 +83,9 @@ describe("HealthIndicator", () => {
     healthIndicator.start();
 
     const statusChangePromise = new Promise<HealthStatus>((resolve) => {
-      events.addEventListener("waku:health", (e: CustomEvent<HealthStatus>) =>
-        resolve(e.detail)
+      events.addEventListener(
+        WakuEventType.Health,
+        (e: CustomEvent<HealthStatus>) => resolve(e.detail)
       );
     });
 

--- a/packages/sdk/src/health_indicator/health_indicator.ts
+++ b/packages/sdk/src/health_indicator/health_indicator.ts
@@ -1,6 +1,11 @@
 import type { IdentifyResult, PeerId } from "@libp2p/interface";
 import { FilterCodecs, LightPushCodec } from "@waku/core";
-import { HealthStatus, IWakuEventEmitter, Libp2p } from "@waku/interfaces";
+import {
+  HealthStatus,
+  IWakuEventEmitter,
+  Libp2p,
+  WakuEventType
+} from "@waku/interfaces";
 import { Logger } from "@waku/utils";
 
 type PeerEvent<T> = (_event: CustomEvent<T>) => void;
@@ -130,7 +135,7 @@ export class HealthIndicator implements IHealthIndicator {
     if (this.value !== newValue) {
       this.value = newValue;
       this.events.dispatchEvent(
-        new CustomEvent<HealthStatus>("waku:health", {
+        new CustomEvent<HealthStatus>(WakuEventType.Health, {
           detail: this.value
         })
       );

--- a/packages/sdk/src/peer_manager/peer_manager.spec.ts
+++ b/packages/sdk/src/peer_manager/peer_manager.spec.ts
@@ -43,10 +43,7 @@ describe("PeerManager", () => {
   };
 
   const skipIfNoPeers = (result: PeerId[] | null): boolean => {
-    if (!result || result.length === 0) {
-      return true;
-    }
-    return false;
+    return !result || result.length === 0;
   };
 
   beforeEach(() => {

--- a/packages/sdk/src/peer_manager/peer_manager.spec.ts
+++ b/packages/sdk/src/peer_manager/peer_manager.spec.ts
@@ -154,11 +154,11 @@ describe("PeerManager", () => {
     const connectSpy = sinon.spy();
     const disconnectSpy = sinon.spy();
     peerManager.events.addEventListener(
-      PeerManagerEventNames.Connect,
+      PeerManagerEventNames.FilterConnect,
       connectSpy
     );
     peerManager.events.addEventListener(
-      PeerManagerEventNames.Disconnect,
+      PeerManagerEventNames.FilterDisconnect,
       disconnectSpy
     );
     peerManager["dispatchFilterPeerConnect"](peers[0].id);

--- a/packages/sdk/src/peer_manager/peer_manager.spec.ts
+++ b/packages/sdk/src/peer_manager/peer_manager.spec.ts
@@ -148,20 +148,27 @@ describe("PeerManager", () => {
   });
 
   it("should dispatch connect and disconnect events", () => {
-    const connectSpy = sinon.spy();
-    const disconnectSpy = sinon.spy();
+    const filterConnectSpy = sinon.spy();
+    const storeConnectSpy = sinon.spy();
+    const filterDisconnectSpy = sinon.spy();
     peerManager.events.addEventListener(
       PeerManagerEventNames.FilterConnect,
-      connectSpy
+      filterConnectSpy
+    );
+    peerManager.events.addEventListener(
+      PeerManagerEventNames.StoreConnect,
+      storeConnectSpy
     );
     peerManager.events.addEventListener(
       PeerManagerEventNames.FilterDisconnect,
-      disconnectSpy
+      filterDisconnectSpy
     );
     peerManager["dispatchFilterPeerConnect"](peers[0].id);
+    peerManager["dispatchStorePeerConnect"](peers[0].id);
     peerManager["dispatchFilterPeerDisconnect"](peers[0].id);
-    expect(connectSpy.calledOnce).to.be.true;
-    expect(disconnectSpy.calledOnce).to.be.true;
+    expect(filterConnectSpy.calledOnce).to.be.true;
+    expect(storeConnectSpy.calledOnce).to.be.true;
+    expect(filterDisconnectSpy.calledOnce).to.be.true;
   });
 
   it("should handle onConnected and onDisconnected", async () => {

--- a/packages/sdk/src/peer_manager/peer_manager.ts
+++ b/packages/sdk/src/peer_manager/peer_manager.ts
@@ -34,20 +34,20 @@ type GetPeersParams = {
 };
 
 export enum PeerManagerEventNames {
-  Connect = "filter:connect",
-  Disconnect = "filter:disconnect"
+  FilterConnect = "filter:connect",
+  FilterDisconnect = "filter:disconnect"
 }
 
 interface IPeerManagerEvents {
   /**
    * Notifies about Filter peer being connected.
    */
-  [PeerManagerEventNames.Connect]: CustomEvent<PeerId>;
+  [PeerManagerEventNames.FilterConnect]: CustomEvent<PeerId>;
 
   /**
    * Notifies about Filter peer being disconnected.
    */
-  [PeerManagerEventNames.Disconnect]: CustomEvent<PeerId>;
+  [PeerManagerEventNames.FilterDisconnect]: CustomEvent<PeerId>;
 }
 
 /**
@@ -266,13 +266,13 @@ export class PeerManager {
 
   private dispatchFilterPeerConnect(id: PeerId): void {
     this.events.dispatchEvent(
-      new CustomEvent(PeerManagerEventNames.Connect, { detail: id })
+      new CustomEvent(PeerManagerEventNames.FilterConnect, { detail: id })
     );
   }
 
   private dispatchFilterPeerDisconnect(id: PeerId): void {
     this.events.dispatchEvent(
-      new CustomEvent(PeerManagerEventNames.Disconnect, { detail: id })
+      new CustomEvent(PeerManagerEventNames.FilterDisconnect, { detail: id })
     );
   }
 

--- a/packages/sdk/src/peer_manager/peer_manager.ts
+++ b/packages/sdk/src/peer_manager/peer_manager.ts
@@ -268,7 +268,7 @@ export class PeerManager {
     }
 
     const wasUnlocked = new Date(value).getTime();
-    return Date.now() - wasUnlocked >= 10_000 ? true : false;
+    return Date.now() - wasUnlocked >= 10_000;
   }
 
   private dispatchFilterPeerConnect(id: PeerId): void {

--- a/packages/sdk/src/peer_manager/peer_manager.ts
+++ b/packages/sdk/src/peer_manager/peer_manager.ts
@@ -35,7 +35,8 @@ type GetPeersParams = {
 
 export enum PeerManagerEventNames {
   FilterConnect = "filter:connect",
-  FilterDisconnect = "filter:disconnect"
+  FilterDisconnect = "filter:disconnect",
+  StoreConnect = "store:connect"
 }
 
 interface IPeerManagerEvents {
@@ -48,6 +49,11 @@ interface IPeerManagerEvents {
    * Notifies about Filter peer being disconnected.
    */
   [PeerManagerEventNames.FilterDisconnect]: CustomEvent<PeerId>;
+
+  /**
+   * Notifies about a Store peer being connected.
+   */
+  [PeerManagerEventNames.StoreConnect]: CustomEvent<PeerId>;
 }
 
 /**
@@ -198,12 +204,13 @@ export class PeerManager {
 
   private async onConnected(event: CustomEvent<IdentifyResult>): Promise<void> {
     const result = event.detail;
-    const isFilterPeer = result.protocols.includes(
-      this.matchProtocolToCodec(Protocols.Filter)
-    );
-
-    if (isFilterPeer) {
+    if (
+      result.protocols.includes(this.matchProtocolToCodec(Protocols.Filter))
+    ) {
       this.dispatchFilterPeerConnect(result.peerId);
+    }
+    if (result.protocols.includes(this.matchProtocolToCodec(Protocols.Store))) {
+      this.dispatchStorePeerConnect(result.peerId);
     }
   }
 
@@ -267,6 +274,12 @@ export class PeerManager {
   private dispatchFilterPeerConnect(id: PeerId): void {
     this.events.dispatchEvent(
       new CustomEvent(PeerManagerEventNames.FilterConnect, { detail: id })
+    );
+  }
+
+  private dispatchStorePeerConnect(id: PeerId): void {
+    this.events.dispatchEvent(
+      new CustomEvent(PeerManagerEventNames.StoreConnect, { detail: id })
     );
   }
 

--- a/packages/sdk/src/peer_manager/peer_manager.ts
+++ b/packages/sdk/src/peer_manager/peer_manager.ts
@@ -39,7 +39,7 @@ export enum PeerManagerEventNames {
   StoreConnect = "store:connect"
 }
 
-interface IPeerManagerEvents {
+export interface IPeerManagerEvents {
   /**
    * Notifies about Filter peer being connected.
    */

--- a/packages/tests/tests/connection-mananger/network_monitor.spec.ts
+++ b/packages/tests/tests/connection-mananger/network_monitor.spec.ts
@@ -3,7 +3,7 @@ import type { PeerId } from "@libp2p/interface";
 import { TypedEventEmitter } from "@libp2p/interface";
 import { peerIdFromPrivateKey } from "@libp2p/peer-id";
 import { Multiaddr } from "@multiformats/multiaddr";
-import { LightNode, Protocols, Tags } from "@waku/interfaces";
+import { LightNode, Protocols, Tags, WakuEventType } from "@waku/interfaces";
 import { createRelayNode } from "@waku/relay";
 import { createLightNode } from "@waku/sdk";
 import { expect } from "chai";
@@ -65,10 +65,13 @@ describe("Connection state", function () {
   it("should emit `waku:online` event only when first peer is connected", async function () {
     let eventCount = 0;
     const connectionStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount++;
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount++;
+          resolve(status);
+        }
+      );
     });
 
     await waku.dial(nwaku1PeerId, [Protocols.Filter]);
@@ -87,10 +90,13 @@ describe("Connection state", function () {
 
     let eventCount = 0;
     const connectionStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount++;
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount++;
+          resolve(status);
+        }
+      );
     });
 
     await nwaku1.stop();
@@ -116,18 +122,24 @@ describe("Connection state", function () {
 
     let eventCount1 = 0;
     const connectionStatus1 = new Promise<boolean>((resolve) => {
-      waku1.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount1++;
-        resolve(status);
-      });
+      waku1.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount1++;
+          resolve(status);
+        }
+      );
     });
 
     let eventCount2 = 0;
     const connectionStatus2 = new Promise<boolean>((resolve) => {
-      waku2.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount2++;
-        resolve(status);
-      });
+      waku2.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount2++;
+          resolve(status);
+        }
+      );
     });
 
     await waku1.libp2p.peerStore.merge(waku2.peerId, {
@@ -191,7 +203,7 @@ describe("Connection state", function () {
   });
 });
 
-describe("waku:connection", function () {
+describe(WakuEventType.Connection, function () {
   let navigatorMock: any;
   let originalNavigator: any;
 
@@ -259,10 +271,13 @@ describe("waku:connection", function () {
 
     let eventCount = 0;
     const connectedStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount++;
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount++;
+          resolve(status);
+        }
+      );
     });
 
     waku.libp2p.dispatchEvent(
@@ -279,9 +294,12 @@ describe("waku:connection", function () {
     expect(eventCount).to.be.eq(1);
 
     const disconnectedStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          resolve(status);
+        }
+      );
     });
 
     waku.libp2p.dispatchEvent(
@@ -314,10 +332,13 @@ describe("waku:connection", function () {
 
     let eventCount = 0;
     const connectedStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        eventCount++;
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          eventCount++;
+          resolve(status);
+        }
+      );
     });
 
     waku.libp2p.dispatchEvent(
@@ -331,9 +352,12 @@ describe("waku:connection", function () {
     expect(eventCount).to.be.eq(1);
 
     const disconnectedStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          resolve(status);
+        }
+      );
     });
 
     navigatorMock.onLine = false;
@@ -346,9 +370,12 @@ describe("waku:connection", function () {
     expect(eventCount).to.be.eq(2);
 
     const connectionRecoveredStatus = new Promise<boolean>((resolve) => {
-      waku.events.addEventListener("waku:connection", ({ detail: status }) => {
-        resolve(status);
-      });
+      waku.events.addEventListener(
+        WakuEventType.Connection,
+        ({ detail: status }) => {
+          resolve(status);
+        }
+      );
     });
 
     navigatorMock.onLine = true;


### PR DESCRIPTION
### Problem / Description

As a developer (of SDS wrapper), I want to know when I am connecting to a store node so I can proceed with store queries.

### Solution

Emit event when connecting to a store node, similar to the filter connect event.

### Notes

Add enum usage for events.

---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
