### PR TITLE
chore: redundant `waku` prefix in logs

### DIFF
--- a/packages/rln/src/codec.ts
+++ b/packages/rln/src/codec.ts
@@ -13,7 +13,7 @@ import type { IdentityCredential } from "./identity.js";
 import { RlnMessage, toRLNSignal } from "./message.js";
 import { RLNInstance } from "./rln.js";
 
-const log = new Logger("waku:rln:encoder");
+const log = new Logger("rln:encoder");
 
 export class RLNEncoder implements IEncoder {
   private readonly idSecretHash: Uint8Array;

--- a/packages/rln/src/contract/rln_base_contract.ts
+++ b/packages/rln/src/contract/rln_base_contract.ts
@@ -21,7 +21,7 @@ import {
   RLNContractInitOptions
 } from "./types.js";
 
-const log = new Logger("waku:rln:contract:base");
+const log = new Logger("rln:contract:base");
 
 export class RLNBaseContract {
   public contract: ethers.Contract;

--- a/packages/rln/src/contract/rln_contract.ts
+++ b/packages/rln/src/contract/rln_contract.ts
@@ -9,7 +9,7 @@ import { BytesUtils } from "../utils/bytes.js";
 import { RLNBaseContract } from "./rln_base_contract.js";
 import { RLNContractInitOptions } from "./types.js";
 
-const log = new Logger("waku:rln:contract");
+const log = new Logger("rln:contract");
 
 export class RLNContract extends RLNBaseContract {
   private instance: RLNInstance;

--- a/packages/rln/src/credentials_manager.ts
+++ b/packages/rln/src/credentials_manager.ts
@@ -17,7 +17,7 @@ import { BytesUtils } from "./utils/bytes.js";
 import { extractMetaMaskSigner } from "./utils/index.js";
 import { Zerokit } from "./zerokit.js";
 
-const log = new Logger("waku:credentials");
+const log = new Logger("rln:credentials");
 
 /**
  * Manages credentials for RLN

--- a/packages/rln/src/keystore/keystore.ts
+++ b/packages/rln/src/keystore/keystore.ts
@@ -27,7 +27,7 @@ import type {
   Sha256Hash
 } from "./types.js";
 
-const log = new Logger("waku:rln:keystore");
+const log = new Logger("rln:keystore");
 
 type NwakuCredential = {
   crypto: {

--- a/packages/rln/src/rln.ts
+++ b/packages/rln/src/rln.ts
@@ -26,7 +26,7 @@ import * as wc from "./resources/witness_calculator";
 import { WitnessCalculator } from "./resources/witness_calculator";
 import { Zerokit } from "./zerokit.js";
 
-const log = new Logger("waku:rln");
+const log = new Logger("rln");
 
 type WakuRLNEncoderOptions = WakuEncoderOptions & {
   credentials: EncryptedCredentials | DecryptedCredentials;

--- a/packages/rln/src/utils/epoch.ts
+++ b/packages/rln/src/utils/epoch.ts
@@ -2,7 +2,7 @@ import { Logger } from "@waku/utils";
 
 const DefaultEpochUnitSeconds = 10; // the rln-relay epoch length in seconds
 
-const log = new Logger("waku:rln:epoch");
+const log = new Logger("rln:epoch");
 
 export function dateToEpoch(
   timestamp: Date,

--- a/packages/sdk/src/waku/waku.ts
+++ b/packages/sdk/src/waku/waku.ts
@@ -38,7 +38,7 @@ import { Store } from "../store/index.js";
 
 import { waitForRemotePeer } from "./wait_for_remote_peer.js";
 
-const log = new Logger("waku");
+const log = new Logger("sdk:waku");
 
 type ProtocolsEnabled = {
   filter?: boolean;

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -30,7 +30,7 @@ export const DEFAULT_BLOOM_FILTER_OPTIONS = {
 const DEFAULT_CAUSAL_HISTORY_SIZE = 200;
 const DEFAULT_POSSIBLE_ACKS_THRESHOLD = 2;
 
-const log = new Logger("waku:sds:message-channel");
+const log = new Logger("sds:message-channel");
 
 export interface MessageChannelOptions {
   causalHistorySize?: number;


### PR DESCRIPTION
### Problem / Description

Logs were marked as `waku:waku`

### Solution

Remove redundant prefix

### Notes


---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
