### PR TITLE
feat: allow string event names

### DIFF
--- a/packages/core/src/lib/filter/filter.ts
+++ b/packages/core/src/lib/filter/filter.ts
@@ -1,5 +1,4 @@
-import type { PeerId } from "@libp2p/interface";
-import type { IncomingStreamData } from "@libp2p/interface-internal";
+import type { PeerId, StreamHandler } from "@libp2p/interface";
 import {
   type ContentTopic,
   type CoreProtocolResult,
@@ -52,7 +51,7 @@ export class FilterCore {
 
   public async start(): Promise<void> {
     try {
-      await this.libp2p.handle(FilterCodecs.PUSH, this.onRequest.bind(this), {
+      await this.libp2p.handle(FilterCodecs.PUSH, this.onRequest, {
         maxInboundStreams: 100
       });
     } catch (e) {
@@ -304,7 +303,7 @@ export class FilterCore {
     };
   }
 
-  private onRequest(streamData: IncomingStreamData): void {
+  private onRequest: StreamHandler = (streamData) => {
     const { connection, stream } = streamData;
     const { remotePeer } = connection;
     log.info(`Received message from ${remotePeer.toString()}`);
@@ -345,5 +344,5 @@ export class FilterCore {
     } catch (e) {
       log.error("Error decoding message", e);
     }
-  }
+  };
 }

--- a/packages/core/src/lib/stream_manager/stream_manager.spec.ts
+++ b/packages/core/src/lib/stream_manager/stream_manager.spec.ts
@@ -34,7 +34,7 @@ describe("StreamManager", () => {
         createMockStream({ id: "1", protocol: MULTICODEC, writeStatus })
       ];
 
-      streamManager["libp2p"]["connectionManager"]["getConnections"] = (
+      (streamManager["libp2p"]["connectionManager"] as any).getConnections = (
         _peerId: PeerId | undefined
       ) => [con1];
 
@@ -46,7 +46,7 @@ describe("StreamManager", () => {
   });
 
   it("should return undefined if no connection provided", async () => {
-    streamManager["libp2p"]["connectionManager"]["getConnections"] = (
+    (streamManager["libp2p"]["connectionManager"] as any).getConnections = (
       _peerId: PeerId | undefined
     ) => [];
 
@@ -70,7 +70,7 @@ describe("StreamManager", () => {
       );
 
       con1.newStream = newStreamSpy;
-      streamManager["libp2p"]["connectionManager"]["getConnections"] = (
+      (streamManager["libp2p"]["connectionManager"] as any).getConnections = (
         _peerId: PeerId | undefined
       ) => [con1];
 
@@ -97,7 +97,7 @@ describe("StreamManager", () => {
     );
 
     con1.newStream = newStreamSpy;
-    streamManager["libp2p"]["connectionManager"]["getConnections"] = (
+    (streamManager["libp2p"]["connectionManager"] as any).getConnections = (
       _peerId: PeerId | undefined
     ) => [con1];
 
@@ -148,7 +148,7 @@ describe("StreamManager", () => {
         writeStatus: "writable"
       })
     ];
-    streamManager["libp2p"]["connectionManager"]["getConnections"] = (
+    (streamManager["libp2p"]["connectionManager"] as any).getConnections = (
       _id: PeerId | undefined
     ) => [con1];
 
@@ -178,7 +178,6 @@ function createMockConnection(options: MockConnectionOptions = {}): Connection {
     }
   } as Connection;
 }
-
 type MockStreamOptions = {
   id?: string;
   protocol?: string;

--- a/packages/interfaces/src/waku.ts
+++ b/packages/interfaces/src/waku.ts
@@ -25,10 +25,12 @@ export type CreateEncoderParams = CreateDecoderParams & {
   ephemeral?: boolean;
 };
 
-export enum WakuEvent {
-  Connection = "waku:connection",
-  Health = "waku:health"
-}
+export const WakuEvent = {
+  Connection: "waku:connection",
+  Health: "waku:health"
+} as const;
+
+export type WakuEvent = (typeof WakuEvent)[keyof typeof WakuEvent];
 
 export interface IWakuEvents {
   /**
@@ -36,22 +38,22 @@ export interface IWakuEvents {
    *
    * @example
    * ```typescript
-   * waku.addEventListener(WakuEvent.Connection, (event) => {
+   * waku.events.addEventListener("waku:connection", (event) => {
    *   console.log(event.detail); // true if connected, false if disconnected
    * });
    */
-  [WakuEvent.Connection]: CustomEvent<boolean>;
+  "waku:connection": CustomEvent<boolean>;
 
   /**
    * Emitted when the health status changes.
    *
    * @example
    * ```typescript
-   * waku.addEventListener(WakuEvent.Health, (event) => {
+   * waku.events.addEventListener("waku:health", (event) => {
    *   console.log(event.detail); // 'Unhealthy', 'MinimallyHealthy', or 'SufficientlyHealthy'
    * });
    */
-  [WakuEvent.Health]: CustomEvent<HealthStatus>;
+  "waku:health": CustomEvent<HealthStatus>;
 }
 
 export type IWakuEventEmitter = TypedEventEmitter<IWakuEvents>;
@@ -66,12 +68,12 @@ export interface IWaku {
   /**
    * Emits events related to the Waku node.
    * Those are:
-   * - WakuEvent.Connection
-   * - WakuEvent.Health
+   * - "waku:connection"
+   * - "waku:health"
    *
    * @example
    * ```typescript
-   * waku.events.addEventListener(WakuEvent.Connection, (event) => {
+   * waku.events.addEventListener("waku:connection", (event) => {
    *   console.log(event.detail); // true if connected, false if disconnected
    * });
    * ```


### PR DESCRIPTION
## Summary
- allow Waku event listeners to be registered using string names
- fix libp2p type mismatches and adjust stream manager tests
- document event names and usage with string literals

## Testing
- `npm run build`
- `npm run check`
- `npm run test:node --workspace packages/sdk`


------
https://chatgpt.com/codex/tasks/task_e_68b8c8b38f3c833194e44d778110c784