### PR TITLE
feat: Waku API's subscribe

### DIFF
--- a/packages/interfaces/src/filter.ts
+++ b/packages/interfaces/src/filter.ts
@@ -1,5 +1,6 @@
-import type { IDecodedMessage, IDecoder } from "./message.js";
-import type { Callback } from "./protocols.js";
+import type { IDecodedMessage } from "./message.js";
+import { ContentTopic } from "./misc.js";
+import { IRoutingInfo } from "./sharding.js";
 
 export type IFilter = {
   readonly multicodec: string;
@@ -38,9 +39,10 @@ export type IFilter = {
    *   console.error("Failed to subscribe");
    * }
    */
-  subscribe<T extends IDecodedMessage>(
-    decoders: IDecoder<T> | IDecoder<T>[],
-    callback: Callback<T>
+  subscribe(
+    contentTopics: ContentTopic[],
+    routingInfo: IRoutingInfo,
+    callback: (msg: IDecodedMessage) => void | Promise<void>
   ): Promise<boolean>;
 
   /**
@@ -64,8 +66,9 @@ export type IFilter = {
    *   console.error("Failed to unsubscribe");
    * }
    */
-  unsubscribe<T extends IDecodedMessage>(
-    decoders: IDecoder<T> | IDecoder<T>[]
+  unsubscribe(
+    contentTopics: ContentTopic[],
+    routingInfo: IRoutingInfo
   ): Promise<boolean>;
 
   /**

--- a/packages/interfaces/src/message.ts
+++ b/packages/interfaces/src/message.ts
@@ -105,6 +105,7 @@ export interface IEncoder {
 export interface IDecoder<T extends IDecodedMessage> {
   contentTopic: string;
   pubsubTopic: PubsubTopic;
+  routingInfo: IRoutingInfo;
   fromWireToProtoObj: (bytes: Uint8Array) => Promise<IProtoMessage | undefined>;
   fromProtoObj: (
     pubsubTopic: string,

--- a/packages/interfaces/src/waku.ts
+++ b/packages/interfaces/src/waku.ts
@@ -11,6 +11,7 @@ import type { HealthStatus } from "./health_status.js";
 import type { Libp2p } from "./libp2p.js";
 import type { ILightPush } from "./light_push.js";
 import { IDecodedMessage, IDecoder, IEncoder } from "./message.js";
+import { ContentTopic } from "./misc.js";
 import type { Protocols } from "./protocols.js";
 import type { IRelay } from "./relay.js";
 import type { ShardId } from "./sharding.js";
@@ -250,6 +251,14 @@ export interface IWaku {
    * ```
    */
   createEncoder(params: CreateEncoderParams): IEncoder;
+
+  subscribe(
+    contentTopics: ContentTopic[],
+    callback: (message: {
+      contentTopic: ContentTopic;
+      payload: Uint8Array;
+    }) => void | Promise<void>
+  ): Promise<void>;
 
   /**
    * @returns {boolean} `true` if the node was started and `false` otherwise

--- a/packages/sdk/src/filter/filter.spec.ts
+++ b/packages/sdk/src/filter/filter.spec.ts
@@ -49,7 +49,11 @@ describe("Filter SDK", () => {
     const addStub = sinon.stub(Subscription.prototype, "add").resolves(true);
     const startStub = sinon.stub(Subscription.prototype, "start");
 
-    const result = await filter.subscribe(decoder, callback);
+    const result = await filter.subscribe(
+      [testContentTopic],
+      testRoutingInfo,
+      callback
+    );
 
     expect(result).to.be.true;
     expect(addStub.calledOnce).to.be.true;
@@ -57,7 +61,10 @@ describe("Filter SDK", () => {
   });
 
   it("should return false when unsubscribing from a non-existing subscription", async () => {
-    const result = await filter.unsubscribe(decoder);
+    const result = await filter.unsubscribe(
+      [testContentTopic],
+      testRoutingInfo
+    );
     expect(result).to.be.false;
   });
 

--- a/packages/sdk/src/filter/subscription.spec.ts
+++ b/packages/sdk/src/filter/subscription.spec.ts
@@ -19,7 +19,6 @@ describe("Filter Subscription", () => {
   let filterCore: FilterCore;
   let peerManager: PeerManager;
   let subscription: Subscription;
-  let decoder: IDecoder<IDecodedMessage>;
   let config: FilterProtocolOptions;
 
   beforeEach(() => {
@@ -37,8 +36,6 @@ describe("Filter Subscription", () => {
       config,
       peerManager
     });
-
-    decoder = mockDecoder();
   });
 
   afterEach(() => {

--- a/packages/sdk/src/filter/types.ts
+++ b/packages/sdk/src/filter/types.ts
@@ -1,6 +1,9 @@
 import type { FilterCore } from "@waku/core";
-import type { FilterProtocolOptions, Libp2p } from "@waku/interfaces";
-import type { WakuMessage } from "@waku/proto";
+import type {
+  FilterProtocolOptions,
+  IDecodedMessage,
+  Libp2p
+} from "@waku/interfaces";
 
 import type { PeerManager } from "../peer_manager/index.js";
 
@@ -11,7 +14,7 @@ export type FilterConstructorParams = {
 };
 
 export type SubscriptionEvents = {
-  [contentTopic: string]: CustomEvent<WakuMessage>;
+  [contentTopic: string]: CustomEvent<IDecodedMessage>;
 };
 
 export type SubscriptionParams = {

--- a/packages/sdk/src/reliable_channel/events.ts
+++ b/packages/sdk/src/reliable_channel/events.ts
@@ -1,4 +1,4 @@
-import { IDecodedMessage, ProtocolError } from "@waku/interfaces";
+import { ProtocolError } from "@waku/interfaces";
 import type { HistoryEntry, MessageId } from "@waku/sds";
 
 export const ReliableChannelEvent = {
@@ -56,8 +56,7 @@ export interface ReliableChannelEvents {
     possibleAckCount: number;
   }>;
   "message-acknowledged": CustomEvent<MessageId>;
-  // TODO probably T extends IDecodedMessage?
-  "message-received": CustomEvent<IDecodedMessage>;
+  "message-received": CustomEvent<Uint8Array>;
   "irretrievable-message": CustomEvent<HistoryEntry>;
   "sending-message-irrecoverable-error": CustomEvent<{
     messageId: MessageId;


### PR DESCRIPTION
Introduced a new `subscribe` function to the Waku API.

### Problem / Description

Developer need a simple API to receive messages.

### Solution

See **TODOs / Notes**

```typescript
async subscribe(
    contentTopics: ContentTopic[],
    callback: (message: {
      contentTopic: ContentTopic;
      payload: Uint8Array;
    }) => void | Promise<void>
  ): Promise<void> 
```


### TODOs / Notes

- [ ] Remove callback in favour of event emission
- [ ] Demonstrate integration with encryption
- [ ] Demonstrate integration with encryptio and reliable channels

- Resolves
- Related to https://github.com/waku-org/js-waku/issues/2216

---

#### Checklist
- [ ] Code changes are **covered by unit tests**.
- [ ] Code changes are **covered by e2e tests**, if applicable.
- [ ] **Dogfooding has been performed**, if feasible.
- [ ] A **test version has been published**, if required.
- [ ] All **CI checks** pass successfully.
