### PR TITLE
chore: enforce index re-exports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -94,6 +94,18 @@
   },
   "overrides": [
     {
+      "files": ["packages/*/src/index.ts"],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "Program > :not(ExportNamedDeclaration, ExportAllDeclaration, TSTypeAliasDeclaration, TSInterfaceDeclaration)",
+            "message": "index.ts should only contain re-export statements"
+          }
+        ]
+      }
+    },
+    {
       "files": ["*.spec.ts", "**/test_utils/*.ts", "*.js", "*.cjs"],
       "rules": {
         "@typescript-eslint/no-non-null-assertion": "off",

--- a/packages/message-encryption/src/index.ts
+++ b/packages/message-encryption/src/index.ts
@@ -1,12 +1,9 @@
-import {
+export {
   generatePrivateKey,
   generateSymmetricKey,
   getPublicKey
 } from "./crypto/index.js";
-import { DecodedMessage } from "./decoded_message.js";
-
-export { generatePrivateKey, generateSymmetricKey, getPublicKey };
-export type { DecodedMessage };
+export type { DecodedMessage } from "./decoded_message.js";
 
 export * as ecies from "./ecies.js";
 export * as symmetric from "./symmetric.js";

--- a/packages/rln/src/index.ts
+++ b/packages/rln/src/index.ts
@@ -1,32 +1,15 @@
-import { RLNDecoder, RLNEncoder } from "./codec.js";
-import { RLN_ABI } from "./contract/abi/rln.js";
-import { RLN_CONTRACT, RLNContract } from "./contract/index.js";
-import { RLNBaseContract } from "./contract/rln_base_contract.js";
-import { createRLN } from "./create.js";
-import { RLNCredentialsManager } from "./credentials_manager.js";
-import { IdentityCredential } from "./identity.js";
-import { Keystore } from "./keystore/index.js";
-import { Proof } from "./proof.js";
-import { RLNInstance } from "./rln.js";
-import { MerkleRootTracker } from "./root_tracker.js";
-import { extractMetaMaskSigner } from "./utils/index.js";
-
-export {
-  RLNCredentialsManager,
-  RLNBaseContract,
-  createRLN,
-  Keystore,
-  RLNInstance,
-  IdentityCredential,
-  Proof,
-  RLNEncoder,
-  RLNDecoder,
-  MerkleRootTracker,
-  RLNContract,
-  RLN_CONTRACT,
-  extractMetaMaskSigner,
-  RLN_ABI
-};
+export { RLNDecoder, RLNEncoder } from "./codec.js";
+export { RLN_ABI } from "./contract/abi/rln.js";
+export { RLN_CONTRACT, RLNContract } from "./contract/index.js";
+export { RLNBaseContract } from "./contract/rln_base_contract.js";
+export { createRLN } from "./create.js";
+export { RLNCredentialsManager } from "./credentials_manager.js";
+export { IdentityCredential } from "./identity.js";
+export { Keystore } from "./keystore/index.js";
+export { Proof } from "./proof.js";
+export { RLNInstance } from "./rln.js";
+export { MerkleRootTracker } from "./root_tracker.js";
+export { extractMetaMaskSigner } from "./utils/index.js";
 
 export type {
   DecryptedCredentials,

--- a/packages/rln/src/keystore/index.ts
+++ b/packages/rln/src/keystore/index.ts
@@ -1,5 +1,2 @@
-import { Keystore } from "./keystore.js";
-import type { DecryptedCredentials, EncryptedCredentials } from "./types.js";
-
-export { Keystore };
-export type { EncryptedCredentials, DecryptedCredentials };
+export { Keystore } from "./keystore.js";
+export type { EncryptedCredentials, DecryptedCredentials } from "./types.js";

--- a/packages/sds/src/index.ts
+++ b/packages/sds/src/index.ts
@@ -1,5 +1,3 @@
-import { BloomFilter } from "./bloom_filter/bloom.js";
-
 export {
   MessageChannel,
   MessageChannelEvent,
@@ -10,12 +8,14 @@ export {
   Message,
   ContentMessage,
   SyncMessage,
-  EphemeralMessage,
-  type HistoryEntry,
-  type ChannelId,
-  type MessageChannelEvents,
-  type SenderId,
-  type MessageId
+  EphemeralMessage
+} from "./message_channel/index.js";
+export type {
+  HistoryEntry,
+  ChannelId,
+  MessageChannelEvents,
+  SenderId,
+  MessageId
 } from "./message_channel/index.js";
 
-export { BloomFilter };
+export { BloomFilter } from "./bloom_filter/bloom.js";


### PR DESCRIPTION
## Summary
- enforce index.ts files to contain only re-exports via ESLint override
- refactor existing index files to remove imports

## Testing
- `npx eslint packages/{sdk,message-encryption,core,discovery,sds,relay,enr,tests,rln,interfaces,utils}/src/index.ts`
- `npm test` *(fails: Cannot find module '@waku/interfaces')*


------
https://chatgpt.com/codex/tasks/task_e_68b223d8e0188331a0f988c0fcf7b3a2