### PR TITLE
fix: (sds) ensure incoming messages have their retrieval hint stored

### DIFF
--- a/packages/sdk/src/filter/filter.spec.ts
+++ b/packages/sdk/src/filter/filter.spec.ts
@@ -91,7 +91,7 @@ describe("Filter SDK", () => {
     const message = createMockMessage(testContentTopic);
     const peerId = "peer1";
 
-    await (filter as any).onIncomingMessage(testPubsubTopic, message, peerId);
+    await filter["onIncomingMessage"](testPubsubTopic, message, peerId);
 
     expect(subscriptionInvokeStub.calledOnce).to.be.true;
     expect(subscriptionInvokeStub.firstCall.args[0]).to.equal(message);

--- a/packages/sds/src/index.ts
+++ b/packages/sds/src/index.ts
@@ -14,7 +14,8 @@ export {
   type HistoryEntry,
   type ChannelId,
   type MessageChannelEvents,
-  type SenderId
+  type SenderId,
+  type MessageId
 } from "./message_channel/index.js";
 
 export { BloomFilter };

--- a/packages/sds/src/message_channel/mem_local_history.ts
+++ b/packages/sds/src/message_channel/mem_local_history.ts
@@ -23,9 +23,15 @@ export class MemLocalHistory {
       this.validateMessage(item);
     }
 
-    // Add new items and ensure uniqueness by messageId using sortedUniqBy
+    // Add new items and sort by timestamp, ensuring uniqueness by messageId
     // The valueOf() method on ContentMessage enables native < operator sorting
-    this.items = _.sortedUniqBy([...this.items, ...items], "messageId");
+    const combinedItems = [...this.items, ...items];
+
+    // Sort by timestamp (using valueOf() which creates timestamp_messageId string)
+    combinedItems.sort((a, b) => a.valueOf().localeCompare(b.valueOf()));
+
+    // Remove duplicates by messageId while maintaining order
+    this.items = _.uniqBy(combinedItems, "messageId");
 
     return this.items.length;
   }

--- a/packages/sds/src/message_channel/mem_local_history.ts
+++ b/packages/sds/src/message_channel/mem_local_history.ts
@@ -62,6 +62,17 @@ export class MemLocalHistory {
     return this.items.find(predicate, thisArg);
   }
 
+  public findIndex(
+    predicate: (
+      value: ContentMessage,
+      index: number,
+      obj: ContentMessage[]
+    ) => unknown,
+    thisArg?: any
+  ): number {
+    return this.items.findIndex(predicate, thisArg);
+  }
+
   private validateMessage(message: ContentMessage): void {
     if (!isContentMessage(message)) {
       throw new Error(

--- a/packages/sds/src/message_channel/message.spec.ts
+++ b/packages/sds/src/message_channel/message.spec.ts
@@ -1,3 +1,4 @@
+import { utf8ToBytes } from "@waku/utils/bytes";
 import { expect } from "chai";
 
 import { DefaultBloomFilter } from "../bloom_filter/bloom.js";
@@ -31,6 +32,27 @@ describe("Message serialization", () => {
     );
 
     expect(decBloomFilter.lookup(messageId)).to.be.true;
+  });
+
+  it("Retrieval Hint", () => {
+    const depMessageId = "dependency";
+    const depRetrievalHint = utf8ToBytes("dependency");
+    const message = new Message(
+      "123",
+      "my-channel",
+      "me",
+      [{ messageId: depMessageId, retrievalHint: depRetrievalHint }],
+      0,
+      undefined,
+      undefined
+    );
+
+    const bytes = message.encode();
+    const decMessage = Message.decode(bytes);
+
+    expect(decMessage.causalHistory).to.deep.equal([
+      { messageId: depMessageId, retrievalHint: depRetrievalHint }
+    ]);
   });
 });
 

--- a/packages/sds/src/message_channel/message_channel.spec.ts
+++ b/packages/sds/src/message_channel/message_channel.spec.ts
@@ -349,14 +349,27 @@ describe("MessageChannel", function () {
       expect(localHistory.length).to.equal(3);
 
       // Verify chronological order: message1 (ts=1), message2 (ts=2), message3 (ts=3)
-      expect(localHistory[0].messageId).to.equal(message1Id);
-      expect(localHistory[0].lamportTimestamp).to.equal(1);
 
-      expect(localHistory[1].messageId).to.equal(message2Id);
-      expect(localHistory[1].lamportTimestamp).to.equal(2);
+      const first = localHistory.findIndex(
+        ({ messageId, lamportTimestamp }) => {
+          return messageId === message1Id && lamportTimestamp === 1;
+        }
+      );
+      expect(first).to.eq(0);
 
-      expect(localHistory[2].messageId).to.equal(message3Id);
-      expect(localHistory[2].lamportTimestamp).to.equal(3);
+      const second = localHistory.findIndex(
+        ({ messageId, lamportTimestamp }) => {
+          return messageId === message2Id && lamportTimestamp === 2;
+        }
+      );
+      expect(second).to.eq(1);
+
+      const third = localHistory.findIndex(
+        ({ messageId, lamportTimestamp }) => {
+          return messageId === message3Id && lamportTimestamp === 3;
+        }
+      );
+      expect(third).to.eq(2);
     });
 
     it("should handle messages with same timestamp ordered by messageId", async () => {
@@ -400,12 +413,20 @@ describe("MessageChannel", function () {
       // When timestamps are equal, should be ordered by messageId lexicographically
       // The valueOf() method creates "000000000000005_messageId" for comparison
       const expectedOrder = [message1Id, message2Id].sort();
-      expect(localHistory[0].messageId).to.equal(expectedOrder[0]);
-      expect(localHistory[1].messageId).to.equal(expectedOrder[1]);
 
-      // Both should have the same timestamp
-      expect(localHistory[0].lamportTimestamp).to.equal(5);
-      expect(localHistory[1].lamportTimestamp).to.equal(5);
+      const first = localHistory.findIndex(
+        ({ messageId, lamportTimestamp }) => {
+          return messageId === expectedOrder[0] && lamportTimestamp == 5;
+        }
+      );
+      expect(first).to.eq(0);
+
+      const second = localHistory.findIndex(
+        ({ messageId, lamportTimestamp }) => {
+          return messageId === expectedOrder[1] && lamportTimestamp == 5;
+        }
+      );
+      expect(second).to.eq(1);
     });
   });
 

--- a/packages/sds/src/message_channel/message_channel.ts
+++ b/packages/sds/src/message_channel/message_channel.ts
@@ -50,7 +50,7 @@ export interface MessageChannelOptions {
 
 export type ILocalHistory = Pick<
   Array<ContentMessage>,
-  "some" | "push" | "slice" | "find" | "length"
+  "some" | "push" | "slice" | "find" | "length" | "findIndex"
 >;
 
 export class MessageChannel extends TypedEventEmitter<MessageChannelEvents> {


### PR DESCRIPTION
### Problem / Description

Incoming messages did not have retrieval hints when included in causal history for follow-up outbound messages.

### Solution

This is fix by calculating their retrieval hint upon reception, and before storage.

### Notes

---

#### Checklist
- [x] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [x] **Dogfooding has been performed**, if feasible.
- [x] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
